### PR TITLE
speed up uglify js step

### DIFF
--- a/server/sonar-web/Gruntfile.coffee
+++ b/server/sonar-web/Gruntfile.coffee
@@ -1,5 +1,7 @@
 module.exports = (grunt) ->
-  require('jit-grunt')(grunt);
+  require('jit-grunt')(grunt, {
+    express: 'grunt-express-server'
+  });
 
   pkg = grunt.file.readJSON('package.json')
   expressPort = '<%= grunt.option("port") || 3000 %>'

--- a/server/sonar-web/Gruntfile.coffee
+++ b/server/sonar-web/Gruntfile.coffee
@@ -1,4 +1,6 @@
 module.exports = (grunt) ->
+  require('jit-grunt')(grunt);
+
   pkg = grunt.file.readJSON('package.json')
   expressPort = '<%= grunt.option("port") || 3000 %>'
 
@@ -348,7 +350,7 @@ module.exports = (grunt) ->
         src: ['<%= grunt.option("file") %>']
 
 
-    uglify:
+    uglify_parallel:
       build:
         files: [
           expand: true
@@ -394,29 +396,13 @@ module.exports = (grunt) ->
 
 
 
-  # Load grunt-contrib-* plugins
-  grunt.loadNpmTasks 'grunt-contrib-less'
-  grunt.loadNpmTasks 'grunt-css-url-rewrite'
-  grunt.loadNpmTasks 'grunt-contrib-coffee'
-  grunt.loadNpmTasks 'grunt-contrib-uglify'
-  grunt.loadNpmTasks 'grunt-contrib-requirejs'
-  grunt.loadNpmTasks 'grunt-contrib-handlebars'
-  grunt.loadNpmTasks 'grunt-contrib-watch'
-  grunt.loadNpmTasks 'grunt-contrib-clean'
-  grunt.loadNpmTasks 'grunt-contrib-copy'
-  grunt.loadNpmTasks 'grunt-contrib-concat'
-  grunt.loadNpmTasks 'grunt-contrib-jshint'
-  grunt.loadNpmTasks 'grunt-express-server'
-  grunt.loadNpmTasks 'grunt-casper'
-
-
   # Define tasks
   grunt.registerTask 'dev',
       ['clean:css', 'clean:js', 'less:dev', 'coffee:build', 'handlebars:build', 'copy:js', 'concat:dev']
 
   grunt.registerTask 'build',
       ['clean:css', 'clean:js', 'less:build', 'cssUrlRewrite:build', 'coffee:build', 'handlebars:build', 'copy:js',
-       'concat:build', 'requirejs', 'clean:js', 'copy:build', 'copy:requirejs', 'uglify:build', 'clean:build']
+       'concat:build', 'requirejs', 'clean:js', 'copy:build', 'copy:requirejs', 'uglify_parallel:build', 'clean:build']
 
   grunt.registerTask 'default',
       ['build']

--- a/server/sonar-web/package.json
+++ b/server/sonar-web/package.json
@@ -20,7 +20,9 @@
     "grunt-contrib-watch": "0.5.3",
     "grunt-css-url-rewrite": "0.3.5",
     "grunt-express-server": "0.4.17",
+    "grunt-uglify-parallel": "0.0.1",
     "jade": "1.4.2",
+    "jit-grunt": "0.9.1",
     "phantomjs": "1.9.7-12",
     "serve-static": "1.5.0"
   },


### PR DESCRIPTION
The longest step in `grunt build` is `uglify`. I replaced it by `uglify_parallel` that runs tasks in parallel.
Also I enabled `jit-grunt` that enables lazy loading of grunt plugins.

On my machine I get 100% boost (7s vs 14s).