### PR TITLE
SONAR-5960 ES request fails if author is empty ("")

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/computation/issue/SourceLinesCache.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/issue/SourceLinesCache.java
@@ -20,6 +20,7 @@
 package org.sonar.server.computation.issue;
 
 import com.google.common.base.Function;
+import com.google.common.base.Strings;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -69,7 +70,8 @@ public class SourceLinesCache {
   public String lineAuthor(int lineId) {
     loadIfNeeded();
     if (lineId <= authors.size()) {
-      return authors.get(lineId - 1);
+      String author = authors.get(lineId - 1);
+      return Strings.emptyToNull(author);
     }
     return null;
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/user/index/UserIndex.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/user/index/UserIndex.java
@@ -20,6 +20,7 @@
 
 package org.sonar.server.user.index;
 
+import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -54,17 +55,19 @@ public class UserIndex implements ServerComponent {
 
   @CheckForNull
   public UserDoc getNullableByScmAccount(String scmAccount) {
-    SearchRequestBuilder request = esClient.prepareSearch(UserIndexDefinition.INDEX)
-      .setTypes(UserIndexDefinition.TYPE_USER)
-      .setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(),
-        FilterBuilders.boolFilter()
-          .should(FilterBuilders.termFilter(UserIndexDefinition.FIELD_LOGIN, scmAccount))
-          .should(FilterBuilders.termFilter(UserIndexDefinition.FIELD_EMAIL, scmAccount))
-          .should(FilterBuilders.termFilter(UserIndexDefinition.FIELD_SCM_ACCOUNTS, scmAccount))))
-      .setSize(2);
-    SearchHit[] result = request.get().getHits().getHits();
-    if (result.length == 1) {
-      return new UserDoc(result[0].sourceAsMap());
+    if (!StringUtils.isEmpty(scmAccount)) {
+      SearchRequestBuilder request = esClient.prepareSearch(UserIndexDefinition.INDEX)
+        .setTypes(UserIndexDefinition.TYPE_USER)
+        .setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(),
+          FilterBuilders.boolFilter()
+            .should(FilterBuilders.termFilter(UserIndexDefinition.FIELD_LOGIN, scmAccount))
+            .should(FilterBuilders.termFilter(UserIndexDefinition.FIELD_EMAIL, scmAccount))
+            .should(FilterBuilders.termFilter(UserIndexDefinition.FIELD_SCM_ACCOUNTS, scmAccount))))
+        .setSize(2);
+      SearchHit[] result = request.get().getHits().getHits();
+      if (result.length == 1) {
+        return new UserDoc(result[0].sourceAsMap());
+      }
     }
     return null;
   }

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/issue/SourceLinesCacheTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/issue/SourceLinesCacheTest.java
@@ -47,10 +47,18 @@ public class SourceLinesCacheTest {
 
     assertThat(cache.lineAuthor(1)).isEqualTo("charlie");
     assertThat(cache.lineAuthor(2)).isEqualTo("cabu");
+
+    // blank author -> return null
     assertThat(cache.lineAuthor(3)).isNull();
-    assertThat(cache.countLines()).isEqualTo(2);
+
+    // only 3 lines in the file
+    assertThat(cache.lineAuthor(100)).isNull();
+
+    assertThat(cache.countLines()).isEqualTo(3);
 
     cache.clear();
     assertThat(cache.countLines()).isEqualTo(0);
   }
+
+
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/user/index/UserIndexTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/user/index/UserIndexTest.java
@@ -56,6 +56,7 @@ public class UserIndexTest {
     assertThat(userDoc.createdAt()).isEqualTo(1500000000000L);
     assertThat(userDoc.updatedAt()).isEqualTo(1500000000000L);
 
+    assertThat(index.getNullableByLogin("")).isNull();
     assertThat(index.getNullableByLogin("unknown")).isNull();
   }
 
@@ -100,6 +101,7 @@ public class UserIndexTest {
     assertThat(index.getNullableByScmAccount("user1@mail.com").login()).isEqualTo("user1");
     assertThat(index.getNullableByScmAccount("user1").login()).isEqualTo("user1");
 
+    assertThat(index.getNullableByScmAccount("")).isNull();
     assertThat(index.getNullableByScmAccount("unknown")).isNull();
   }
 

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/issue/SourceLinesCacheTest/load_data.xml
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/issue/SourceLinesCacheTest/load_data.xml
@@ -1,6 +1,6 @@
 <dataset>
   <file_sources id="1" file_uuid="FILE_A" project_uuid="PROJECT_A"
-                data=",charlie,,,,,,,,,,,,,,first line&#13;&#10;,cabu,,,,,,,,,,,,,,second line&#13;&#10;"
+                data=",charlie,,,,,,,,,,,,,,first line&#13;&#10;,cabu,,,,,,,,,,,,,,second line&#13;&#10;,,,,,,,,,,,,,,,third line&#13;&#10;"
                 line_hashes="8d7b3d6b83c0a517eac07e1aac94b773&#10;9a0364b9e99bb480dd25e1f0284c8555"
                 data_hash="0263047cd758c68c27683625f072f010"
                 src_hash="123456"


### PR DESCRIPTION
SONAR-5960 ES request fails if author is empty ("")

 - do not allow blank author on issues
 - fix ES search