### PR TITLE
SONAR-5885 Fix mapping of htmlDesc attribute to fetch correct fields in ES

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/rule/ws/RuleMapping.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/rule/ws/RuleMapping.java
@@ -78,7 +78,7 @@ public class RuleMapping extends BaseMapping<RuleDoc, RuleMappingContext> {
   }
 
   private void mapDescriptionFields(final MacroInterpreter macroInterpreter) {
-    map("htmlDesc", new Mapper<RuleDoc, RuleMappingContext>() {
+    map("htmlDesc", new IndexMapper<RuleDoc, RuleMappingContext>(RuleNormalizer.RuleField.MARKDOWN_DESCRIPTION.field(), RuleNormalizer.RuleField.HTML_DESCRIPTION.field()) {
       @Override
       public void write(JsonWriter json, RuleDoc rule, RuleMappingContext context) {
         if (rule.markdownDescription() != null) {

--- a/server/sonar-server/src/test/java/org/sonar/server/rule/ws/RulesWebServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/rule/ws/RulesWebServiceMediumTest.java
@@ -19,6 +19,8 @@
  */
 package org.sonar.server.rule.ws;
 
+import org.sonar.core.rule.RuleDto.Format;
+
 import com.google.common.collect.ImmutableSet;
 import org.junit.After;
 import org.junit.Before;
@@ -176,6 +178,19 @@ public class RulesWebServiceMediumTest {
     WsTester.Result result = request.execute();
 
     result.assertJson(getClass(), "search_2_rules.json", false);
+  }
+
+  @Test
+  public void search_2_rules_with_field_selection() throws Exception {
+    ruleDao.insert(session, RuleTesting.newXooX1());
+    ruleDao.insert(session, RuleTesting.newXooX2().setDescription("A *Xoo* rule").setDescriptionFormat(Format.MARKDOWN));
+    session.commit();
+
+    MockUserSession.set();
+    WsTester.TestRequest request = tester.wsTester().newGetRequest(API_ENDPOINT, API_SEARCH_METHOD).setParam(SearchOptions.PARAM_FIELDS, "name,htmlDesc,mdDesc");
+    WsTester.Result result = request.execute();
+
+    result.assertJson(getClass(), "search_2_rules_fields.json", false);
   }
 
   @Test

--- a/server/sonar-server/src/test/resources/org/sonar/server/rule/ws/RulesWebServiceMediumTest/search_2_rules_fields.json
+++ b/server/sonar-server/src/test/resources/org/sonar/server/rule/ws/RulesWebServiceMediumTest/search_2_rules_fields.json
@@ -1,0 +1,15 @@
+{
+  "total": 2, "p": 1, "ps": 100,
+  "rules": [
+    {
+      "key": "xoo:x2",
+      "name": "Rule x2",
+      "mdDesc": "A *Xoo* rule",
+      "htmlDesc": "A <em>Xoo</em> rule"
+    },
+    {
+      "key": "xoo:x1",
+      "name": "Rule x1",
+      "htmlDesc": "Description x1",
+    }
+  ]}


### PR DESCRIPTION
The issue here was that a simple ``Mapper`` does not declare which document fields the WS field maps to, whereas an ``IndexMapper`` allows this. 