### PR TITLE
(SONAR-2578) Make possible to associate decimal numbers to weigths

### DIFF
--- a/plugins/sonar-core-plugin/src/main/java/org/sonar/plugins/core/sensors/WeightedViolationsDecorator.java
+++ b/plugins/sonar-core-plugin/src/main/java/org/sonar/plugins/core/sensors/WeightedViolationsDecorator.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 public class WeightedViolationsDecorator implements Decorator {
 
-  private Map<RulePriority, Integer> weights;
+  private Map<RulePriority, Double> weights;
 
 
   @DependsUpon
@@ -55,7 +55,7 @@ public class WeightedViolationsDecorator implements Decorator {
   /**
    * for unit tests
    */
-  protected WeightedViolationsDecorator(Map<RulePriority, Integer> weights) {
+  protected WeightedViolationsDecorator(Map<RulePriority, Double> weights) {
     this.weights = weights;
   }
 
@@ -78,7 +78,7 @@ public class WeightedViolationsDecorator implements Decorator {
     for (RuleMeasure violations : context.getMeasures(MeasuresFilters.rules(CoreMetrics.VIOLATIONS))) {
       if (MeasureUtils.hasValue(violations)) {
         violationsByPriority.add(violations.getRulePriority(), violations.getValue().intValue());
-        double add = (int) weights.get(violations.getRulePriority()) * violations.getValue();
+        double add = (double) weights.get(violations.getRulePriority()) * violations.getValue();
         debt += add;
       }
     }

--- a/plugins/sonar-core-plugin/src/test/java/org/sonar/plugins/core/sensors/WeightedViolationsDecoratorTest.java
+++ b/plugins/sonar-core-plugin/src/test/java/org/sonar/plugins/core/sensors/WeightedViolationsDecoratorTest.java
@@ -53,19 +53,19 @@ public class WeightedViolationsDecoratorTest {
     );
   }
 
-  private Map<RulePriority, Integer> createWeights() {
-    Map<RulePriority, Integer> weights = new HashMap();
-    weights.put(RulePriority.BLOCKER, 10);
-    weights.put(RulePriority.CRITICAL, 5);
-    weights.put(RulePriority.MAJOR, 2);
-    weights.put(RulePriority.MINOR, 1);
-    weights.put(RulePriority.INFO, 0);
+  private Map<RulePriority, Double> createWeights() {
+    Map<RulePriority, Double> weights = new HashMap();
+    weights.put(RulePriority.BLOCKER, 10d);
+    weights.put(RulePriority.CRITICAL, 5d);
+    weights.put(RulePriority.MAJOR, 2d);
+    weights.put(RulePriority.MINOR, 1d);
+    weights.put(RulePriority.INFO, 0d);
     return weights;
   }
 
   @Test
   public void weightedViolations() {
-    Map<RulePriority, Integer> weights = createWeights();
+    Map<RulePriority, Double> weights = createWeights();
 
     WeightedViolationsDecorator decorator = new WeightedViolationsDecorator(weights);
     DecoratorContext context = mock(DecoratorContext.class);
@@ -80,7 +80,7 @@ public class WeightedViolationsDecoratorTest {
 
   @Test
   public void doNotSaveZero() {
-    Map<RulePriority, Integer> weights = createWeights();
+    Map<RulePriority, Double> weights = createWeights();
 
     WeightedViolationsDecorator decorator = new WeightedViolationsDecorator(weights);
     DecoratorContext context = mock(DecoratorContext.class);

--- a/sonar-plugin-api/src/main/java/org/sonar/api/rules/RuleUtils.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/rules/RuleUtils.java
@@ -40,14 +40,14 @@ public final class RuleUtils {
    * @param configuration the Sonar configuration
    * @return a map
    */
-  public static Map<RulePriority, Integer> getPriorityWeights(final Configuration configuration) {
+  public static Map<RulePriority, Double> getPriorityWeights(final Configuration configuration) {
     String levelWeight = configuration.getString(CoreProperties.CORE_RULE_WEIGHTS_PROPERTY, CoreProperties.CORE_RULE_WEIGHTS_DEFAULT_VALUE);
 
-    Map<RulePriority, Integer> weights = KeyValueFormat.parse(levelWeight, new KeyValueFormat.RulePriorityNumbersPairTransformer());
+    Map<RulePriority, Double> weights = KeyValueFormat.parse(levelWeight, new KeyValueFormat.RulePriorityNumbersPairTransformer());
 
     for (RulePriority priority : RulePriority.values()) {
       if (!weights.containsKey(priority)) {
-        weights.put(priority, 1);
+        weights.put(priority, 1d);
       }
     }
     return weights;

--- a/sonar-plugin-api/src/main/java/org/sonar/api/utils/KeyValueFormat.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/utils/KeyValueFormat.java
@@ -478,14 +478,14 @@ public final class KeyValueFormat {
    * @deprecated since 2.7. Replaced by Converter
    */
   @Deprecated
-  public static class RulePriorityNumbersPairTransformer implements Transformer<RulePriority, Integer> {
+  public static class RulePriorityNumbersPairTransformer implements Transformer<RulePriority, Double> {
 
-    public KeyValue<RulePriority, Integer> transform(String key, String value) {
+    public KeyValue<RulePriority, Double> transform(String key, String value) {
       try {
         if (StringUtils.isBlank(value)) {
           value = "0";
         }
-        return new KeyValue<RulePriority, Integer>(RulePriority.valueOf(key.toUpperCase()), Integer.parseInt(value));
+        return new KeyValue<RulePriority, Double>(RulePriority.valueOf(key.toUpperCase()), Double.parseDouble(value));
       } catch (Exception e) {
         LoggerFactory.getLogger(RulePriorityNumbersPairTransformer.class).warn("Property " + key + " has invalid value: " + value, e);
         return null;

--- a/sonar-plugin-api/src/test/java/org/sonar/api/rules/RuleUtilsTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/rules/RuleUtilsTest.java
@@ -40,13 +40,13 @@ public class RuleUtilsTest {
     Configuration conf = mock(Configuration.class);
     when(conf.getString(Matchers.eq(CoreProperties.CORE_RULE_WEIGHTS_PROPERTY), anyString())).thenReturn("info=0;minor=1;major=2;critical=5;blocker=10");
 
-    final Map<RulePriority, Integer> map = RuleUtils.getPriorityWeights(conf);
+    final Map<RulePriority, Double> map = RuleUtils.getPriorityWeights(conf);
 
-    assertThat(map.get(RulePriority.BLOCKER), is(10));
-    assertThat(map.get(RulePriority.CRITICAL), is(5));
-    assertThat(map.get(RulePriority.MAJOR), is(2));
-    assertThat(map.get(RulePriority.MINOR), is(1));
-    assertThat(map.get(RulePriority.INFO), is(0));
+    assertThat(map.get(RulePriority.BLOCKER), is(10d));
+    assertThat(map.get(RulePriority.CRITICAL), is(5d));
+    assertThat(map.get(RulePriority.MAJOR), is(2d));
+    assertThat(map.get(RulePriority.MINOR), is(1d));
+    assertThat(map.get(RulePriority.INFO), is(0d));
   }
 
   @Test
@@ -54,13 +54,13 @@ public class RuleUtilsTest {
     Configuration conf = mock(Configuration.class);
     when(conf.getString(Matchers.eq(CoreProperties.CORE_RULE_WEIGHTS_PROPERTY), anyString())).thenReturn("foo=0;bar=1;CRITICAL=5");
 
-    final Map<RulePriority, Integer> map = RuleUtils.getPriorityWeights(conf);
+    final Map<RulePriority, Double> map = RuleUtils.getPriorityWeights(conf);
 
-    assertThat(map.get(RulePriority.BLOCKER), is(1));
-    assertThat(map.get(RulePriority.CRITICAL), is(5));
-    assertThat(map.get(RulePriority.MAJOR), is(1));
-    assertThat(map.get(RulePriority.MINOR), is(1));
-    assertThat(map.get(RulePriority.INFO), is(1));
+    assertThat(map.get(RulePriority.BLOCKER), is(1d));
+    assertThat(map.get(RulePriority.CRITICAL), is(5d));
+    assertThat(map.get(RulePriority.MAJOR), is(1d));
+    assertThat(map.get(RulePriority.MINOR), is(1d));
+    assertThat(map.get(RulePriority.INFO), is(1d));
   }
 
 }

--- a/sonar-plugin-api/src/test/java/org/sonar/api/utils/DeprecatedKeyValueFormatTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/utils/DeprecatedKeyValueFormatTest.java
@@ -108,10 +108,10 @@ public class DeprecatedKeyValueFormatTest {
 
   @Test
   public void parseWithRulePriorityNumbersTransformation() {
-    Map<RulePriority, Integer> map = KeyValueFormat.parse("BLOCKER=1;MAJOR=;INFO=5", new KeyValueFormat.RulePriorityNumbersPairTransformer());
+    Map<RulePriority, Double> map = KeyValueFormat.parse("BLOCKER=1;MAJOR=;INFO=5", new KeyValueFormat.RulePriorityNumbersPairTransformer());
     assertThat(map.size(), is(3));
-    assertEquals(new Integer(1), map.get(RulePriority.BLOCKER));
-    assertEquals(new Integer(0), map.get(RulePriority.MAJOR));
-    assertEquals(new Integer(5), map.get(RulePriority.INFO));
+    assertEquals(new Double(1), map.get(RulePriority.BLOCKER));
+    assertEquals(new Double(0), map.get(RulePriority.MAJOR));
+    assertEquals(new Double(5), map.get(RulePriority.INFO));
   }
 }


### PR DESCRIPTION
(SONAR-2578) Make possible to associate decimal numbers to weigths instead of only Integers to each priority to calculate the RC
