### PR TITLE
Added sonar property `sonar.search.host`

### DIFF
--- a/server/sonar-process/src/main/java/org/sonar/process/ProcessConstants.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/ProcessConstants.java
@@ -48,12 +48,12 @@ public interface ProcessConstants {
   String PATH_TEMP = "sonar.path.temp";
   String PATH_WEB = "sonar.path.web";
 
+  String SEARCH_HOST = "sonar.search.host";
   String SEARCH_PORT = "sonar.search.port";
   String SEARCH_JAVA_OPTS = "sonar.search.javaOpts";
   String SEARCH_JAVA_ADDITIONAL_OPTS = "sonar.search.javaAdditionalOpts";
   String SEARCH_TYPE = "sonar.search.type";
 
-  String WEB_HOST = "sonar.web.host"; 
   String WEB_JAVA_OPTS = "sonar.web.javaOpts";
   String WEB_JAVA_ADDITIONAL_OPTS = "sonar.web.javaAdditionalOpts";
 

--- a/server/sonar-process/src/main/java/org/sonar/process/ProcessConstants.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/ProcessConstants.java
@@ -48,6 +48,7 @@ public interface ProcessConstants {
   String PATH_TEMP = "sonar.path.temp";
   String PATH_WEB = "sonar.path.web";
 
+  String SEARCH_HOST = "sonar.search.host";
   String SEARCH_PORT = "sonar.search.port";
   String SEARCH_JAVA_OPTS = "sonar.search.javaOpts";
   String SEARCH_JAVA_ADDITIONAL_OPTS = "sonar.search.javaAdditionalOpts";

--- a/server/sonar-process/src/main/java/org/sonar/process/ProcessConstants.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/ProcessConstants.java
@@ -48,12 +48,12 @@ public interface ProcessConstants {
   String PATH_TEMP = "sonar.path.temp";
   String PATH_WEB = "sonar.path.web";
 
-  String SEARCH_HOST = "sonar.search.host";
   String SEARCH_PORT = "sonar.search.port";
   String SEARCH_JAVA_OPTS = "sonar.search.javaOpts";
   String SEARCH_JAVA_ADDITIONAL_OPTS = "sonar.search.javaAdditionalOpts";
   String SEARCH_TYPE = "sonar.search.type";
 
+  String WEB_HOST = "sonar.web.host"; 
   String WEB_JAVA_OPTS = "sonar.web.javaOpts";
   String WEB_JAVA_ADDITIONAL_OPTS = "sonar.web.javaAdditionalOpts";
 

--- a/server/sonar-search/src/main/java/org/sonar/search/SearchSettings.java
+++ b/server/sonar-search/src/main/java/org/sonar/search/SearchSettings.java
@@ -53,7 +53,7 @@ class SearchSettings {
     this.props = props;
     masterHosts.addAll(Arrays.asList(StringUtils.split(props.value(ProcessConstants.CLUSTER_MASTER_HOST, ""), ",")));
     clusterName = props.value(ProcessConstants.CLUSTER_NAME);
-    hostName = props.value(ProcessConstants.SEARCH_HOST);
+    hostName = props.value(ProcessConstants.WEB_HOST);
     Integer port = props.valueAsInt(ProcessConstants.SEARCH_PORT);
     if (port == null) {
       throw new MessageException("Property is not set: " + ProcessConstants.SEARCH_PORT);

--- a/server/sonar-search/src/main/java/org/sonar/search/SearchSettings.java
+++ b/server/sonar-search/src/main/java/org/sonar/search/SearchSettings.java
@@ -46,12 +46,14 @@ class SearchSettings {
   private final Props props;
   private final Set<String> masterHosts = new LinkedHashSet<String>();
   private final String clusterName;
+  private final String hostName;
   private final int tcpPort;
 
   SearchSettings(Props props) {
     this.props = props;
     masterHosts.addAll(Arrays.asList(StringUtils.split(props.value(ProcessConstants.CLUSTER_MASTER_HOST, ""), ",")));
     clusterName = props.value(ProcessConstants.CLUSTER_NAME);
+    hostName = props.value(ProcessConstants.SEARCH_HOST);
     Integer port = props.valueAsInt(ProcessConstants.SEARCH_PORT);
     if (port == null) {
       throw new MessageException("Property is not set: " + ProcessConstants.SEARCH_PORT);
@@ -73,6 +75,10 @@ class SearchSettings {
 
   int tcpPort() {
     return tcpPort;
+  }
+  
+  String hostName() {
+    return hostName;
   }
 
   Settings build() {
@@ -130,6 +136,9 @@ class SearchSettings {
     // disable multicast
     builder.put("discovery.zen.ping.multicast.enabled", "false");
     builder.put("transport.tcp.port", tcpPort);
+    if (hostName != null) {
+      builder.put("transport.host", hostName);
+    }
     // Elasticsearch sets the default value of TCP reuse address to true only on non-MSWindows machines, but why ?
     builder.put("network.tcp.reuse_address", true);
 
@@ -143,7 +152,11 @@ class SearchSettings {
       // see https://github.com/lmenezes/elasticsearch-kopf/issues/195
       builder.put("http.cors.enabled", true);
       builder.put("http.enabled", true);
-      builder.put("http.host", "127.0.0.1");
+      if (hostName != null) {
+        builder.put("http.host", hostName);
+      } else {
+        builder.put("http.host", "127.0.0.1");
+      }
       builder.put("http.port", httpPort);
     }
   }

--- a/server/sonar-search/src/main/java/org/sonar/search/SearchSettings.java
+++ b/server/sonar-search/src/main/java/org/sonar/search/SearchSettings.java
@@ -53,7 +53,7 @@ class SearchSettings {
     this.props = props;
     masterHosts.addAll(Arrays.asList(StringUtils.split(props.value(ProcessConstants.CLUSTER_MASTER_HOST, ""), ",")));
     clusterName = props.value(ProcessConstants.CLUSTER_NAME);
-    hostName = props.value(ProcessConstants.WEB_HOST);
+    hostName = props.value(ProcessConstants.SEARCH_HOST);
     Integer port = props.valueAsInt(ProcessConstants.SEARCH_PORT);
     if (port == null) {
       throw new MessageException("Property is not set: " + ProcessConstants.SEARCH_PORT);

--- a/server/sonar-search/src/test/java/org/sonar/search/SearchSettingsTest.java
+++ b/server/sonar-search/src/test/java/org/sonar/search/SearchSettingsTest.java
@@ -54,7 +54,7 @@ public class SearchSettingsTest {
     File homeDir = temp.newFolder();
     Props props = new Props(new Properties());
     props.set(ProcessConstants.SEARCH_PORT, "1234");
-    props.set(ProcessConstants.SEARCH_HOST, "127.0.0.1");
+    props.set(ProcessConstants.WEB_HOST, "127.0.0.1");
     props.set(ProcessConstants.PATH_HOME, homeDir.getAbsolutePath());
     props.set(ProcessConstants.CLUSTER_NAME, "tests");
     props.set(ProcessConstants.CLUSTER_NODE_NAME, "test");
@@ -173,7 +173,7 @@ public class SearchSettingsTest {
   public void enable_http_connector_different_host() throws Exception {
     Props props = minProps();
     props.set(SearchSettings.PROP_HTTP_PORT, "9010");
-    props.set(ProcessConstants.SEARCH_HOST, "127.0.0.2");
+    props.set(ProcessConstants.WEB_HOST, "127.0.0.2");
     Settings settings = new SearchSettings(props).build();
 
     assertThat(settings.get("http.port")).isEqualTo("9010");

--- a/server/sonar-search/src/test/java/org/sonar/search/SearchSettingsTest.java
+++ b/server/sonar-search/src/test/java/org/sonar/search/SearchSettingsTest.java
@@ -54,7 +54,7 @@ public class SearchSettingsTest {
     File homeDir = temp.newFolder();
     Props props = new Props(new Properties());
     props.set(ProcessConstants.SEARCH_PORT, "1234");
-    props.set(ProcessConstants.WEB_HOST, "127.0.0.1");
+    props.set(ProcessConstants.SEARCH_HOST, "127.0.0.1");
     props.set(ProcessConstants.PATH_HOME, homeDir.getAbsolutePath());
     props.set(ProcessConstants.CLUSTER_NAME, "tests");
     props.set(ProcessConstants.CLUSTER_NODE_NAME, "test");
@@ -173,7 +173,7 @@ public class SearchSettingsTest {
   public void enable_http_connector_different_host() throws Exception {
     Props props = minProps();
     props.set(SearchSettings.PROP_HTTP_PORT, "9010");
-    props.set(ProcessConstants.WEB_HOST, "127.0.0.2");
+    props.set(ProcessConstants.SEARCH_HOST, "127.0.0.2");
     Settings settings = new SearchSettings(props).build();
 
     assertThat(settings.get("http.port")).isEqualTo("9010");

--- a/server/sonar-server/src/main/java/org/sonar/server/search/SearchClient.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/search/SearchClient.java
@@ -75,12 +75,12 @@ public class SearchClient extends TransportClient implements Startable {
   public SearchClient(Settings settings) {
     super(ImmutableSettings.settingsBuilder()
       .put("node.name", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.CLUSTER_NODE_NAME), "sq_local_client"))
-      .put("network.bind_host", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.WEB_HOST), "localhost"))
+      .put("network.bind_host", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.SEARCH_HOST), "localhost"))
       .put("node.rack_id", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.CLUSTER_NODE_NAME), "unknown"))
       .put("cluster.name", StringUtils.defaultIfBlank(settings.getString(ProcessConstants.CLUSTER_NAME), "sonarqube"))
       .build());
     initLogging();
-    this.addTransportAddress(new InetSocketTransportAddress(StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.WEB_HOST), LoopbackAddress.get().getHostAddress()),
+    this.addTransportAddress(new InetSocketTransportAddress(StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.SEARCH_HOST), LoopbackAddress.get().getHostAddress()),
       settings.getInt(ProcessConstants.SEARCH_PORT)));
   }
 

--- a/server/sonar-server/src/main/java/org/sonar/server/search/SearchClient.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/search/SearchClient.java
@@ -75,12 +75,12 @@ public class SearchClient extends TransportClient implements Startable {
   public SearchClient(Settings settings) {
     super(ImmutableSettings.settingsBuilder()
       .put("node.name", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.CLUSTER_NODE_NAME), "sq_local_client"))
-      .put("network.bind_host", "localhost")
+      .put("network.bind_host", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.SEARCH_HOST), "localhost"))
       .put("node.rack_id", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.CLUSTER_NODE_NAME), "unknown"))
       .put("cluster.name", StringUtils.defaultIfBlank(settings.getString(ProcessConstants.CLUSTER_NAME), "sonarqube"))
       .build());
     initLogging();
-    this.addTransportAddress(new InetSocketTransportAddress(LoopbackAddress.get().getHostAddress(),
+    this.addTransportAddress(new InetSocketTransportAddress(StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.SEARCH_HOST), LoopbackAddress.get().getHostAddress()),
       settings.getInt(ProcessConstants.SEARCH_PORT)));
   }
 

--- a/server/sonar-server/src/main/java/org/sonar/server/search/SearchClient.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/search/SearchClient.java
@@ -75,12 +75,12 @@ public class SearchClient extends TransportClient implements Startable {
   public SearchClient(Settings settings) {
     super(ImmutableSettings.settingsBuilder()
       .put("node.name", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.CLUSTER_NODE_NAME), "sq_local_client"))
-      .put("network.bind_host", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.SEARCH_HOST), "localhost"))
+      .put("network.bind_host", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.WEB_HOST), "localhost"))
       .put("node.rack_id", StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.CLUSTER_NODE_NAME), "unknown"))
       .put("cluster.name", StringUtils.defaultIfBlank(settings.getString(ProcessConstants.CLUSTER_NAME), "sonarqube"))
       .build());
     initLogging();
-    this.addTransportAddress(new InetSocketTransportAddress(StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.SEARCH_HOST), LoopbackAddress.get().getHostAddress()),
+    this.addTransportAddress(new InetSocketTransportAddress(StringUtils.defaultIfEmpty(settings.getString(ProcessConstants.WEB_HOST), LoopbackAddress.get().getHostAddress()),
       settings.getInt(ProcessConstants.SEARCH_PORT)));
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/es/EsServerHolder.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/es/EsServerHolder.java
@@ -111,7 +111,7 @@ public class EsServerHolder {
       properties.setProperty(ProcessConstants.CLUSTER_NAME, clusterName);
       properties.setProperty(ProcessConstants.CLUSTER_NODE_NAME, nodeName);
       properties.setProperty(ProcessConstants.SEARCH_PORT, String.valueOf(port));
-      properties.setProperty(ProcessConstants.SEARCH_HOST, hostName);
+      properties.setProperty(ProcessConstants.WEB_HOST, hostName);
       properties.setProperty(ProcessConstants.PATH_HOME, homeDir.getAbsolutePath());
       SearchServer server = new SearchServer(new Props(properties));
       server.start();

--- a/server/sonar-server/src/test/java/org/sonar/server/es/EsServerHolder.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/es/EsServerHolder.java
@@ -111,7 +111,7 @@ public class EsServerHolder {
       properties.setProperty(ProcessConstants.CLUSTER_NAME, clusterName);
       properties.setProperty(ProcessConstants.CLUSTER_NODE_NAME, nodeName);
       properties.setProperty(ProcessConstants.SEARCH_PORT, String.valueOf(port));
-      properties.setProperty(ProcessConstants.WEB_HOST, hostName);
+      properties.setProperty(ProcessConstants.SEARCH_HOST, hostName);
       properties.setProperty(ProcessConstants.PATH_HOME, homeDir.getAbsolutePath());
       SearchServer server = new SearchServer(new Props(properties));
       server.start();

--- a/server/sonar-server/src/test/java/org/sonar/server/es/EsServerHolder.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/es/EsServerHolder.java
@@ -38,14 +38,16 @@ public class EsServerHolder {
   private static EsServerHolder HOLDER = null;
   private final String clusterName, nodeName;
   private final int port;
+  private final String hostName;
   private final File homeDir;
   private final SearchServer server;
 
-  private EsServerHolder(SearchServer server, String clusterName, String nodeName, int port, File homeDir) {
+  private EsServerHolder(SearchServer server, String clusterName, String nodeName, int port, String hostName, File homeDir) {
     this.server = server;
     this.clusterName = clusterName;
     this.nodeName = nodeName;
     this.port = port;
+    this.hostName = hostName;
     this.homeDir = homeDir;
   }
 
@@ -59,6 +61,10 @@ public class EsServerHolder {
 
   public int getPort() {
     return port;
+  }
+  
+  public String getHostName() {
+  return hostName;
   }
 
   public SearchServer getServer() {
@@ -98,16 +104,18 @@ public class EsServerHolder {
 
       String clusterName = "testCluster";
       String nodeName = "test";
+      String hostName = "127.0.0.1";
       int port = NetworkUtils.freePort();
 
       Properties properties = new Properties();
       properties.setProperty(ProcessConstants.CLUSTER_NAME, clusterName);
       properties.setProperty(ProcessConstants.CLUSTER_NODE_NAME, nodeName);
       properties.setProperty(ProcessConstants.SEARCH_PORT, String.valueOf(port));
+      properties.setProperty(ProcessConstants.SEARCH_HOST, hostName);
       properties.setProperty(ProcessConstants.PATH_HOME, homeDir.getAbsolutePath());
       SearchServer server = new SearchServer(new Props(properties));
       server.start();
-      HOLDER = new EsServerHolder(server, clusterName, nodeName, port, homeDir);
+      HOLDER = new EsServerHolder(server, clusterName, nodeName, port, hostName, homeDir);
     }
     HOLDER.reset();
     return HOLDER;

--- a/server/sonar-server/src/test/java/org/sonar/server/search/BaseIndexTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/search/BaseIndexTest.java
@@ -52,7 +52,7 @@ public class BaseIndexTest {
     settings.setProperty(ProcessConstants.CLUSTER_NAME, holder.getClusterName());
     settings.setProperty(ProcessConstants.CLUSTER_NODE_NAME, holder.getNodeName());
     settings.setProperty(ProcessConstants.SEARCH_PORT, String.valueOf(holder.getPort()));
-    settings.setProperty(ProcessConstants.WEB_HOST, String.valueOf(holder.getHostName()));
+    settings.setProperty(ProcessConstants.SEARCH_HOST, String.valueOf(holder.getHostName()));
     searchClient = new SearchClient(settings);
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/search/BaseIndexTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/search/BaseIndexTest.java
@@ -52,7 +52,7 @@ public class BaseIndexTest {
     settings.setProperty(ProcessConstants.CLUSTER_NAME, holder.getClusterName());
     settings.setProperty(ProcessConstants.CLUSTER_NODE_NAME, holder.getNodeName());
     settings.setProperty(ProcessConstants.SEARCH_PORT, String.valueOf(holder.getPort()));
-    settings.setProperty(ProcessConstants.SEARCH_HOST, String.valueOf(holder.getHostName()));
+    settings.setProperty(ProcessConstants.WEB_HOST, String.valueOf(holder.getHostName()));
     searchClient = new SearchClient(settings);
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/search/BaseIndexTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/search/BaseIndexTest.java
@@ -52,6 +52,7 @@ public class BaseIndexTest {
     settings.setProperty(ProcessConstants.CLUSTER_NAME, holder.getClusterName());
     settings.setProperty(ProcessConstants.CLUSTER_NODE_NAME, holder.getNodeName());
     settings.setProperty(ProcessConstants.SEARCH_PORT, String.valueOf(holder.getPort()));
+    settings.setProperty(ProcessConstants.SEARCH_HOST, String.valueOf(holder.getHostName()));
     searchClient = new SearchClient(settings);
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/tester/ServerTester.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/tester/ServerTester.java
@@ -84,7 +84,7 @@ public class ServerTester extends ExternalResource {
       properties.setProperty(ProcessConstants.CLUSTER_NAME, esServerHolder.getClusterName());
       properties.setProperty(ProcessConstants.CLUSTER_NODE_NAME, esServerHolder.getNodeName());
       properties.setProperty(ProcessConstants.SEARCH_PORT, String.valueOf(esServerHolder.getPort()));
-      properties.setProperty(ProcessConstants.SEARCH_HOST, String.valueOf(esServerHolder.getHostName()));
+      properties.setProperty(ProcessConstants.WEB_HOST, String.valueOf(esServerHolder.getHostName()));
       properties.setProperty(ProcessConstants.PATH_HOME, homeDir.getAbsolutePath());
       properties.setProperty(DatabaseProperties.PROP_URL, "jdbc:h2:" + homeDir.getAbsolutePath() + "/h2");
       for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {

--- a/server/sonar-server/src/test/java/org/sonar/server/tester/ServerTester.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/tester/ServerTester.java
@@ -84,7 +84,7 @@ public class ServerTester extends ExternalResource {
       properties.setProperty(ProcessConstants.CLUSTER_NAME, esServerHolder.getClusterName());
       properties.setProperty(ProcessConstants.CLUSTER_NODE_NAME, esServerHolder.getNodeName());
       properties.setProperty(ProcessConstants.SEARCH_PORT, String.valueOf(esServerHolder.getPort()));
-      properties.setProperty(ProcessConstants.WEB_HOST, String.valueOf(esServerHolder.getHostName()));
+      properties.setProperty(ProcessConstants.SEARCH_HOST, String.valueOf(esServerHolder.getHostName()));
       properties.setProperty(ProcessConstants.PATH_HOME, homeDir.getAbsolutePath());
       properties.setProperty(DatabaseProperties.PROP_URL, "jdbc:h2:" + homeDir.getAbsolutePath() + "/h2");
       for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {

--- a/server/sonar-server/src/test/java/org/sonar/server/tester/ServerTester.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/tester/ServerTester.java
@@ -84,6 +84,7 @@ public class ServerTester extends ExternalResource {
       properties.setProperty(ProcessConstants.CLUSTER_NAME, esServerHolder.getClusterName());
       properties.setProperty(ProcessConstants.CLUSTER_NODE_NAME, esServerHolder.getNodeName());
       properties.setProperty(ProcessConstants.SEARCH_PORT, String.valueOf(esServerHolder.getPort()));
+      properties.setProperty(ProcessConstants.SEARCH_HOST, String.valueOf(esServerHolder.getHostName()));
       properties.setProperty(ProcessConstants.PATH_HOME, homeDir.getAbsolutePath());
       properties.setProperty(DatabaseProperties.PROP_URL, "jdbc:h2:" + homeDir.getAbsolutePath() + "/h2");
       for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -216,10 +216,8 @@
 
 # Elasticsearch port. Default is 9001. Use 0 to get a free port.
 # This port must be private and must not be exposed to the Internet.
+# Binding IP address is the one set up in sonar.web.host property.
 #sonar.search.port=9001
-# Elasticsearch host. The search server will bind this address and the search client will connect to it. Default ist 127.0.0.1.
-#sonar.search.host=127.0.0.1
-
 
 #--------------------------------------------------------------------------------------------------
 # UPDATE CENTER

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -217,6 +217,8 @@
 # Elasticsearch port. Default is 9001. Use 0 to get a free port.
 # This port must be private and must not be exposed to the Internet.
 #sonar.search.port=9001
+# Elasticsearch host. The search server will bind this address and the search client will connect to it. Default ist 127.0.0.1.
+#sonar.search.host=127.0.0.1
 
 
 #--------------------------------------------------------------------------------------------------

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -216,8 +216,10 @@
 
 # Elasticsearch port. Default is 9001. Use 0 to get a free port.
 # This port must be private and must not be exposed to the Internet.
-# Binding IP address is the one set up in sonar.web.host property.
 #sonar.search.port=9001
+# Elasticsearch host. The search server will bind this address and the search client will connect to it. Default ist 127.0.0.1.
+#sonar.search.host=127.0.0.1
+
 
 #--------------------------------------------------------------------------------------------------
 # UPDATE CENTER


### PR DESCRIPTION
In certain environments (e.g. OpenShift) you cannot bind to 127.0.0.1 or you can only bind to certain port ranges.
That's why we have the `sonar.web.host`, `sonar.web.port`, `sonar.search.httpPort` and `sonar.search.port` properties.
What's missing is a `sonar.search.host`. I don't see any other way to run the recent versions of SonarQube on such environments.

See also my question on [stackoverflow](http://stackoverflow.com/questions/28594063/sonarqube-change-the-elastic-search-client-host).