### PR TITLE
Fix example response of /api/authentication/validate

### DIFF
--- a/server/sonar-server/src/main/resources/org/sonar/server/authentication/ws/example-validate.json
+++ b/server/sonar-server/src/main/resources/org/sonar/server/authentication/ws/example-validate.json
@@ -1,1 +1,1 @@
-{"validate": true}
+{"valid": true}


### PR DESCRIPTION
The boolean field is not "validate" but "valid" (tested with v 5.0.1)