### PR TITLE
Refactoring away from Resource<T>

### DIFF
--- a/plugins/sonar-cobertura-plugin/src/main/java/org/sonar/plugins/cobertura/CoberturaSensor.java
+++ b/plugins/sonar-cobertura-plugin/src/main/java/org/sonar/plugins/cobertura/CoberturaSensor.java
@@ -64,7 +64,7 @@ public class CoberturaSensor implements Sensor, CoverageExtension {
 
   private static final class JavaCoberturaParser extends AbstractCoberturaParser {
     @Override
-    protected Resource<?> getResource(String fileName) {
+    protected Resource getResource(String fileName) {
       return new JavaFile(fileName);
     }
   }

--- a/plugins/sonar-core-plugin/src/main/java/org/sonar/plugins/core/sensors/ReviewsMeasuresDecorator.java
+++ b/plugins/sonar-core-plugin/src/main/java/org/sonar/plugins/core/sensors/ReviewsMeasuresDecorator.java
@@ -134,7 +134,7 @@ public class ReviewsMeasuresDecorator implements Decorator {
     return newViolationCount - newReviewedViolationCount;
   }
 
-  private int sumChildren(Resource<?> resource, DecoratorContext context, Metric metric) {
+  private int sumChildren(Resource resource, DecoratorContext context, Metric metric) {
     int sum = 0;
     if (!ResourceUtils.isFile(resource)) {
       sum = MeasureUtils.sum(true, context.getChildrenMeasures(metric)).intValue();

--- a/plugins/sonar-core-plugin/src/main/java/org/sonar/plugins/core/timemachine/NewViolationsDecorator.java
+++ b/plugins/sonar-core-plugin/src/main/java/org/sonar/plugins/core/timemachine/NewViolationsDecorator.java
@@ -93,7 +93,7 @@ public class NewViolationsDecorator implements Decorator {
     }
   }
 
-  private boolean shouldDecorateResource(Resource<?> resource, DecoratorContext context) {
+  private boolean shouldDecorateResource(Resource resource, DecoratorContext context) {
     return (StringUtils.equals(Scopes.PROJECT, resource.getScope()) || StringUtils.equals(Scopes.DIRECTORY, resource.getScope()) || StringUtils
         .equals(Scopes.FILE, resource.getScope()))
       && (context.getMeasure(CoreMetrics.NEW_VIOLATIONS) == null);

--- a/plugins/sonar-core-plugin/src/test/java/org/sonar/plugins/core/sensors/ReviewsMeasuresDecoratorTest.java
+++ b/plugins/sonar-core-plugin/src/test/java/org/sonar/plugins/core/sensors/ReviewsMeasuresDecoratorTest.java
@@ -96,7 +96,7 @@ public class ReviewsMeasuresDecoratorTest {
   public void shouldDecoratePersistableResource() throws Exception {
     ReviewsMeasuresDecorator decorator = new ReviewsMeasuresDecorator(null, null);
     DecoratorContext context = mock(DecoratorContext.class);
-    Resource<?> resource = mock(Resource.class);
+    Resource resource = mock(Resource.class);
     when(resource.getScope()).thenReturn(Scopes.BLOCK_UNIT);
     decorator.decorate(resource, context);
     verify(context, never()).saveMeasure(any(Metric.class), anyDouble());
@@ -106,7 +106,7 @@ public class ReviewsMeasuresDecoratorTest {
   public void shouldNotDecorateUnitTest() throws Exception {
     ReviewsMeasuresDecorator decorator = new ReviewsMeasuresDecorator(null, null);
     DecoratorContext context = mock(DecoratorContext.class);
-    Resource<?> resource = mock(Resource.class);
+    Resource resource = mock(Resource.class);
     when(resource.getScope()).thenReturn(Scopes.FILE);
     when(resource.getQualifier()).thenReturn(Qualifiers.UNIT_TEST_FILE);
     decorator.decorate(resource, context);
@@ -115,7 +115,7 @@ public class ReviewsMeasuresDecoratorTest {
 
   @Test
   public void shouldTrackNewViolationsWithoutReview() throws Exception {
-    Resource<?> resource = new File("foo").setId(1);
+    Resource resource = new File("foo").setId(1);
     Violation v1 = Violation.create((Rule) null, resource).setPermanentId(1); // test the null case for the created_at date
     Violation v2 = Violation.create((Rule) null, resource).setPermanentId(2).setCreatedAt(rightNow);
     Violation v3 = Violation.create((Rule) null, resource).setPermanentId(3).setCreatedAt(fiveDaysAgo);

--- a/plugins/sonar-core-plugin/src/test/java/org/sonar/plugins/core/timemachine/NewViolationsDecoratorTest.java
+++ b/plugins/sonar-core-plugin/src/test/java/org/sonar/plugins/core/timemachine/NewViolationsDecoratorTest.java
@@ -71,7 +71,7 @@ public class NewViolationsDecoratorTest {
 
   private NewViolationsDecorator decorator;
   private DecoratorContext context;
-  private Resource<?> resource;
+  private Resource resource;
   private NotificationManager notificationManager;
 
   private Date rightNow;

--- a/plugins/sonar-surefire-plugin/src/main/java/org/sonar/plugins/surefire/SurefireSensor.java
+++ b/plugins/sonar-surefire-plugin/src/main/java/org/sonar/plugins/surefire/SurefireSensor.java
@@ -57,7 +57,7 @@ public class SurefireSensor implements Sensor {
     logger.info("parsing {}", reportsDir);
     new AbstractSurefireParser() {
       @Override
-      protected Resource<?> getUnitTestResource(String classKey) {
+      protected Resource getUnitTestResource(String classKey) {
         if (!StringUtils.contains(classKey, "$")) {
           // temporary hack waiting for http://jira.codehaus.org/browse/SONAR-1865
           return new JavaFile(classKey, true);

--- a/plugins/sonar-surefire-plugin/src/main/java/org/sonar/plugins/surefire/api/AbstractSurefireParser.java
+++ b/plugins/sonar-surefire-plugin/src/main/java/org/sonar/plugins/surefire/api/AbstractSurefireParser.java
@@ -137,6 +137,6 @@ public abstract class AbstractSurefireParser {
     context.saveMeasure(resource, new Measure(CoreMetrics.TEST_DATA, report.toXml()));
   }
 
-  protected abstract Resource<?> getUnitTestResource(String classKey);
+  protected abstract Resource getUnitTestResource(String classKey);
 
 }

--- a/plugins/sonar-surefire-plugin/src/test/java/org/sonar/plugins/surefire/api/AbstractSurefireParserTest.java
+++ b/plugins/sonar-surefire-plugin/src/test/java/org/sonar/plugins/surefire/api/AbstractSurefireParserTest.java
@@ -153,7 +153,7 @@ public class AbstractSurefireParserTest {
   private AbstractSurefireParser newParser() {
     return new AbstractSurefireParser() {
       @Override
-      protected Resource<?> getUnitTestResource(String classKey) {
+      protected Resource getUnitTestResource(String classKey) {
         return new File(classKey);
       }
     };

--- a/sonar-plugin-api/src/main/java/org/sonar/api/resources/DuplicatedSourceException.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/resources/DuplicatedSourceException.java
@@ -27,7 +27,7 @@ import org.sonar.api.utils.SonarException;
  */
 public final class DuplicatedSourceException extends SonarException {
 
-  public DuplicatedSourceException(Resource<?> resource) {
+  public DuplicatedSourceException(Resource resource) {
     super("Duplicate source for resource: " + ObjectUtils.toString(resource));
   }
 }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/resources/File.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/resources/File.java
@@ -30,7 +30,7 @@ import java.util.List;
  * 
  * @since 1.10
  */
-public class File extends Resource<Directory> {
+public class File extends Resource {
 
   public static final String SCOPE = Scopes.FILE;
 

--- a/sonar-plugin-api/src/main/java/org/sonar/api/resources/JavaFile.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/resources/JavaFile.java
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * @since 1.10
  */
-public class JavaFile extends Resource<JavaPackage> {
+public class JavaFile extends Resource {
 
   private String filename;
   private String longName;

--- a/sonar-plugin-api/src/main/java/org/sonar/api/resources/JavaPackage.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/resources/JavaPackage.java
@@ -99,7 +99,7 @@ public class JavaPackage extends Resource {
    * {@inheritDoc}
    */
   @Override
-  public Resource<?> getParent() {
+  public Resource getParent() {
     return null;
   }
 

--- a/sonar-plugin-api/src/main/java/org/sonar/api/resources/Resource.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/resources/Resource.java
@@ -24,7 +24,7 @@ package org.sonar.api.resources;
  * 
  * @since 1.10
  */
-public abstract class Resource<PARENT extends Resource> {
+public abstract class Resource {
 
   /**
    * @deprecated since 2.6. Use Scopes.PROJECT.
@@ -176,7 +176,7 @@ public abstract class Resource<PARENT extends Resource> {
    * Return null if the parent is the project.
    * </p>
    */
-  public abstract PARENT getParent();
+  public abstract Resource getParent();
 
   /**
    * Check resource against an Ant pattern, like mypackag?/*Foo.java. It's used for example to match resource exclusions.


### PR DESCRIPTION
Most clients ignore the type parameter, and subclassing users are
forced to specify twice the same type.
