### PR TITLE
SONAR-4175 Unable to display several Measure Filter Treemaps in the same dashboard

### DIFF
--- a/sonar-server/src/main/webapp/WEB-INF/app/views/measures/_display_treemap.html.erb
+++ b/sonar-server/src/main/webapp/WEB-INF/app/views/measures/_display_treemap.html.erb
@@ -2,7 +2,7 @@
   var filterCriteria<%= widget_id -%> = <%= filter.criteria.to_json -%>;
 </script>
 <%
-   treemap_id = (defined? widget) ? widget.id : 1
+   treemap_id = (defined? widget_id) ? widget_id : 1
    unless edit_mode
 %>
   <table class="spaced">


### PR DESCRIPTION
Here is a fix for the issue 4175 As suggested in JIRA

http://jira.codehaus.org/browse/SONAR-4175?page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel
