### PR TITLE
Keep compatibility with issue-assign and cockpit plugins

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/computation/issue/IssueComputation.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/issue/IssueComputation.java
@@ -58,15 +58,21 @@ public class IssueComputation {
   }
 
   private void guessAuthor(DefaultIssue issue) {
-    if (issue.line() != null) {
+    // issue.authorLogin() can be not-null when old developer cockpit plugin (or other plugin)
+    // is still installed and executed during analysis
+    if (issue.authorLogin() == null && issue.line() != null) {
       issue.setAuthorLogin(linesCache.lineAuthor(issue.line()));
     }
   }
 
   private void autoAssign(DefaultIssue issue) {
-    String scmAccount = issue.authorLogin();
-    if (scmAccount != null) {
-      issue.setAssignee(scmAccountCache.getNullable(scmAccount));
+    // issue.assignee() can be not-null if the issue-assign-plugin is
+    // still installed and executed during analysis
+    if (issue.assignee() == null) {
+      String scmAccount = issue.authorLogin();
+      if (scmAccount != null) {
+        issue.setAssignee(scmAccountCache.getNullable(scmAccount));
+      }
     }
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/issue/IssueComputationTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/issue/IssueComputationTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class IssueComputationTest {
@@ -145,6 +146,24 @@ public class IssueComputationTest {
     process();
 
     assertThat(Iterators.getOnlyElement(issueCache.traverse()).assignee()).isNull();
+  }
+
+  @Test
+  public void do_not_override_author_and_assignee_set_by_old_batch_plugins() throws Exception {
+    issue.setNew(true);
+
+    // these fields were provided during project analysis, for instance
+    // by developer cockpit or issue-assign plugins
+    issue.setAuthorLogin("charlie");
+    issue.setAssignee("cabu");
+
+    process();
+
+    // keep the values, without trying to update them
+    DefaultIssue cachedIssue = Iterators.getOnlyElement(issueCache.traverse());
+    assertThat(cachedIssue.assignee()).isEqualTo("cabu");
+    assertThat(cachedIssue.authorLogin()).isEqualTo("charlie");
+    verifyZeroInteractions(scmAccountCache);
   }
 
   private void process() {


### PR DESCRIPTION
Keep compatibility with issue-assign and cockpit plugins

Do not override author and assignee fields of new issues