### PR TITLE
Add the ability to search for rules by profiles in RubyRuleService - Needed to fix SQALE-269

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/rule/RubyRuleService.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/rule/RubyRuleService.java
@@ -83,6 +83,11 @@ public class RubyRuleService implements ServerComponent, Startable {
     query.setDebtCharacteristics(RubyUtils.toStrings(params.get("debtCharacteristics")));
     query.setHasDebtCharacteristic(RubyUtils.toBoolean(params.get("hasDebtCharacteristic")));
     query.setSortField(RuleNormalizer.RuleField.NAME);
+    String profile = Strings.emptyToNull((String) params.get("profile"));
+    if (profile != null) {
+      query.setQProfileKey(profile);
+      query.setActivation(true);
+    }
 
     QueryContext options = new QueryContext();
     Integer pageSize = RubyUtils.toInteger(params.get("pageSize"));

--- a/server/sonar-server/src/test/java/org/sonar/server/rule/RubyRuleServiceTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/rule/RubyRuleServiceTest.java
@@ -103,9 +103,25 @@ public class RubyRuleServiceTest {
     assertThat(ruleQueryCaptor.getValue().getTags()).containsOnly("tag1", "tag2");
     assertThat(ruleQueryCaptor.getValue().getDebtCharacteristics()).containsOnly("char1", "char2");
     assertThat(ruleQueryCaptor.getValue().getHasDebtCharacteristic()).isTrue();
+    assertThat(ruleQueryCaptor.getValue().getQProfileKey()).isNull();
+    assertThat(ruleQueryCaptor.getValue().getActivation()).isNull();
 
     assertThat(optionsCaptor.getValue().getLimit()).isEqualTo(40);
     assertThat(optionsCaptor.getValue().getOffset()).isEqualTo(0);
+  }
+
+  @Test
+  public void search_rules_activated_on_a_profile() throws Exception {
+    when(ruleService.search(any(RuleQuery.class), any(QueryContext.class))).thenReturn(mock(Result.class));
+
+    HashMap<String, Object> params = newHashMap();
+    params.put("profile", "xoo-profile");
+    service.find(params);
+
+    verify(ruleService).search(ruleQueryCaptor.capture(), optionsCaptor.capture());
+
+    assertThat(ruleQueryCaptor.getValue().getQProfileKey()).isEqualTo("xoo-profile");
+    assertThat(ruleQueryCaptor.getValue().getActivation()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Add search the ability to search for rules by profiles in RubyRuleService
Needed to fix SQALE-269