### PR TITLE
Deprecate sonar.verbose and replace it by sonar.logLevel

### DIFF
--- a/sonar-batch/src/main/java/org/sonar/batch/bootstrapper/Batch.java
+++ b/sonar-batch/src/main/java/org/sonar/batch/bootstrapper/Batch.java
@@ -21,6 +21,7 @@ package org.sonar.batch.bootstrapper;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.bootstrap.ProjectReactor;
 import org.sonar.batch.bootstrap.BootstrapContainer;
 import org.sonar.batch.bootstrap.BootstrapProperties;
@@ -71,6 +72,9 @@ public final class Batch {
 
   public Batch execute() {
     configureLogging();
+    if (bootstrapProperties.containsKey("sonar.verbose")) {
+      LoggerFactory.getLogger(getClass()).warn("sonar.verbose is deprecated, use sonar.logLevel instead");
+    }
     startBatch();
     return this;
   }

--- a/sonar-batch/src/main/java/org/sonar/batch/bootstrapper/LoggingConfiguration.java
+++ b/sonar-batch/src/main/java/org/sonar/batch/bootstrapper/LoggingConfiguration.java
@@ -56,7 +56,7 @@ public final class LoggingConfiguration {
   private Map<String, String> substitutionVariables = Maps.newHashMap();
 
   private LoggingConfiguration(@Nullable EnvironmentInformation environment) {
-    setVerbose(false);
+    setRootLevel(LEVEL_ROOT_DEFAULT);
     if (environment != null && "maven".equalsIgnoreCase(environment.getKey())) {
       setFormat(FORMAT_MAVEN);
     } else {
@@ -71,7 +71,9 @@ public final class LoggingConfiguration {
   public LoggingConfiguration setProperties(Map<String, String> properties) {
     Profiling.Level profilingLevel = Profiling.Level.fromConfigString(properties.get("sonar.log.profilingLevel"));
     setShowSqlResults(profilingLevel == Level.FULL);
-    setVerbose("true".equals(properties.get("sonar.verbose")));
+    if (properties.containsKey("sonar.logLevel")) {
+      setRootLevel(properties.get("sonar.logLevel"));
+    }
     return this;
   }
 

--- a/sonar-batch/src/main/resources/org/sonar/batch/bootstrapper/logback.xml
+++ b/sonar-batch/src/main/resources/org/sonar/batch/bootstrapper/logback.xml
@@ -2,7 +2,7 @@
 <configuration debug="false">
 
   <!--
-  
+
   This file is loaded by bootstrappers like Ant Task and Java Runner.
 
   Reasons to NOT move this configuration to bootstrappers:
@@ -26,7 +26,7 @@
     <level value="WARN"/>
   </logger>
 
-  <!-- BeanUtils generate to many DEBUG logs when sonar.verbose is set -->
+  <!-- BeanUtils generate to many DEBUG logs when sonar.logLevel is set to DEBUG -->
   <logger name="org.apache.commons.beanutils.converters">
     <level value="WARN"/>
   </logger>
@@ -53,7 +53,7 @@
   </logger>
 
   <root>
-    <!-- sonar.verbose -->
+    <!-- sonar.logLevel -->
     <level value="${ROOT_LOGGER_LEVEL}"/>
     <appender-ref ref="STDOUT"/>
   </root>

--- a/sonar-batch/src/main/resources/org/sonar/batch/logback.xml
+++ b/sonar-batch/src/main/resources/org/sonar/batch/logback.xml
@@ -2,7 +2,7 @@
 <configuration debug="false">
 
   <!--
-  
+
   This file is deprecated. It's replaced by org/sonar/batch/bootstrapper/logback.xml.
   It can't be deleted as long as Ant Task and Java Runner do not use org.sonar.batch.bootstrapper.LoggingConfiguration.
 
@@ -22,7 +22,7 @@
     <level value="WARN"/>
   </logger>
 
-  <!-- BeanUtils generate to many DEBUG logs when sonar.verbose is set -->
+  <!-- BeanUtils generate to many DEBUG logs when sonar.logLevel is set to DEBUG -->
   <logger name="org.apache.commons.beanutils.converters">
     <level value="WARN"/>
   </logger>
@@ -50,7 +50,7 @@
 
 
   <root>
-    <!-- sonar.verbose -->
+    <!-- sonar.logLevel -->
     <level value="${ROOT_LOGGER_LEVEL}"/>
     <appender-ref ref="STDOUT"/>
   </root>

--- a/sonar-batch/src/test/java/org/sonar/batch/bootstrapper/LoggingConfigurationTest.java
+++ b/sonar-batch/src/test/java/org/sonar/batch/bootstrapper/LoggingConfigurationTest.java
@@ -47,18 +47,18 @@ public class LoggingConfigurationTest {
   }
 
   @Test
-  public void testSetVerboseProperty() {
+  public void testSetLogLevelProperty() {
     Map<String, String> properties = Maps.newHashMap();
     assertThat(LoggingConfiguration.create(null).setProperties(properties)
         .getSubstitutionVariable(LoggingConfiguration.PROPERTY_ROOT_LOGGER_LEVEL)).isEqualTo(LoggingConfiguration.LEVEL_ROOT_DEFAULT);
 
-    properties.put("sonar.verbose", "true");
+    properties.put("sonar.logLevel", "WARN");
     assertThat(LoggingConfiguration.create(null).setProperties(properties)
-        .getSubstitutionVariable(LoggingConfiguration.PROPERTY_ROOT_LOGGER_LEVEL)).isEqualTo(LoggingConfiguration.LEVEL_ROOT_VERBOSE);
+        .getSubstitutionVariable(LoggingConfiguration.PROPERTY_ROOT_LOGGER_LEVEL)).isEqualTo("WARN");
 
-    properties.put("sonar.verbose", "false");
+    properties.put("sonar.logLevel", "OFF");
     assertThat(LoggingConfiguration.create(null).setProperties(properties)
-        .getSubstitutionVariable(LoggingConfiguration.PROPERTY_ROOT_LOGGER_LEVEL)).isEqualTo(LoggingConfiguration.LEVEL_ROOT_DEFAULT);
+        .getSubstitutionVariable(LoggingConfiguration.PROPERTY_ROOT_LOGGER_LEVEL)).isEqualTo("OFF");
   }
 
   @Test

--- a/sonar-maven-plugin/src/main/java/org/sonar/maven/SonarMojo.java
+++ b/sonar-maven-plugin/src/main/java/org/sonar/maven/SonarMojo.java
@@ -168,7 +168,7 @@ public final class SonarMojo extends AbstractMojo {
       runner.addExtensions(session, getLog(), lifecycleExecutor, artifactFactory, localRepository, artifactMetadataSource, artifactCollector,
         dependencyTreeBuilder, projectBuilder);
       if (getLog().isDebugEnabled()) {
-        runner.setProperty("sonar.verbose", "true");
+        runner.setProperty("sonar.logLevel", "DEBUG");
       }
       runner.execute();
     } catch (Exception e) {


### PR DESCRIPTION
I'd like to be able to specify the log level if I do a sonar analysis.
E. G. when starting an analysis from a cron job on linux, I want the log level to be WARN, to get the warnings mailed.
Currently this can only be done by filtering out INFO lines from the output with various patterns.
I'd like to be able to control this from sonar-runner with a command line switch.
So here is the sonarqube part, a pull request for the sonar-runner part follows.