### PR TITLE
SONAR-6238 Updating only the name of a rule is not taking in account when synchronizing rules at startup

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/rule/RegisterRules.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/rule/RegisterRules.java
@@ -51,12 +51,8 @@ import org.sonar.server.startup.RegisterDebtModel;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
 
 import static com.google.common.collect.Lists.newArrayList;
 
@@ -228,7 +224,9 @@ public class RegisterRules implements Startable {
       dto.setName(def.name());
       changed = true;
     }
-    changed = mergeDescription(def, dto);
+    if (mergeDescription(def, dto)) {
+      changed= true;
+    }
     if (!dto.getSystemTags().containsAll(def.tags())) {
       dto.setSystemTags(def.tags());
       changed = true;

--- a/server/sonar-server/src/test/java/org/sonar/server/rule/RegisterRulesMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/rule/RegisterRulesMediumTest.java
@@ -253,6 +253,56 @@ public class RegisterRulesMediumTest {
   }
 
   @Test
+  public void update_only_rule_name() {
+    register(new Rules() {
+      @Override
+      public void init(RulesDefinition.NewRepository repository) {
+        repository.createRule("x1")
+          .setName("Name1")
+          .setHtmlDescription("Desc1");
+      }
+    });
+
+    register(new Rules() {
+      @Override
+      public void init(RulesDefinition.NewRepository repository) {
+        repository.createRule(RuleTesting.XOO_X1.rule())
+          .setName("Name2")
+          .setHtmlDescription("Desc1");
+      }
+    });
+
+    Rule rule = ruleIndex.getByKey(RuleTesting.XOO_X1);
+    assertThat(rule.name()).isEqualTo("Name2");
+    assertThat(rule.htmlDescription()).isEqualTo("Desc1");
+  }
+
+  @Test
+  public void update_only_rule_description() {
+    register(new Rules() {
+      @Override
+      public void init(RulesDefinition.NewRepository repository) {
+        repository.createRule("x1")
+          .setName("Name1")
+          .setHtmlDescription("Desc1");
+      }
+    });
+
+    register(new Rules() {
+      @Override
+      public void init(RulesDefinition.NewRepository repository) {
+        repository.createRule(RuleTesting.XOO_X1.rule())
+          .setName("Name1")
+          .setHtmlDescription("Desc2");
+      }
+    });
+
+    Rule rule = ruleIndex.getByKey(RuleTesting.XOO_X1);
+    assertThat(rule.name()).isEqualTo("Name1");
+    assertThat(rule.htmlDescription()).isEqualTo("Desc2");
+  }
+
+  @Test
   public void do_not_update_rules_if_no_changes() throws Exception {
     Rules rules = new Rules() {
       @Override

--- a/server/sonar-server/src/test/java/org/sonar/server/rule/RegisterRulesTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/rule/RegisterRulesTest.java
@@ -218,6 +218,8 @@ public class RegisterRulesTest extends AbstractDaoTestCase {
 
     RegisterRules task = new RegisterRules(loader, ruleActivator, dbClient, languages);
     task.start();
+    // Execute a commit to refresh session state as the task is using its own session
+    dbSession.commit();
   }
 
   private RuleParamDto getParam(List<RuleParamDto> params, String key) {


### PR DESCRIPTION
SONAR-6238 Updating only the name of a rule is not taking in account when synchronizing rules at startup