### PR TITLE
Refactoring on IssueQueryService

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/issue/IssueQuery.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/IssueQuery.java
@@ -28,6 +28,7 @@ import org.sonar.server.user.UserSession;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -84,7 +85,6 @@ public class IssueQuery {
   private final String sort;
   private final Boolean asc;
   private final Boolean ignorePaging;
-  private final Boolean contextualized;
 
   private final String userLogin;
   private final Set<String> userGroups;
@@ -123,7 +123,6 @@ public class IssueQuery {
     this.userLogin = builder.userLogin;
     this.userGroups = builder.userGroups;
     this.checkAuthorization = builder.checkAuthorization;
-    this.contextualized = builder.contextualized;
   }
 
   public Collection<String> issueKeys() {
@@ -269,11 +268,6 @@ public class IssueQuery {
     return checkAuthorization;
   }
 
-  @CheckForNull
-  public Boolean isContextualized() {
-    return contextualized;
-  }
-
   @Override
   public String toString() {
     return ReflectionToStringBuilder.toString(this);
@@ -313,7 +307,6 @@ public class IssueQuery {
     private String sort;
     private Boolean asc = false;
     private Boolean ignorePaging = false;
-    private boolean contextualized;
     private String userLogin = UserSession.get().login();
     private Set<String> userGroups = UserSession.get().userGroups();
     private boolean checkAuthorization = true;
@@ -515,10 +508,6 @@ public class IssueQuery {
       return this;
     }
 
-    public Builder setContextualized(boolean b) {
-      this.contextualized = b;
-      return this;
-    }
   }
 
   private static <T> Collection<T> defaultCollection(@Nullable Collection<T> c) {

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/IssueQueryService.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/IssueQueryService.java
@@ -204,16 +204,12 @@ public class IssueQueryService implements ServerComponent {
     builder.onComponentOnly(effectiveOnComponentOnly);
 
     if (allComponentUuids.isEmpty()) {
-      builder.setContextualized(false);
       addComponentsBelowView(builder, session, authors, projects, projectUuids, moduleUuids, directories, fileUuids);
     } else {
       if (effectiveOnComponentOnly) {
-        builder.setContextualized(false);
         builder.componentUuids(allComponentUuids);
         return;
       }
-
-      builder.setContextualized(true);
 
       Set<String> qualifiers = componentService.getDistinctQualifiers(session, allComponentUuids);
       if (qualifiers.isEmpty()) {

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/IssueService.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/IssueService.java
@@ -64,13 +64,7 @@ import org.sonar.server.user.index.UserIndex;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.google.common.collect.Maps.newLinkedHashMap;
 
@@ -402,7 +396,6 @@ public class IssueService implements ServerComponent {
       .userGroups(UserSession.get().userGroups())
       .moduleRootUuids(Arrays.asList(componentUuid))
       .onComponentOnly(false)
-      .setContextualized(true)
       .resolved(false)
       .build();
     return issueIndex.countTags(query, pageSize);

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/index/IssueIndex.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/index/IssueIndex.java
@@ -253,42 +253,19 @@ public class IssueIndex extends BaseIndex {
     FilterBuilder directoryFilter = createTermsFilter(IssueIndexDefinition.FIELD_ISSUE_DIRECTORY_PATH, query.directories());
     FilterBuilder fileFilter = createTermsFilter(IssueIndexDefinition.FIELD_ISSUE_COMPONENT_UUID, query.fileUuids());
 
-    if (BooleanUtils.isTrue(query.isContextualized())) {
-      if (viewFilter != null) {
-        filters.put(FILTER_COMPONENT_ROOT, viewFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_PROJECT_UUID, projectFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_MODULE_UUID, moduleFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_DIRECTORY_PATH, directoryFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_COMPONENT_UUID, fileFilter);
-      } else if (projectFilter != null) {
-        filters.put(FILTER_COMPONENT_ROOT, projectFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_MODULE_UUID, moduleFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_DIRECTORY_PATH, directoryFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_COMPONENT_UUID, fileFilter);
-      } else if (moduleRootFilter != null) {
-        filters.put(FILTER_COMPONENT_ROOT, moduleRootFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_MODULE_UUID, moduleFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_DIRECTORY_PATH, directoryFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_COMPONENT_UUID, fileFilter);
-      } else if (directoryRootFilter != null) {
-        filters.put(FILTER_COMPONENT_ROOT, directoryRootFilter);
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_COMPONENT_UUID, fileFilter);
-      } else if (fileFilter != null) {
-        filters.put(FILTER_COMPONENT_ROOT, fileFilter);
-      } else if (componentFilter != null) {
-        // Last resort, when component type is unknown
-        filters.put(FILTER_COMPONENT_ROOT, componentFilter);
-      }
+    if (query.onComponentOnly()) {
+      filters.put(IssueIndexDefinition.FIELD_ISSUE_COMPONENT_UUID, componentFilter);
     } else {
-      if (query.onComponentOnly()) {
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_COMPONENT_UUID, componentFilter);
-      } else {
-        filters.put(IssueIndexDefinition.FIELD_ISSUE_COMPONENT_UUID, fileFilter);
-      }
+      filters.put("__view", viewFilter);
       filters.put(IssueIndexDefinition.FIELD_ISSUE_PROJECT_UUID, projectFilter);
+      filters.put("__module", moduleRootFilter);
       filters.put(IssueIndexDefinition.FIELD_ISSUE_MODULE_UUID, moduleFilter);
       filters.put(IssueIndexDefinition.FIELD_ISSUE_DIRECTORY_PATH, directoryFilter);
-      filters.put("view", viewFilter);
+      if (fileFilter != null) {
+        filters.put(IssueIndexDefinition.FIELD_ISSUE_COMPONENT_UUID, fileFilter);
+      } else {
+        filters.put(IssueIndexDefinition.FIELD_ISSUE_COMPONENT_UUID, componentFilter);
+      }
     }
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/index/IssueIndexMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/index/IssueIndexMediumTest.java
@@ -205,19 +205,19 @@ public class IssueIndexMediumTest {
       IssueTesting.newDoc("ISSUE5", subModule),
       IssueTesting.newDoc("ISSUE6", file3));
 
-    assertThat(index.search(IssueQuery.builder().setContextualized(true).fileUuids(newArrayList(file1.uuid(), file2.uuid(), file3.uuid())).build(), new SearchOptions())
+    assertThat(index.search(IssueQuery.builder().fileUuids(newArrayList(file1.uuid(), file2.uuid(), file3.uuid())).build(), new SearchOptions())
       .getDocs()).hasSize(3);
-    assertThat(index.search(IssueQuery.builder().setContextualized(true).fileUuids(newArrayList(file1.uuid())).build(), new SearchOptions())
+    assertThat(index.search(IssueQuery.builder().fileUuids(newArrayList(file1.uuid())).build(), new SearchOptions())
       .getDocs()).hasSize(1);
-    assertThat(index.search(IssueQuery.builder().setContextualized(true).moduleRootUuids(newArrayList(subModule.uuid())).build(), new SearchOptions())
+    assertThat(index.search(IssueQuery.builder().moduleRootUuids(newArrayList(subModule.uuid())).build(), new SearchOptions())
       .getDocs()).hasSize(2);
-    assertThat(index.search(IssueQuery.builder().setContextualized(true).moduleRootUuids(newArrayList(module.uuid())).build(), new SearchOptions())
+    assertThat(index.search(IssueQuery.builder().moduleRootUuids(newArrayList(module.uuid())).build(), new SearchOptions())
       .getDocs()).hasSize(4);
-    assertThat(index.search(IssueQuery.builder().setContextualized(true).projectUuids(newArrayList(project.uuid())).build(), new SearchOptions())
+    assertThat(index.search(IssueQuery.builder().projectUuids(newArrayList(project.uuid())).build(), new SearchOptions())
       .getDocs()).hasSize(6);
-    assertThat(index.search(IssueQuery.builder().setContextualized(true).viewUuids(newArrayList(view)).build(), new SearchOptions())
+    assertThat(index.search(IssueQuery.builder().viewUuids(newArrayList(view)).build(), new SearchOptions())
       .getDocs()).hasSize(6);
-    assertThat(index.search(IssueQuery.builder().setContextualized(true).projectUuids(newArrayList("unknown")).build(), new SearchOptions())
+    assertThat(index.search(IssueQuery.builder().projectUuids(newArrayList("unknown")).build(), new SearchOptions())
       .getDocs()).isEmpty();
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionComponentsMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionComponentsMediumTest.java
@@ -139,7 +139,7 @@ public class SearchActionComponentsMediumTest {
   }
 
   @Test
-  public void project_facet_is_sticky_when_non_contextualized() throws Exception {
+  public void project_facet_is_sticky() throws Exception {
     ComponentDto project1 = insertComponent(ComponentTesting.newProjectDto("ABCD").setKey("MyProject1"));
     ComponentDto project2 = insertComponent(ComponentTesting.newProjectDto("BCDE").setKey("MyProject2"));
     ComponentDto project3 = insertComponent(ComponentTesting.newProjectDto("CDEF").setKey("MyProject3"));
@@ -162,12 +162,6 @@ public class SearchActionComponentsMediumTest {
       .setParam(WebService.Param.FACETS, "projectUuids")
       .execute()
       .assertJson(this.getClass(), "display_sticky_project_facet.json", false);
-
-    wsTester.newGetRequest(IssuesWs.API_ENDPOINT, SearchAction.SEARCH_ACTION)
-      .setParam(IssueFilterParameters.COMPONENT_UUIDS, project1.uuid())
-      .setParam(WebService.Param.FACETS, "projectUuids")
-      .execute()
-      .assertJson(this.getClass(), "display_non_sticky_project_facet.json", false);
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionComponentsMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionComponentsMediumTest.java
@@ -342,7 +342,7 @@ public class SearchActionComponentsMediumTest {
     tester.get(IssueIndexer.class).indexAll();
 
     wsTester.newGetRequest(IssuesWs.API_ENDPOINT, SearchAction.SEARCH_ACTION)
-      .setParam(IssueFilterParameters.COMPONENT_UUIDS, project.uuid())
+      .setParam(IssueFilterParameters.COMPONENT_UUIDS, module.uuid())
       .setParam(IssueFilterParameters.MODULE_UUIDS, subModule1.uuid() + "," + subModule3.uuid())
       .setParam(WebService.Param.FACETS, "moduleUuids")
       .execute()


### PR DESCRIPTION
- First commit gets rid of the "contextualized" parameter, which was used to manage stickyness of facets depending on "context", but which introduced too much complexity for something which can be managed on UI side
- Second commit moves some code to make IssueQueryService a bit more testable and readable