### PR TITLE
Exit code is not properly returned when using RUN_AS_USER

### DIFF
--- a/sonar-application/src/main/assembly/bin/linux-ppc-64/sonar.sh
+++ b/sonar-application/src/main/assembly/bin/linux-ppc-64/sonar.sh
@@ -334,6 +334,7 @@ checkUser() {
         # Still want to change users, recurse.  This means that the user will only be
         #  prompted for a password once. Variables shifted by 1
         su -m $RUN_AS_USER -c "\"$REALPATH\" $2"
+        RETVAL=$?
 
         # Now that we are the original user again, we may need to clean up the lock file.
         if [ "X$LOCKPROP" != "X" ]
@@ -349,7 +350,7 @@ checkUser() {
             fi
         fi
 
-        exit 0
+        exit $RETVAL
     fi
 }
 

--- a/sonar-application/src/main/assembly/bin/linux-x86-32/sonar.sh
+++ b/sonar-application/src/main/assembly/bin/linux-x86-32/sonar.sh
@@ -334,6 +334,7 @@ checkUser() {
         # Still want to change users, recurse.  This means that the user will only be
         #  prompted for a password once. Variables shifted by 1
         su -m $RUN_AS_USER -c "\"$REALPATH\" $2"
+        RETVAL=$?
 
         # Now that we are the original user again, we may need to clean up the lock file.
         if [ "X$LOCKPROP" != "X" ]
@@ -349,7 +350,7 @@ checkUser() {
             fi
         fi
 
-        exit 0
+        exit $RETVAL
     fi
 }
 

--- a/sonar-application/src/main/assembly/bin/linux-x86-64/sonar.sh
+++ b/sonar-application/src/main/assembly/bin/linux-x86-64/sonar.sh
@@ -334,6 +334,7 @@ checkUser() {
         # Still want to change users, recurse.  This means that the user will only be
         #  prompted for a password once. Variables shifted by 1
         su -m $RUN_AS_USER -c "\"$REALPATH\" $2"
+        RETVAL=$?
 
         # Now that we are the original user again, we may need to clean up the lock file.
         if [ "X$LOCKPROP" != "X" ]
@@ -349,7 +350,7 @@ checkUser() {
             fi
         fi
 
-        exit 0
+        exit $RETVAL
     fi
 }
 

--- a/sonar-application/src/main/assembly/bin/macosx-universal-32/sonar.sh
+++ b/sonar-application/src/main/assembly/bin/macosx-universal-32/sonar.sh
@@ -334,6 +334,7 @@ checkUser() {
         # Still want to change users, recurse.  This means that the user will only be
         #  prompted for a password once. Variables shifted by 1
         su -m $RUN_AS_USER -c "\"$REALPATH\" $2"
+        RETVAL=$?
 
         # Now that we are the original user again, we may need to clean up the lock file.
         if [ "X$LOCKPROP" != "X" ]
@@ -349,7 +350,7 @@ checkUser() {
             fi
         fi
 
-        exit 0
+        exit $RETVAL
     fi
 }
 

--- a/sonar-application/src/main/assembly/bin/macosx-universal-64/sonar.sh
+++ b/sonar-application/src/main/assembly/bin/macosx-universal-64/sonar.sh
@@ -334,6 +334,7 @@ checkUser() {
         # Still want to change users, recurse.  This means that the user will only be
         #  prompted for a password once. Variables shifted by 1
         su -m $RUN_AS_USER -c "\"$REALPATH\" $2"
+        RETVAL=$?
 
         # Now that we are the original user again, we may need to clean up the lock file.
         if [ "X$LOCKPROP" != "X" ]
@@ -349,7 +350,7 @@ checkUser() {
             fi
         fi
 
-        exit 0
+        exit $RETVAL
     fi
 }
 

--- a/sonar-application/src/main/assembly/bin/solaris-sparc-32/sonar.sh
+++ b/sonar-application/src/main/assembly/bin/solaris-sparc-32/sonar.sh
@@ -335,6 +335,7 @@ checkUser() {
         # Still want to change users, recurse.  This means that the user will only be
         #  prompted for a password once. Variables shifted by 1
         su -m $RUN_AS_USER -c "\"$REALPATH\" $2"
+        RETVAL=$?
 
         # Now that we are the original user again, we may need to clean up the lock file.
         if [ "X$LOCKPROP" != "X" ]
@@ -350,7 +351,7 @@ checkUser() {
             fi
         fi
 
-        exit 0
+        exit $RETVAL
     fi
 }
 

--- a/sonar-application/src/main/assembly/bin/solaris-sparc-64/sonar.sh
+++ b/sonar-application/src/main/assembly/bin/solaris-sparc-64/sonar.sh
@@ -335,6 +335,7 @@ checkUser() {
         # Still want to change users, recurse.  This means that the user will only be
         #  prompted for a password once. Variables shifted by 1
         su -m $RUN_AS_USER -c "\"$REALPATH\" $2"
+        RETVAL=$?
 
         # Now that we are the original user again, we may need to clean up the lock file.
         if [ "X$LOCKPROP" != "X" ]
@@ -350,7 +351,7 @@ checkUser() {
             fi
         fi
 
-        exit 0
+        exit $RETVAL
     fi
 }
 

--- a/sonar-application/src/main/assembly/bin/solaris-x86-32/sonar.sh
+++ b/sonar-application/src/main/assembly/bin/solaris-x86-32/sonar.sh
@@ -334,6 +334,7 @@ checkUser() {
         # Still want to change users, recurse.  This means that the user will only be
         #  prompted for a password once. Variables shifted by 1
         sudo -u $RUN_AS_USER "$REALPATH" "$2"
+        RETVAL=$?
 
         # Now that we are the original user again, we may need to clean up the lock file.
         if [ "X$LOCKPROP" != "X" ]
@@ -349,7 +350,7 @@ checkUser() {
             fi
         fi
 
-        exit 0
+        exit $RETVAL
     fi
 }
 


### PR DESCRIPTION
Exit code is not properly returned when using RUN_AS_USER

I found that issue in the appassembler plugin http://jira.codehaus.org/browse/MAPPASM-113
and seems that the sonar shell scripts still have the issue

This is key for automated tools to know whether the Sonar service is running or not, ie. puppet
https://github.com/maestrodev/puppet-sonar
