### PR TITLE
New violations email should contain total violations for each violation type

### DIFF
--- a/plugins/sonar-core-plugin/src/main/java/org/sonar/plugins/core/timemachine/NewViolationsDecorator.java
+++ b/plugins/sonar-core-plugin/src/main/java/org/sonar/plugins/core/timemachine/NewViolationsDecorator.java
@@ -216,16 +216,29 @@ public class NewViolationsDecorator implements Decorator {
       // Do not send notification if this is the first analysis or if there's no violation
       if (pastSnapshot.getTargetDate() != null && newViolationsCount != null && newViolationsCount > 0) {
         // Maybe we should check if this is the first analysis or not?
-        DateFormat dateformat = new SimpleDateFormat("yyyy-MM-dd");
+        DateFormat dateformat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         Notification notification = new Notification("new-violations")
             .setFieldValue("count", String.valueOf(newViolationsCount.intValue()))
             .setFieldValue("projectName", project.getLongName())
             .setFieldValue("projectKey", project.getKey())
             .setFieldValue("projectId", String.valueOf(project.getId()))
             .setFieldValue("fromDate", dateformat.format(pastSnapshot.getTargetDate()));
+
+        // Add violation detailed counters
+        addViolationDetail(context, notification, CoreMetrics.NEW_BLOCKER_VIOLATIONS, "count-blocker");
+        addViolationDetail(context, notification, CoreMetrics.NEW_CRITICAL_VIOLATIONS, "count-critical");
+        addViolationDetail(context, notification, CoreMetrics.NEW_MAJOR_VIOLATIONS, "count-major");
+        addViolationDetail(context, notification, CoreMetrics.NEW_MINOR_VIOLATIONS, "count-minor");
+        addViolationDetail(context, notification, CoreMetrics.NEW_INFO_VIOLATIONS, "count-info");
+
         notificationManager.scheduleForSending(notification);
       }
     }
+  }
+
+  private void addViolationDetail(DecoratorContext context, Notification notification, Metric metric, String fieldName) {
+    Double variation = context.getMeasure(metric).getVariation1();
+    notification.setFieldValue(fieldName, String.valueOf(variation.intValue()));
   }
 
   @Override

--- a/plugins/sonar-core-plugin/src/test/java/org/sonar/plugins/core/timemachine/NewViolationsDecoratorTest.java
+++ b/plugins/sonar-core-plugin/src/test/java/org/sonar/plugins/core/timemachine/NewViolationsDecoratorTest.java
@@ -237,13 +237,28 @@ public class NewViolationsDecoratorTest {
     PastSnapshot pastSnapshot = new PastSnapshot("", pastDate.getTime());
     when(timeMachineConfiguration.getProjectPastSnapshots()).thenReturn(Lists.newArrayList(pastSnapshot, pastSnapshot));
     Measure m = new Measure(CoreMetrics.NEW_VIOLATIONS).setVariation1(32.0);
+    Measure mblocker = new Measure(CoreMetrics.NEW_BLOCKER_VIOLATIONS).setVariation1(12.0);
+    Measure mcritical = new Measure(CoreMetrics.NEW_CRITICAL_VIOLATIONS).setVariation1(10.0);
+    Measure mmajor = new Measure(CoreMetrics.NEW_MAJOR_VIOLATIONS).setVariation1(5.0);
+    Measure mminor = new Measure(CoreMetrics.NEW_MINOR_VIOLATIONS).setVariation1(5.0);
+    Measure minfo = new Measure(CoreMetrics.NEW_INFO_VIOLATIONS).setVariation1(0.0);
     when(context.getMeasure(CoreMetrics.NEW_VIOLATIONS)).thenReturn(m);
+    when(context.getMeasure(CoreMetrics.NEW_BLOCKER_VIOLATIONS)).thenReturn(mblocker);
+    when(context.getMeasure(CoreMetrics.NEW_CRITICAL_VIOLATIONS)).thenReturn(mcritical);
+    when(context.getMeasure(CoreMetrics.NEW_MAJOR_VIOLATIONS)).thenReturn(mmajor);
+    when(context.getMeasure(CoreMetrics.NEW_MINOR_VIOLATIONS)).thenReturn(mminor);
+    when(context.getMeasure(CoreMetrics.NEW_INFO_VIOLATIONS)).thenReturn(minfo);
 
     decorator.decorate(project, context);
 
-    DateFormat dateformat = new SimpleDateFormat("yyyy-MM-dd");
+    DateFormat dateformat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     Notification notification = new Notification("new-violations")
         .setFieldValue("count", "32")
+        .setFieldValue("count-blocker", "12")
+        .setFieldValue("count-critical", "10")
+        .setFieldValue("count-major", "5")
+        .setFieldValue("count-minor", "5")
+        .setFieldValue("count-info", "0")        
         .setFieldValue("projectName", "LongName")
         .setFieldValue("projectKey", "key")
         .setFieldValue("projectId", "45")

--- a/plugins/sonar-email-notifications-plugin/src/main/java/org/sonar/plugins/emailnotifications/newviolations/NewViolationsEmailTemplate.java
+++ b/plugins/sonar-email-notifications-plugin/src/main/java/org/sonar/plugins/emailnotifications/newviolations/NewViolationsEmailTemplate.java
@@ -45,11 +45,24 @@ public class NewViolationsEmailTemplate extends EmailTemplate {
     StringBuilder sb = new StringBuilder();
 
     String projectName = notification.getFieldValue("projectName");
-    String violationsCount = notification.getFieldValue("count");
     String fromDate = notification.getFieldValue("fromDate");
+
+    String violationsCount = notification.getFieldValue("count");
+    String blockerViolationsCount = notification.getFieldValue("count-blocker");
+    String criticalViolationsCount = notification.getFieldValue("count-critical");
+    String majorViolationsCount = notification.getFieldValue("count-major");
+    String minorViolationsCount = notification.getFieldValue("count-minor");
+    String infoViolationsCount = notification.getFieldValue("count-info");
 
     sb.append("Project: ").append(projectName).append('\n');
     sb.append(violationsCount).append(" new violations introduced since ").append(fromDate).append('\n');
+    sb.append("\n")
+      .append(" Blocker: ").append(blockerViolationsCount).append(" ")
+      .append(" Critical: ").append(criticalViolationsCount).append(" ")
+      .append(" Major: ").append(majorViolationsCount).append(" ")
+      .append(" Minor: ").append(minorViolationsCount).append(" ")
+      .append(" Info: ").append(infoViolationsCount).append("\n")
+    ;
     appendFooter(sb, notification);
 
     EmailMessage message = new EmailMessage()

--- a/plugins/sonar-email-notifications-plugin/src/test/java/org/sonar/plugins/emailnotifications/newviolations/NewViolationsEmailTemplateTest.java
+++ b/plugins/sonar-email-notifications-plugin/src/test/java/org/sonar/plugins/emailnotifications/newviolations/NewViolationsEmailTemplateTest.java
@@ -57,6 +57,8 @@ public class NewViolationsEmailTemplateTest {
    * Project: Foo
    * 32 new violations introduced since 2012-01-02
    * 
+   *  Blocker: 12  Critical: 10  Major: 5  Minor: 5  Info: 0
+   * 
    * See it in Sonar: http://nemo.sonarsource.org/drilldown/measures/org.sonar.foo:foo?metric=new_violations&period=1
    * </pre>
    */
@@ -64,6 +66,11 @@ public class NewViolationsEmailTemplateTest {
   public void shouldFormatCommentAdded() {
     Notification notification = new Notification("new-violations")
         .setFieldValue("count", "32")
+        .setFieldValue("count-blocker", "12")
+        .setFieldValue("count-critical", "10")
+        .setFieldValue("count-major", "5")
+        .setFieldValue("count-minor", "5")
+        .setFieldValue("count-info", "0")
         .setFieldValue("projectName", "Foo")
         .setFieldValue("projectKey", "org.sonar.foo:foo")
         .setFieldValue("projectId", "45")
@@ -75,6 +82,8 @@ public class NewViolationsEmailTemplateTest {
     assertThat(message.getMessage(), is("" +
       "Project: Foo\n" +
       "32 new violations introduced since 2012-01-02\n" +
+      "\n" + 
+      " Blocker: 12  Critical: 10  Major: 5  Minor: 5  Info: 0\n" + 
       "\n" +
       "See it in Sonar: http://nemo.sonarsource.org/drilldown/measures/org.sonar.foo:foo?metric=new_violations&period=1\n"));
   }


### PR DESCRIPTION
...type

New violations email only contains information regarding the total violations.
This commit adds support to displaying the total violations for each violation type.

Before the change the email format is like:
      Subject: New violations for project Foo
      From: Sonar

```
  Project: Foo
  32 new violations introduced since 2012-01-02

  See it in Sonar: http://nemo.sonarsource.org/drilldown/measures/org.sonar.foo:foo?metric=new_violations&period=1
```

After the change the email format is like:
      Subject: New violations for project Foo
      From: Sonar

```
  Project: Foo
  32 new violations introduced since 2012-01-02

   Blocker: 12  Critical: 10  Major: 5  Minor: 5  Info: 0

  See it in Sonar: http://nemo.sonarsource.org/drilldown/measures/org.sonar.foo:foo?metric=new_violations&period=1
```
