### PR TITLE
fix minor typo in comment in sonar.properties

### DIFF
--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -220,7 +220,7 @@
 # Elasticsearch port. Default is 9001. Use 0 to get a free port.
 # This port must be private and must not be exposed to the Internet.
 #sonar.search.port=9001
-# Elasticsearch host. The search server will bind this address and the search client will connect to it. Default ist 127.0.0.1.
+# Elasticsearch host. The search server will bind this address and the search client will connect to it. Default is 127.0.0.1.
 #sonar.search.host=127.0.0.1
 
 


### PR DESCRIPTION
this fixes a minor typo in a sonar.properties comment
this also serves as a test for the PR process and GitHub setup