### PR TITLE
Enable parallel execution of web tests

### DIFF
--- a/server/sonar-web/Gruntfile.coffee
+++ b/server/sonar-web/Gruntfile.coffee
@@ -331,6 +331,7 @@ module.exports = (grunt) ->
           'no-colors': true
           'fail-fast': true
           concise: true
+          parallel: true
           port: expressPort
         src: ['<%= pkg.sources %>js/tests/e2e/tests/**/*.js']
       single:

--- a/server/sonar-web/src/main/js/tests/e2e/lib.js
+++ b/server/sonar-web/src/main/js/tests/e2e/lib.js
@@ -12,6 +12,7 @@ var BASE_URL = 'http://localhost:' + getPort() + '/pages/',
 
 
 exports.initMessages = function () {
+  casper.options.waitTimeout = 10000;
   if (casper.cli.options.verbose) {
     // Dump log messages
     casper.removeAllListeners('remote.message');


### PR DESCRIPTION
On my machine this change decreases time of execution of web tests on **68%**, which is **43%** for build of web module and **8%** overall as shown below.

```
$ uname -p -m -o
x86_64 Intel(R) Core(TM) i7-3632QM CPU @ 2.20GHz GNU/Linux
```

Before:
```
$ time mvn clean install -pl server/sonar-web
[INFO] Casper Task 'casper:test' took ~67805ms to run
real    1m46.001s
user    1m7.538s
sys     0m2.216s

$ time mvn clean install
real    8m23.034s
user    9m17.843s
sys     0m20.167s
```
After:
```
$ time mvn clean install -pl server/sonar-web
[INFO] Casper Task 'casper:test' took ~21746ms to run
real    1m0.827s
user    1m15.891s
sys     0m3.304s

$ time mvn clean install
real    7m40.100s
user    9m52.647s
sys     0m22.536s
```

I'm not a JavaScript expert, but seems that there is no problem of isolation of tests. At least I did not observed spontaneous failures among 20 sequential runs.

Default value of "concurrency" level (5) seems good enough - on my machine higher values do not provide further decrease of time.