### PR TITLE
SONAR-4197 Escaping JSON in Timeline widget

### DIFF
--- a/plugins/sonar-core-plugin/src/main/resources/org/sonar/plugins/core/widgets/timeline.html.erb
+++ b/plugins/sonar-core-plugin/src/main/resources/org/sonar/plugins/core/widgets/timeline.html.erb
@@ -134,7 +134,7 @@
          js_events += "),l:["
          e_details.each() do |e|
            js_events += "{n:\""
-           js_events += e.name
+           js_events += json_escape(e.name)
            js_events += "\"},"
          end
          js_events = js_events.chomp(',') + "]},"


### PR DESCRIPTION
In some of my projects it's not possible to view the Timeline chart ("Displays
up to 3 metrics on a history chart"). In Firefox's firebug I can see the
javascript error message:

``` javascript
SyntaxError: missing } after property list
...f(pv.$.s.type=="text/javascript+protovis"){try{window.eval(pv.parse(pv.$.s.text)
```

It happens on line 4162 in file sonar.js.
I set a breakpoint on this line:

``` javascript
if(pv.$.s.type=="text/javascript+protovis"){try{window.eval(pv.parse(pv.$.s.text))
```

I traced the pv.$.s.text variable and found the problematic value:

``` javascript
function d(y, m, d, h, min, s) {
return new Date(y, m, d, h, min, s);
}
var data =
[[{x:d(2013,2,1,15,58,29),y:1252.00,yl:"1,252"},{x:d(2013,2,4,18,15,28),y:1255.00,yl:"1,255"}],[{x:d(2013,2,1,15,58,29),y:37.60,yl:"37.6%"},{x:d(2013,2,4,18,15,28),y:37.70,yl:"37.7%"}],[{x:d(2013,2,1,15,58,29),y:2.20,yl:"2.2%"},{x:d(2013,2,4,18,15,28),y:2.20,yl:"2.2%"}]];
var snapshots = [{sid:545013,d:"01 Mar 2013"},{sid:552310,d:"04 Mar 2013"}];
var metrics = ["Lines of code","Line coverage","IT line coverage"];
var events =
[{sid:408582,d:d(2013,0,15,18,30,9),l:[{n:""1.0""}]},{sid:552310,d:d(2013,2,4,18,15,28),l:[{n:"1.0"}]}];
var timeline = new SonarWidgets.Timeline('timeline-chart-52')
.height(80)
.data(data)
.snapshots(snapshots)
.metrics(metrics)
.events(events);
timeline.render();
autoResize(200, function() {
timeline.render();
});
```

The syntax error here is around events variable: {n:""1.0""}]
It has two double quotes, number and two double quotes, what throws that syntax
error. It turned out I specified version for sonar runner in quotes and it's not properly escaped by timeline widget what caused the problems.
