### PR TITLE
Specify data types on inserts into project_measures

### DIFF
--- a/sonar-plugin-api/src/main/resources/org/sonar/api/database/model/MeasureMapper.xml
+++ b/sonar-plugin-api/src/main/resources/org/sonar/api/database/model/MeasureMapper.xml
@@ -9,10 +9,10 @@
       project_id, alert_status, alert_text, url, description, rule_priority, characteristic_id, variation_value_1,
       variation_value_2, variation_value_3, variation_value_4, variation_value_5, person_id, measure_data)
     VALUES (
-      #{value}, #{metricId}, #{snapshotId}, #{ruleId}, #{textValue}, #{tendency},
-      #{measureDate}, #{projectId}, #{alertStatus}, #{alertText},
-      #{url}, #{description}, #{rulePriority.ordinal}, #{characteristicId}, #{variationValue1},
-      #{variationValue2}, #{variationValue3}, #{variationValue4}, #{variationValue5}, #{personId}, #{data}
+      #{value, jdbcType=DOUBLE}, #{metricId, jdbcType=INTEGER}, #{snapshotId, jdbcType=INTEGER}, #{ruleId, jdbcType=INTEGER}, #{textValue, jdbcType=VARCHAR}, #{tendency, jdbcType=INTEGER},
+      #{measureDate, jdbcType=TIMESTAMP}, #{projectId, jdbcType=INTEGER}, #{alertStatus, jdbcType=VARCHAR}, #{alertText, jdbcType=VARCHAR},
+      #{url, jdbcType=VARCHAR}, #{description, jdbcType=VARCHAR}, #{rulePriority.ordinal, jdbcType=INTEGER}, #{characteristicId, jdbcType=INTEGER}, #{variationValue1, jdbcType=DOUBLE},
+      #{variationValue2, jdbcType=DOUBLE}, #{variationValue3, jdbcType=DOUBLE}, #{variationValue4, jdbcType=DOUBLE}, #{variationValue5, jdbcType=DOUBLE}, #{personId, jdbcType=INTEGER}, #{data}
     )
   </insert>
 


### PR DESCRIPTION
At least when using Oracle databases, projects with large volumes of
updates (over a million inserts per hour) see lots of cursor
contention, accounting for up to 40% of the database's activity (after
adjusting the shared pool size appropriately). This is due to the
presence of null values where the database can't determine the data
type, and therefore has to try different variants of the statement.

Specifying the data types on the non-blob columns avoids the type
uncertainty, and solves the cursor contention.

Signed-off-by: Stephen Kitt steve@sk2.org
