### PR TITLE
Changed all references to docs.codehaus.org to docs.sonarqube.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Licensed under the GNU Lesser General Public License, Version 3.0: http://www.gn
 
  [1]: http://www.sonarqube.org/
  [2]: http://jira.codehaus.org/browse/SONAR
- [3]: http://docs.codehaus.org/display/SONAR
+ [3]: http://docs.sonarqube.org/display/SONAR

--- a/server/sonar-server/src/main/java/org/sonar/server/component/ws/EventsWs.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/component/ws/EventsWs.java
@@ -38,7 +38,7 @@ public class EventsWs implements WebService {
 
   private void defineIndexAction(NewController controller) {
     controller.createAction("index")
-      .setDescription("Documentation of this web service is available <a href=\"http://docs.codehaus.org/x/2ICYDg\">here</a>")
+      .setDescription("Documentation of this web service is available <a href=\"http://docs.sonarqube.org/x/2ICYDg\">here</a>")
       .setSince("2.6")
       .setHandler(RailsHandler.INSTANCE);
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/component/ws/ResourcesWs.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/component/ws/ResourcesWs.java
@@ -50,7 +50,7 @@ public class ResourcesWs implements WebService {
       .setExampleValue("org.codehaus.sonar:sonar");
 
     action.createParam("metrics")
-      .setDescription("Comma-separated list of <a href=\"http://docs.codehaus.org/display/SONAR/Metric+definitions\">metric keys/ids</a>. " +
+      .setDescription("Comma-separated list of <a href=\"http://docs.sonarqube.org/display/SONAR/Metric+definitions\">metric keys/ids</a>. " +
         "Load measures on selected metrics. If only one metric is set, then measures are ordered by value")
       .setExampleValue("lines,blocker_violations");
 

--- a/server/sonar-server/src/main/java/org/sonar/server/config/ws/PropertiesWs.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/config/ws/PropertiesWs.java
@@ -38,7 +38,7 @@ public class PropertiesWs implements WebService {
 
   private void defineIndexAction(NewController controller) {
     controller.createAction("index")
-      .setDescription("Documentation of this web service is available <a href=\"http://docs.codehaus.org/x/0YCYDg\">here</a>")
+      .setDescription("Documentation of this web service is available <a href=\"http://docs.sonarqube.org/x/0YCYDg\">here</a>")
       .setSince("2.6")
       .setHandler(RailsHandler.INSTANCE);
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/measure/ws/ManualMeasuresWs.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/measure/ws/ManualMeasuresWs.java
@@ -38,7 +38,7 @@ public class ManualMeasuresWs implements WebService {
 
   private void defineIndexAction(NewController controller) {
     controller.createAction("index")
-      .setDescription("Documentation of this web service is available <a href=\"http://docs.codehaus.org/x/0oCYDg\">here</a>")
+      .setDescription("Documentation of this web service is available <a href=\"http://docs.sonarqube.org/x/0oCYDg\">here</a>")
       .setSince("2.10")
       .setHandler(RailsHandler.INSTANCE);
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/measure/ws/MetricsWs.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/measure/ws/MetricsWs.java
@@ -38,7 +38,7 @@ public class MetricsWs implements WebService {
 
   private void defineIndexAction(NewController controller) {
     controller.createAction("index")
-      .setDescription("Documentation of this web service is available <a href=\"http://docs.codehaus.org/x/04CYDg\">here</a>")
+      .setDescription("Documentation of this web service is available <a href=\"http://docs.sonarqube.org/x/04CYDg\">here</a>")
       .setSince("2.6")
       .setHandler(RailsHandler.INSTANCE);
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/measure/ws/TimeMachineWs.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/measure/ws/TimeMachineWs.java
@@ -50,7 +50,7 @@ public class TimeMachineWs implements WebService {
       .setExampleValue("org.codehaus.sonar:sonar");
 
     action.createParam("metrics")
-      .setDescription("Comma-separated list of <a href=\"http://docs.codehaus.org/display/SONAR/Metric+definitions\">metric keys/ids</a>")
+      .setDescription("Comma-separated list of <a href=\"http://docs.sonarqube.org/display/SONAR/Metric+definitions\">metric keys/ids</a>")
       .setRequired(true)
       .setExampleValue("coverage,violations");
 

--- a/server/sonar-server/src/main/java/org/sonar/server/user/ws/FavoritesWs.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/user/ws/FavoritesWs.java
@@ -38,7 +38,7 @@ public class FavoritesWs implements WebService {
 
   private void defineIndexAction(NewController controller) {
     controller.createAction("index")
-      .setDescription("Documentation of this web service is available <a href=\"http://docs.codehaus.org/x/3ICYDg\">here</a>")
+      .setDescription("Documentation of this web service is available <a href=\"http://docs.sonarqube.org/x/3ICYDg\">here</a>")
       .setSince("2.6")
       .setHandler(RailsHandler.INSTANCE);
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/user/ws/UserPropertiesWs.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/user/ws/UserPropertiesWs.java
@@ -38,7 +38,7 @@ public class UserPropertiesWs implements WebService {
 
   private void defineIndexAction(NewController controller) {
     controller.createAction("index")
-      .setDescription("Documentation of this web service is available <a href=\"http://docs.codehaus.org/x/5ICYDg\">here</a>")
+      .setDescription("Documentation of this web service is available <a href=\"http://docs.sonarqube.org/x/5ICYDg\">here</a>")
       .setSince("2.6")
       .setHandler(RailsHandler.INSTANCE);
   }

--- a/server/sonar-web/src/main/hbs/design/design.hbs
+++ b/server/sonar-web/src/main/hbs/design/design.hbs
@@ -1,5 +1,5 @@
 <div class="dsm-header">
-  <i class="icon-help"></i> <a href="http://docs.codehaus.org/x/QQFhC">{{t 'design.help'}}</a>
+  <i class="icon-help"></i> <a href="http://docs.sonarqube.org/x/QQFhC">{{t 'design.help'}}</a>
 </div>
 
 <ul class="dsm-legend">

--- a/server/sonar-web/src/main/webapp/WEB-INF/app/models/database_migration_manager.rb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/models/database_migration_manager.rb
@@ -58,7 +58,7 @@ class DatabaseMigrationManager
         @message = "Migration required."
       else
         @status = MIGRATION_FAILED
-        @message = "Upgrade is not supported. Please use a <a href=\"http://docs.codehaus.org/display/SONAR/Requirements\">production-ready database</a>."
+        @message = "Upgrade is not supported. Please use a <a href=\"http://docs.sonarqube.org/display/SONAR/Requirements\">production-ready database</a>."
       end
     end
   end

--- a/server/sonar-web/src/main/webapp/WEB-INF/app/views/encryption_configuration/generate_secret_form.html.erb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/views/encryption_configuration/generate_secret_form.html.erb
@@ -9,7 +9,7 @@
   <tr class="property">
     <td style="padding: 10px">
       <p class="marginbottom10">Secret key is required to be able to encrypt properties.
-        <a href="http://docs.codehaus.org/display/SONAR/Security#Security-encryption" class="external" target="sonar_doc">More
+        <a href="http://docs.sonarqube.org/display/SONAR/Security#Security-encryption" class="external" target="sonar_doc">More
           information</a>.</p>
 
       <div id="secret_content">

--- a/server/sonar-web/src/main/webapp/WEB-INF/app/views/encryption_configuration/index.html.erb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/views/encryption_configuration/index.html.erb
@@ -40,7 +40,7 @@
       <span id="encryption_error" class="error" style="display:none"></span>
 
       <p><br/>Note that the <%= link_to 'secret key can be changed', {:action => 'generate_secret_form'}, :class => 'link-action', :id => 'link-generate-key' %>
-        but all the encrypted properties will have to be updated. <a href="http://docs.codehaus.org/display/SONAR/Settings+Encryption" class="external" target="sonar_doc">More information</a>.</p>
+        but all the encrypted properties will have to be updated. <a href="http://docs.sonarqube.org/display/SONAR/Settings+Encryption" class="external" target="sonar_doc">More information</a>.</p>
     </td>
   </tr>
   </tbody>

--- a/server/sonar-web/src/main/webapp/WEB-INF/app/views/layouts/_footer.html.erb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/views/layouts/_footer.html.erb
@@ -3,7 +3,7 @@
   <div style="margin-top:150px;text-align:center;line-height:1.4;color:#333;">
     The web interface cannot be displayed because your browser is not supported.<br>
     Please switch to a <a target="_blank"
-                          href="http://docs.codehaus.org/x/zYHEBg">supported version or another supported browser</a>.
+                          href="http://docs.sonarqube.org/x/zYHEBg">supported version or another supported browser</a>.
   </div>
 </div>
 <!--<![endif]-->

--- a/server/sonar-web/src/main/webapp/WEB-INF/app/views/layouts/_layout.html.erb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/views/layouts/_layout.html.erb
@@ -225,7 +225,7 @@
           <br><br><span class="error">The embedded database will not scale, it will not support upgrading to newer versions of SonarQube, and there is no support for migrating your data out of it into a different database engine.</span>
         <% end %>
       </div>
-      <!--[if lte IE 8 ]><br/><span class="ie-warn">IE 8 is not supported. Some widgets may not be properly displayed. Please switch to a <a target="_blank" href="http://docs.codehaus.org/x/zYHEBg">supported version or another supported browser</a>.</span><!--<![endif]-->
+      <!--[if lte IE 8 ]><br/><span class="ie-warn">IE 8 is not supported. Some widgets may not be properly displayed. Please switch to a <a target="_blank" href="http://docs.sonarqube.org/x/zYHEBg">supported version or another supported browser</a>.</span><!--<![endif]-->
     </div>
   </div>
 <% end %>

--- a/server/sonar-web/src/main/webapp/WEB-INF/app/views/maintenance/index.html.erb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/views/maintenance/index.html.erb
@@ -13,5 +13,5 @@
 <div id="maintenance">
 <div id="maintenancelogo"><a href="http://www.sonarqube.org"><%= image_tag('logo.png', :class => 'png') -%></a></div>
 <h1>SonarQube is under maintenance. <a href="<%= ApplicationController.root_context -%>/">Please check back later.</a></h1>
-<p>Whilst waiting, you might want to check <a href="http://sonar-plugins.codehaus.org">new plugins</a> to extend the current functionality. </p><p>If you are an administrator and have no idea why this message is showing, you should read the <a href="http://docs.codehaus.org/x/CIF7BQ">upgrade guide</a>.</p>
+<p>Whilst waiting, you might want to check <a href="http://sonar-plugins.codehaus.org">new plugins</a> to extend the current functionality. </p><p>If you are an administrator and have no idea why this message is showing, you should read the <a href="http://docs.sonarqube.org/x/CIF7BQ">upgrade guide</a>.</p>
 </div>

--- a/server/sonar-web/src/main/webapp/WEB-INF/app/views/updatecenter/system_updates.html.erb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/views/updatecenter/system_updates.html.erb
@@ -71,7 +71,7 @@
                       <ol class="bulletpoints">
                         <li>Stop SonarQube</li>
                         <li><%= link_to 'Download', release.getDownloadUrl(), :class => 'external' -%> and install
-                          SonarQube <%= release.getVersion() -%> after having carefully read the <a href="http://docs.codehaus.org/display/SONAR/Upgrading" class="external">upgrade guide</a>.
+                          SonarQube <%= release.getVersion() -%> after having carefully read the <a href="http://docs.sonarqube.org/display/SONAR/Upgrading" class="external">upgrade guide</a>.
                         </li>
                         <% update.getIncompatiblePlugins().each do |incompatible_plugin| %>
                         <li>
@@ -92,7 +92,7 @@
 
                     <% else %>
                       <%= link_to 'Download', release.getDownloadUrl(), :class => 'external' -%> and install
-                      SonarQube <%= release.getVersion() -%> after having carefully read the <a href="http://docs.codehaus.org/display/SONAR/Upgrading" class="external">upgrade guide</a>.
+                      SonarQube <%= release.getVersion() -%> after having carefully read the <a href="http://docs.sonarqube.org/display/SONAR/Upgrading" class="external">upgrade guide</a>.
                     <% end %>
                   </td>
                 </tr>

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -3,7 +3,7 @@
 #
 # Property values can:
 # - reference an environment variable, for example sonar.jdbc.url= ${env:SONAR_JDBC_URL}
-# - be encrypted. See http://docs.codehaus.org/display/SONAR/Settings+Encryption
+# - be encrypted. See http://docs.sonarqube.org/display/SONAR/Settings+Encryption
 
 
 #--------------------------------------------------------------------------------------------------

--- a/sonar-application/src/main/assembly/extensions/jdbc-driver/oracle/README.txt
+++ b/sonar-application/src/main/assembly/extensions/jdbc-driver/oracle/README.txt
@@ -1,2 +1,2 @@
-Please copy an Oracle JDBC driver in this directory. See compatible versions at http://docs.codehaus.org/display/SONAR/Requirements.
+Please copy an Oracle JDBC driver in this directory. See compatible versions at http://docs.sonarqube.org/display/SONAR/Requirements.
 Note that only a single JAR file is accepted. A failure is raised at startup if multiple JAR files are available.

--- a/sonar-deprecated/src/main/java/org/sonar/api/batch/SquidUtils.java
+++ b/sonar-deprecated/src/main/java/org/sonar/api/batch/SquidUtils.java
@@ -49,7 +49,7 @@ public final class SquidUtils {
   }
 
   private static UnsupportedOperationException unsupported() {
-    return new UnsupportedOperationException("Not supported since v4.2. See http://docs.codehaus.org/display/SONAR/API+Changes");
+    return new UnsupportedOperationException("Not supported since v4.2. See http://docs.sonarqube.org/display/SONAR/API+Changes");
   }
 
   /**

--- a/sonar-deprecated/src/main/java/org/sonar/api/resources/JavaFile.java
+++ b/sonar-deprecated/src/main/java/org/sonar/api/resources/JavaFile.java
@@ -29,7 +29,7 @@ import java.util.List;
  *
  * @since 1.10
  * @deprecated since 4.2 use {@link org.sonar.api.resources.File}. See
- * http://docs.codehaus.org/display/SONAR/API+Changes for more details
+ * http://docs.sonarqube.org/display/SONAR/API+Changes for more details
  */
 @Deprecated
 public class JavaFile extends Resource {
@@ -115,7 +115,7 @@ public class JavaFile extends Resource {
   }
 
   private static UnsupportedOperationException unsupported() {
-    throw new UnsupportedOperationException("Not supported since v4.2. See http://docs.codehaus.org/display/SONAR/API+Changes");
+    throw new UnsupportedOperationException("Not supported since v4.2. See http://docs.sonarqube.org/display/SONAR/API+Changes");
   }
 
 }

--- a/sonar-deprecated/src/main/java/org/sonar/api/resources/JavaPackage.java
+++ b/sonar-deprecated/src/main/java/org/sonar/api/resources/JavaPackage.java
@@ -83,6 +83,6 @@ public class JavaPackage extends Resource {
   }
 
   private static UnsupportedOperationException unsupported() {
-    throw new UnsupportedOperationException("Not supported since v4.2. See http://docs.codehaus.org/display/SONAR/API+Changes");
+    throw new UnsupportedOperationException("Not supported since v4.2. See http://docs.sonarqube.org/display/SONAR/API+Changes");
   }
 }

--- a/sonar-markdown/src/main/java/org/sonar/markdown/HtmlLinkChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/HtmlLinkChannel.java
@@ -27,8 +27,8 @@ import java.util.regex.Pattern;
 /**
  * Markdown interprets text in brackets followed by text in parentheses to generate documented links.
  *
- * E.g., the input [See documentation](http://docs.codehaus.org/display/SONAR) will produce
- * {@literal<a href="http://docs.codehaus.org/display/SONAR">}See documentation{@literal</a>}
+ * E.g., the input [See documentation](http://docs.sonarqube.org/display/SONAR) will produce
+ * {@literal<a href="http://docs.sonarqube.org/display/SONAR">}See documentation{@literal</a>}
  */
 class HtmlLinkChannel extends RegexChannel<MarkdownOutput> {
 

--- a/sonar-markdown/src/test/java/org/sonar/markdown/MarkdownTest.java
+++ b/sonar-markdown/src/test/java/org/sonar/markdown/MarkdownTest.java
@@ -33,8 +33,8 @@ public class MarkdownTest {
 
   @Test
   public void shouldDecorateDocumentedLink() {
-    assertThat(Markdown.convertToHtml("For more details, please [check online documentation](http://docs.codehaus.org/display/SONAR)."))
-        .isEqualTo("For more details, please <a href=\"http://docs.codehaus.org/display/SONAR\" target=\"_blank\">check online documentation</a>.");
+    assertThat(Markdown.convertToHtml("For more details, please [check online documentation](http://docs.sonarqube.org/display/SONAR)."))
+        .isEqualTo("For more details, please <a href=\"http://docs.sonarqube.org/display/SONAR\" target=\"_blank\">check online documentation</a>.");
   }
 
 

--- a/sonar-plugin-api/src/main/java/org/sonar/api/web/NavigationSection.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/web/NavigationSection.java
@@ -45,7 +45,7 @@ public @interface NavigationSection {
   String CONFIGURATION = "configuration";
 
   /**
-   * Only Ruby and rails application. See http://docs.codehaus.org/display/SONAR/Extend+Web+Application.
+   * Only Ruby and rails application. See http://docs.sonarqube.org/display/SONAR/Extend+Web+Application.
    * Use the resource parameter in order to get the current resource.
    *
    * @since 3.6


### PR DESCRIPTION
It is fairly inconvenient when I an error message that goes like

```
Not supported since v4.2. See http://docs.codehaus.org/display/SONAR/API+Changes
```

But end up on a non-existent page.