### PR TITLE
Adding forward slash to regex for validation of project/module key

### DIFF
--- a/sonar-batch/src/main/java/org/sonar/batch/scan/ProjectReactorValidator.java
+++ b/sonar-batch/src/main/java/org/sonar/batch/scan/ProjectReactorValidator.java
@@ -36,7 +36,7 @@ import java.util.List;
  */
 public class ProjectReactorValidator {
 
-  private static final String VALID_MODULE_KEY_REGEXP = "[0-9a-zA-Z\\-_\\.:]+";
+  private static final String VALID_MODULE_KEY_REGEXP = "[0-9a-zA-Z\\-_\\.:/]+";
   private final Settings settings;
 
   public ProjectReactorValidator(Settings settings) {


### PR DESCRIPTION
Forward slashes in project/module key worked in 3.5 and earlier.
