### PR TITLE
do not clear whole localStorage on logout

### DIFF
--- a/server/sonar-web/src/main/js/recent-history.js
+++ b/server/sonar-web/src/main/js/recent-history.js
@@ -14,7 +14,7 @@ Sonar.RecentHistory.prototype.getRecentHistory = function () {
 };
 
 Sonar.RecentHistory.prototype.clear = function () {
-  localStorage.clear();
+  localStorage.removeItem("sonar_recent_history");
 };
 
 Sonar.RecentHistory.prototype.add = function (resourceKey, resourceName, icon) {


### PR DESCRIPTION
SonarQube clears the whole localStorage on logout. This could affect other applications which are running on the same domain.