### PR TITLE
add FluentIterable fork in new module sonar-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <maven.min.version>3.0.5</maven.min.version>
     <maven.api.version>3.0.5</maven.api.version>
     <jdk.min.version>1.7</jdk.min.version>
+    <guava.version>10.0.1</guava.version>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
 
@@ -723,7 +724,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>10.0.1</version>
+        <version>${guava.version}</version>
         <exclusions>
           <exclusion>
             <!-- should be declared with scope provided -->
@@ -731,6 +732,11 @@
             <artifactId>jsr305</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-testlib</artifactId>
+        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -11,6 +11,7 @@
   <name>SonarQube :: Server :: Parent</name>
 
   <modules>
+    <module>sonar-utils</module>
     <module>sonar-process</module>
     <module>sonar-process-monitor</module>
     <module>sonar-search</module>

--- a/server/sonar-utils/pom.xml
+++ b/server/sonar-utils/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.codehaus.sonar</groupId>
+    <artifactId>server</artifactId>
+    <version>5.2-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>sonar-utils</artifactId>
+  <name>SonarQube :: Utils</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>${skipServerTests}</skipTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/server/sonar-utils/src/main/java/org/sonar/core/collect/FluentIterable.java
+++ b/server/sonar-utils/src/main/java/org/sonar/core/collect/FluentIterable.java
@@ -1,0 +1,233 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.core.collect;
+
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.GwtIncompatible;
+import com.google.common.base.*;
+import com.google.common.base.Optional;
+import com.google.common.collect.*;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import java.util.*;
+
+/**
+ * FluentIterable - Fork from Guava's 18.0 FluentIterable class (introduced in 12.0) with slight cleaning modification,
+ * removal of deprecated and beta methods, removal of those relying on other Guava class or methods which are not
+ * available in Guava 10.1 and fix of missing generics arguments in some methods.
+ *
+ * @author Marcin Mikosik
+ */
+public abstract class FluentIterable<E> implements Iterable<E> {
+  private final Iterable<E> iterable;
+
+  protected FluentIterable() {
+    this.iterable = this;
+  }
+
+  FluentIterable(Iterable<E> iterable) {
+    this.iterable = Preconditions.checkNotNull(iterable);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <E> FluentIterable<E> from(final Iterable<E> iterable) {
+    return iterable instanceof FluentIterable ? (FluentIterable) iterable : new FluentIterable(iterable) {
+      public Iterator<E> iterator() {
+        return iterable.iterator();
+      }
+    };
+  }
+
+  public String toString() {
+    return Iterables.toString(this.iterable);
+  }
+
+  public final int size() {
+    return Iterables.size(this.iterable);
+  }
+
+  public final boolean contains(@Nullable Object element) {
+    return Iterables.contains(this.iterable, element);
+  }
+
+  @CheckReturnValue
+  public final FluentIterable<E> cycle() {
+    return from(Iterables.cycle(this.iterable));
+  }
+
+  @CheckReturnValue
+  @Beta
+  public final FluentIterable<E> append(Iterable<? extends E> other) {
+    return from(Iterables.concat(this.iterable, other));
+  }
+
+  @CheckReturnValue
+  @Beta
+  public final FluentIterable<E> append(E... elements) {
+    return from(Iterables.concat(this.iterable, Arrays.asList(elements)));
+  }
+
+  @CheckReturnValue
+  public final FluentIterable<E> filter(Predicate<? super E> predicate) {
+    return from(Iterables.filter(this.iterable, predicate));
+  }
+
+  @CheckReturnValue
+  @GwtIncompatible("Class.isInstance")
+  public final <T> FluentIterable<T> filter(Class<T> type) {
+    return from(Iterables.filter(this.iterable, type));
+  }
+
+  public final boolean anyMatch(Predicate<? super E> predicate) {
+    return Iterables.any(this.iterable, predicate);
+  }
+
+  public final boolean allMatch(Predicate<? super E> predicate) {
+    return Iterables.all(this.iterable, predicate);
+  }
+
+  public final Optional<E> firstMatch(Predicate<? super E> predicate) {
+    Iterator<E> iterable = Iterables.filter(this.iterable, predicate).iterator();
+    if (iterable.hasNext()) {
+      return Optional.of(iterable.next());
+    }
+    return Optional.absent();
+  }
+
+  public final <T> FluentIterable<T> transform(Function<? super E, T> function) {
+    return from(Iterables.transform(this.iterable, function));
+  }
+
+  public <T> FluentIterable<T> transformAndConcat(Function<? super E, ? extends Iterable<? extends T>> function) {
+    return from(Iterables.concat(this.transform(function)));
+  }
+
+  public final Optional<E> first() {
+    Iterator<E> iterator = this.iterable.iterator();
+    return iterator.hasNext() ? Optional.<E>of(iterator.next()) : Optional.<E>absent();
+  }
+
+  public final Optional<E> last() {
+    if (this.iterable instanceof List) {
+      List<E> iterator1 = (List) this.iterable;
+      return iterator1.isEmpty() ? Optional.<E>absent() : Optional.<E>of(iterator1.get(iterator1.size() - 1));
+    } else {
+      Iterator<E> iterator = this.iterable.iterator();
+      if (!iterator.hasNext()) {
+        return Optional.absent();
+      } else if (this.iterable instanceof SortedSet) {
+        SortedSet<E> current1 = (SortedSet) this.iterable;
+        return Optional.<E>of(current1.last());
+      } else {
+        E current;
+        do {
+          current = iterator.next();
+        } while (iterator.hasNext());
+
+        return Optional.of(current);
+      }
+    }
+  }
+
+  @CheckReturnValue
+  public final FluentIterable<E> skip(int numberToSkip) {
+    return from(Iterables.skip(this.iterable, numberToSkip));
+  }
+
+  @CheckReturnValue
+  public final FluentIterable<E> limit(int size) {
+    return from(Iterables.limit(this.iterable, size));
+  }
+
+  public final boolean isEmpty() {
+    return !this.iterable.iterator().hasNext();
+  }
+
+  public final ImmutableList<E> toList() {
+    return ImmutableList.copyOf(this.iterable);
+  }
+
+  public final ImmutableList<E> toSortedList(Comparator<? super E> comparator) {
+    return Ordering.from(comparator).immutableSortedCopy(this.iterable);
+  }
+
+  public final ImmutableSet<E> toSet() {
+    return ImmutableSet.copyOf(this.iterable);
+  }
+
+  public final ImmutableSortedSet<E> toSortedSet(Comparator<? super E> comparator) {
+    return ImmutableSortedSet.copyOf(comparator, this.iterable);
+  }
+
+  public final <K> ImmutableListMultimap<K, E> index(Function<? super E, K> keyFunction) {
+    return Multimaps.index(this.iterable, keyFunction);
+  }
+
+  public final <K> ImmutableMap<K, E> uniqueIndex(Function<? super E, K> keyFunction) {
+    return Maps.uniqueIndex(this.iterable, keyFunction);
+  }
+
+  @GwtIncompatible("Array.newArray(Class, int)")
+  public final E[] toArray(Class<E> type) {
+    return Iterables.toArray(this.iterable, type);
+  }
+
+  public final <C extends Collection<? super E>> C copyInto(C collection) {
+    Preconditions.checkNotNull(collection);
+    if (this.iterable instanceof Collection) {
+      collection.addAll(castCollection(this.iterable));
+    } else {
+      Iterator<E> i$ = this.iterable.iterator();
+
+      while (i$.hasNext()) {
+        E item = i$.next();
+        collection.add(item);
+      }
+    }
+
+    return collection;
+  }
+
+  /**
+   * Used to avoid http://bugs.sun.com/view_bug.do?bug_id=6558557
+   */
+  private static <T> Collection<T> castCollection(Iterable<T> iterable) {
+    return (Collection<T>) iterable;
+  }
+
+  @Beta
+  public final String join(Joiner joiner) {
+    return joiner.join(this);
+  }
+
+  public final E get(int position) {
+    return Iterables.get(this.iterable, position);
+  }
+
+  private static class FromIterableFunction<E> implements Function<Iterable<E>, FluentIterable<E>> {
+    private FromIterableFunction() {
+    }
+
+    public FluentIterable<E> apply(Iterable<E> fromObject) {
+      return FluentIterable.from(fromObject);
+    }
+  }
+}

--- a/server/sonar-utils/src/test/java/org/sonar/core/collect/FluentIterableTest.java
+++ b/server/sonar-utils/src/test/java/org/sonar/core/collect/FluentIterableTest.java
@@ -1,0 +1,770 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.core.collect;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.*;
+import com.google.common.collect.testing.IteratorFeature;
+import com.google.common.collect.testing.IteratorTester;
+import com.google.common.testing.NullPointerTester;
+
+import junit.framework.AssertionFailedError;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import javax.annotation.Nullable;
+
+/**
+ * Fork of unit test for {@link FluentIterable} from Guava 18.
+ *
+ * @author Marcin Mikosik
+ */
+@GwtCompatible(emulated = true)
+public class FluentIterableTest extends TestCase {
+
+  @GwtIncompatible("NullPointerTester")
+  public void testNullPointerExceptions() throws Exception {
+    NullPointerTester tester = new NullPointerTester();
+    tester.testAllPublicStaticMethods(FluentIterable.class);
+  }
+
+  public void testFrom() {
+    assertEquals(ImmutableList.of(1, 2, 3, 4),
+      Lists.newArrayList(FluentIterable.from(ImmutableList.of(1, 2, 3, 4))));
+  }
+
+  public void testSize1Collection() {
+    assertEquals(1, FluentIterable.from(asList("a")).size());
+  }
+
+  public void testSize2NonCollection() {
+    Iterable<Integer> iterable = new Iterable<Integer>() {
+      @Override
+      public Iterator<Integer> iterator() {
+        return asList(0, 1).iterator();
+      }
+    };
+    assertEquals(2, FluentIterable.from(iterable).size());
+  }
+
+  public void testSize_collectionDoesntIterate() {
+    List<Integer> nums = asList(1, 2, 3, 4, 5);
+    List<Integer> collection = new ArrayList<Integer>(nums) {
+      @Override
+      public Iterator<Integer> iterator() {
+        throw new AssertionFailedError("Don't iterate me!");
+      }
+    };
+    assertEquals(5, FluentIterable.from(collection).size());
+  }
+
+  public void testContains_nullSetYes() {
+    Iterable<String> set = Sets.newHashSet("a", null, "b");
+    assertTrue(FluentIterable.from(set).contains(null));
+  }
+
+  public void testContains_nullSetNo() {
+    Iterable<String> set = ImmutableSortedSet.of("a", "b");
+    assertFalse(FluentIterable.from(set).contains(null));
+  }
+
+  public void testContains_nullIterableYes() {
+    Iterable<String> iterable = iterable("a", null, "b");
+    assertTrue(FluentIterable.from(iterable).contains(null));
+  }
+
+  public void testContains_nullIterableNo() {
+    Iterable<String> iterable = iterable("a", "b");
+    assertFalse(FluentIterable.from(iterable).contains(null));
+  }
+
+  public void testContains_nonNullSetYes() {
+    Iterable<String> set = Sets.newHashSet("a", null, "b");
+    assertTrue(FluentIterable.from(set).contains("b"));
+  }
+
+  public void testContains_nonNullSetNo() {
+    Iterable<String> set = Sets.newHashSet("a", "b");
+    assertFalse(FluentIterable.from(set).contains("c"));
+  }
+
+  public void testContains_nonNullIterableYes() {
+    Iterable<String> set = iterable("a", null, "b");
+    assertTrue(FluentIterable.from(set).contains("b"));
+  }
+
+  public void testContains_nonNullIterableNo() {
+    Iterable<String> iterable = iterable("a", "b");
+    assertFalse(FluentIterable.from(iterable).contains("c"));
+  }
+
+  public void testCycle() {
+    FluentIterable<String> cycle = FluentIterable.from(asList("a", "b")).cycle();
+
+    int howManyChecked = 0;
+    for (String string : cycle) {
+      String expected = (howManyChecked % 2 == 0) ? "a" : "b";
+      assertEquals(expected, string);
+      if (howManyChecked++ == 5) {
+        break;
+      }
+    }
+
+    // We left the last iterator pointing to "b". But a new iterator should
+    // always point to "a".
+    assertEquals("a", cycle.iterator().next());
+  }
+
+  public void testCycle_removingAllElementsStopsCycle() {
+    FluentIterable<Integer> cycle = fluent(1, 2).cycle();
+    Iterator<Integer> iterator = cycle.iterator();
+    iterator.next();
+    iterator.remove();
+    iterator.next();
+    iterator.remove();
+    assertFalse(iterator.hasNext());
+    assertFalse(cycle.iterator().hasNext());
+  }
+
+  public void testAppend() {
+    FluentIterable<Integer> result =
+      FluentIterable.<Integer>from(asList(1, 2, 3)).append(Lists.newArrayList(4, 5, 6));
+    assertEquals(asList(1, 2, 3, 4, 5, 6), Lists.newArrayList(result));
+    assertEquals("[1, 2, 3, 4, 5, 6]", result.toString());
+
+    result = FluentIterable.<Integer>from(asList(1, 2, 3)).append(4, 5, 6);
+    assertEquals(asList(1, 2, 3, 4, 5, 6), Lists.newArrayList(result));
+    assertEquals("[1, 2, 3, 4, 5, 6]", result.toString());
+  }
+
+  public void testAppend_emptyList() {
+    FluentIterable<Integer> result =
+      FluentIterable.<Integer>from(asList(1, 2, 3)).append(Lists.<Integer>newArrayList());
+    assertEquals(asList(1, 2, 3), Lists.newArrayList(result));
+  }
+
+  @SuppressWarnings("ReturnValueIgnored")
+  public void testAppend_nullPointerException() {
+    try {
+      FluentIterable.<Integer>from(asList(1, 2)).append((List<Integer>) null);
+      fail("Appending null iterable should throw NPE.");
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  /*
+   * Tests for partition(int size) method.
+   */
+
+  /*
+   * Tests for partitionWithPadding(int size) method.
+   */
+
+  public void testFilter() {
+    FluentIterable<String> filtered =
+      FluentIterable.from(asList("foo", "bar")).filter(Predicates.equalTo("foo"));
+
+    List<String> expected = Collections.singletonList("foo");
+    List<String> actual = Lists.newArrayList(filtered);
+    assertEquals(expected, actual);
+    assertCanIterateAgain(filtered);
+    assertEquals("[foo]", filtered.toString());
+  }
+
+  private static class TypeA {
+  }
+  private interface TypeB {
+  }
+  private static class HasBoth extends TypeA implements TypeB {
+  }
+
+  @GwtIncompatible("Iterables.filter(Iterable, Class)")
+  public void testFilterByType() throws Exception {
+    HasBoth hasBoth = new HasBoth();
+    FluentIterable<TypeA> alist =
+      FluentIterable.from(asList(new TypeA(), new TypeA(), hasBoth, new TypeA()));
+    Iterable<TypeB> blist = alist.filter(TypeB.class);
+    assertThat(blist).containsExactly(hasBoth);
+  }
+
+  public void testAnyMatch() {
+    ArrayList<String> list = Lists.newArrayList();
+    FluentIterable<String> iterable = FluentIterable.<String>from(list);
+    Predicate<String> predicate = Predicates.equalTo("pants");
+
+    assertFalse(iterable.anyMatch(predicate));
+    list.add("cool");
+    assertFalse(iterable.anyMatch(predicate));
+    list.add("pants");
+    assertTrue(iterable.anyMatch(predicate));
+  }
+
+  public void testAllMatch() {
+    List<String> list = Lists.newArrayList();
+    FluentIterable<String> iterable = FluentIterable.<String>from(list);
+    Predicate<String> predicate = Predicates.equalTo("cool");
+
+    assertTrue(iterable.allMatch(predicate));
+    list.add("cool");
+    assertTrue(iterable.allMatch(predicate));
+    list.add("pants");
+    assertFalse(iterable.allMatch(predicate));
+  }
+
+  public void testFirstMatch() {
+    FluentIterable<String> iterable = FluentIterable.from(Lists.newArrayList("cool", "pants"));
+    assertEquals(Optional.of("cool"), iterable.firstMatch(Predicates.equalTo("cool")));
+    assertEquals(Optional.of("pants"), iterable.firstMatch(Predicates.equalTo("pants")));
+    assertEquals(Optional.absent(), iterable.firstMatch(Predicates.alwaysFalse()));
+    assertEquals(Optional.of("cool"), iterable.firstMatch(Predicates.alwaysTrue()));
+  }
+
+  private static final class IntegerValueOfFunction implements Function<String, Integer> {
+    @Override
+    public Integer apply(String from) {
+      return Integer.valueOf(from);
+    }
+  }
+
+  public void testTransformWith() {
+    List<String> input = asList("1", "2", "3");
+    Iterable<Integer> iterable =
+      FluentIterable.from(input).transform(new IntegerValueOfFunction());
+
+    assertEquals(asList(1, 2, 3), Lists.newArrayList(iterable));
+    assertCanIterateAgain(iterable);
+    assertEquals("[1, 2, 3]", iterable.toString());
+  }
+
+  public void testTransformWith_poorlyBehavedTransform() {
+    List<String> input = asList("1", null, "3");
+    Iterable<Integer> iterable =
+      FluentIterable.from(input).transform(new IntegerValueOfFunction());
+
+    Iterator<Integer> resultIterator = iterable.iterator();
+    resultIterator.next();
+
+    try {
+      resultIterator.next();
+      fail("Transforming null to int should throw NumberFormatException");
+    } catch (NumberFormatException expected) {
+    }
+  }
+
+  private static final class StringValueOfFunction implements Function<Integer, String> {
+    @Override
+    public String apply(Integer from) {
+      return String.valueOf(from);
+    }
+  }
+
+  public void testTransformWith_nullFriendlyTransform() {
+    List<Integer> input = asList(1, 2, null, 3);
+    Iterable<String> result = FluentIterable.from(input).transform(new StringValueOfFunction());
+
+    assertEquals(asList("1", "2", "null", "3"), Lists.newArrayList(result));
+  }
+
+  private static final class RepeatedStringValueOfFunction
+    implements Function<Integer, List<String>> {
+    @Override
+    public List<String> apply(Integer from) {
+      String value = String.valueOf(from);
+      return ImmutableList.of(value, value);
+    }
+  }
+
+  public void testTransformAndConcat() {
+    List<Integer> input = asList(1, 2, 3);
+    Iterable<String> result =
+      FluentIterable.from(input).transformAndConcat(new RepeatedStringValueOfFunction());
+    assertEquals(asList("1", "1", "2", "2", "3", "3"), Lists.newArrayList(result));
+  }
+
+  private static final class RepeatedStringValueOfWildcardFunction
+    implements Function<Integer, List<? extends String>> {
+    @Override
+    public List<String> apply(Integer from) {
+      String value = String.valueOf(from);
+      return ImmutableList.of(value, value);
+    }
+  }
+
+  public void testTransformAndConcat_wildcardFunctionGenerics() {
+    List<Integer> input = asList(1, 2, 3);
+    FluentIterable.from(input).transformAndConcat(new RepeatedStringValueOfWildcardFunction());
+  }
+
+  public void testFirst_list() {
+    List<String> list = Lists.newArrayList("a", "b", "c");
+    assertEquals("a", FluentIterable.from(list).first().get());
+  }
+
+  public void testFirst_null() {
+    List<String> list = Lists.newArrayList(null, "a", "b");
+    try {
+      FluentIterable.from(list).first();
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  public void testFirst_emptyList() {
+    List<String> list = Collections.emptyList();
+    assertEquals(Optional.absent(), FluentIterable.from(list).first());
+  }
+
+  public void testFirst_sortedSet() {
+    SortedSet<String> sortedSet = ImmutableSortedSet.of("b", "c", "a");
+    assertEquals("a", FluentIterable.from(sortedSet).first().get());
+  }
+
+  public void testFirst_emptySortedSet() {
+    SortedSet<String> sortedSet = ImmutableSortedSet.of();
+    assertEquals(Optional.absent(), FluentIterable.from(sortedSet).first());
+  }
+
+  public void testFirst_iterable() {
+    Set<String> set = ImmutableSet.of("a", "b", "c");
+    assertEquals("a", FluentIterable.from(set).first().get());
+  }
+
+  public void testFirst_emptyIterable() {
+    Set<String> set = Sets.newHashSet();
+    assertEquals(Optional.absent(), FluentIterable.from(set).first());
+  }
+
+  public void testLast_list() {
+    List<String> list = Lists.newArrayList("a", "b", "c");
+    assertEquals("c", FluentIterable.from(list).last().get());
+  }
+
+  public void testLast_null() {
+    List<String> list = Lists.newArrayList("a", "b", null);
+    try {
+      FluentIterable.from(list).last();
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  public void testLast_emptyList() {
+    List<String> list = Collections.emptyList();
+    assertEquals(Optional.absent(), FluentIterable.from(list).last());
+  }
+
+  public void testLast_sortedSet() {
+    SortedSet<String> sortedSet = ImmutableSortedSet.of("b", "c", "a");
+    assertEquals("c", FluentIterable.from(sortedSet).last().get());
+  }
+
+  public void testLast_emptySortedSet() {
+    SortedSet<String> sortedSet = ImmutableSortedSet.of();
+    assertEquals(Optional.absent(), FluentIterable.from(sortedSet).last());
+  }
+
+  public void testLast_iterable() {
+    Set<String> set = ImmutableSet.of("a", "b", "c");
+    assertEquals("c", FluentIterable.from(set).last().get());
+  }
+
+  public void testLast_emptyIterable() {
+    Set<String> set = Sets.newHashSet();
+    assertEquals(Optional.absent(), FluentIterable.from(set).last());
+  }
+
+  public void testSkip_simple() {
+    Collection<String> set = ImmutableSet.of("a", "b", "c", "d", "e");
+    assertEquals(Lists.newArrayList("c", "d", "e"),
+      Lists.newArrayList(FluentIterable.from(set).skip(2)));
+    assertEquals("[c, d, e]", FluentIterable.from(set).skip(2).toString());
+  }
+
+  public void testSkip_simpleList() {
+    Collection<String> list = Lists.newArrayList("a", "b", "c", "d", "e");
+    assertEquals(Lists.newArrayList("c", "d", "e"),
+      Lists.newArrayList(FluentIterable.from(list).skip(2)));
+    assertEquals("[c, d, e]", FluentIterable.from(list).skip(2).toString());
+  }
+
+  public void testSkip_pastEnd() {
+    Collection<String> set = ImmutableSet.of("a", "b");
+    assertEquals(Collections.emptyList(), Lists.newArrayList(FluentIterable.from(set).skip(20)));
+  }
+
+  public void testSkip_pastEndList() {
+    Collection<String> list = Lists.newArrayList("a", "b");
+    assertEquals(Collections.emptyList(), Lists.newArrayList(FluentIterable.from(list).skip(20)));
+  }
+
+  public void testSkip_skipNone() {
+    Collection<String> set = ImmutableSet.of("a", "b");
+    assertEquals(Lists.newArrayList("a", "b"),
+      Lists.newArrayList(FluentIterable.from(set).skip(0)));
+  }
+
+  public void testSkip_skipNoneList() {
+    Collection<String> list = Lists.newArrayList("a", "b");
+    assertEquals(Lists.newArrayList("a", "b"),
+      Lists.newArrayList(FluentIterable.from(list).skip(0)));
+  }
+
+  public void testSkip_iterator() throws Exception {
+    new IteratorTester<Integer>(5, IteratorFeature.MODIFIABLE, Lists.newArrayList(2, 3),
+      IteratorTester.KnownOrder.KNOWN_ORDER) {
+      @Override
+      protected Iterator<Integer> newTargetIterator() {
+        Collection<Integer> collection = Sets.newLinkedHashSet();
+        Collections.addAll(collection, 1, 2, 3);
+        return FluentIterable.from(collection).skip(1).iterator();
+      }
+    }.test();
+  }
+
+  public void testSkip_iteratorList() throws Exception {
+    new IteratorTester<Integer>(5, IteratorFeature.MODIFIABLE, Lists.newArrayList(2, 3),
+      IteratorTester.KnownOrder.KNOWN_ORDER) {
+      @Override
+      protected Iterator<Integer> newTargetIterator() {
+        return FluentIterable.from(Lists.newArrayList(1, 2, 3)).skip(1).iterator();
+      }
+    }.test();
+  }
+
+  public void testSkip_nonStructurallyModifiedList() throws Exception {
+    List<String> list = Lists.newArrayList("a", "b", "c");
+    FluentIterable<String> tail = FluentIterable.from(list).skip(1);
+    Iterator<String> tailIterator = tail.iterator();
+    list.set(2, "c2");
+    assertEquals("b", tailIterator.next());
+    assertEquals("c2", tailIterator.next());
+    assertFalse(tailIterator.hasNext());
+  }
+
+  public void testSkip_structurallyModifiedSkipSome() throws Exception {
+    Collection<String> set = Sets.newLinkedHashSet();
+    Collections.addAll(set, "a", "b", "c");
+    FluentIterable<String> tail = FluentIterable.from(set).skip(1);
+    set.remove("b");
+    set.addAll(Lists.newArrayList("X", "Y", "Z"));
+    assertThat(tail).containsExactly("c", "X", "Y", "Z");
+  }
+
+  public void testSkip_structurallyModifiedSkipSomeList() throws Exception {
+    List<String> list = Lists.newArrayList("a", "b", "c");
+    FluentIterable<String> tail = FluentIterable.from(list).skip(1);
+    list.subList(1, 3).clear();
+    list.addAll(0, Lists.newArrayList("X", "Y", "Z"));
+    assertThat(tail).containsExactly("Y", "Z", "a");
+  }
+
+  public void testSkip_structurallyModifiedSkipAll() throws Exception {
+    Collection<String> set = Sets.newLinkedHashSet();
+    Collections.addAll(set, "a", "b", "c");
+    FluentIterable<String> tail = FluentIterable.from(set).skip(2);
+    set.remove("a");
+    set.remove("b");
+    assertFalse(tail.iterator().hasNext());
+  }
+
+  public void testSkip_structurallyModifiedSkipAllList() throws Exception {
+    List<String> list = Lists.newArrayList("a", "b", "c");
+    FluentIterable<String> tail = FluentIterable.from(list).skip(2);
+    list.subList(0, 2).clear();
+    assertThat(tail).isEmpty();
+  }
+
+  @SuppressWarnings("ReturnValueIgnored")
+  public void testSkip_illegalArgument() {
+    try {
+      FluentIterable.from(asList("a", "b", "c")).skip(-1);
+      fail("Skipping negative number of elements should throw IllegalArgumentException.");
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  public void testLimit() {
+    Iterable<String> iterable = Lists.newArrayList("foo", "bar", "baz");
+    FluentIterable<String> limited = FluentIterable.from(iterable).limit(2);
+
+    assertEquals(ImmutableList.of("foo", "bar"), Lists.newArrayList(limited));
+    assertCanIterateAgain(limited);
+    assertEquals("[foo, bar]", limited.toString());
+  }
+
+  @SuppressWarnings("ReturnValueIgnored")
+  public void testLimit_illegalArgument() {
+    try {
+      FluentIterable.from(Lists.newArrayList("a", "b", "c")).limit(-1);
+      fail("Passing negative number to limit(...) method should throw IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  public void testIsEmpty() {
+    assertTrue(FluentIterable.<String>from(Collections.<String>emptyList()).isEmpty());
+    assertFalse(FluentIterable.<String>from(Lists.newArrayList("foo")).isEmpty());
+  }
+
+  public void testToList() {
+    assertEquals(Lists.newArrayList(1, 2, 3, 4), fluent(1, 2, 3, 4).toList());
+  }
+
+  public void testToList_empty() {
+    assertTrue(fluent().toList().isEmpty());
+  }
+
+  public void testToSortedList_withComparator() {
+    assertEquals(Lists.newArrayList(4, 3, 2, 1),
+      fluent(4, 1, 3, 2).toSortedList(Ordering.<Integer>natural().reverse()));
+  }
+
+  public void testToSortedList_withDuplicates() {
+    assertEquals(Lists.newArrayList(4, 3, 1, 1),
+      fluent(1, 4, 1, 3).toSortedList(Ordering.<Integer>natural().reverse()));
+  }
+
+  public void testToSet() {
+    assertThat(fluent(1, 2, 3, 4).toSet()).containsExactly(1, 2, 3, 4);
+  }
+
+  public void testToSet_removeDuplicates() {
+    assertThat(fluent(1, 2, 1, 2).toSet()).containsExactly(1, 2);
+  }
+
+  public void testToSet_empty() {
+    assertTrue(fluent().toSet().isEmpty());
+  }
+
+  public void testToSortedSet() {
+    assertThat(fluent(1, 4, 2, 3).toSortedSet(Ordering.<Integer>natural().reverse()))
+      .containsExactly(4, 3, 2, 1);
+  }
+
+  public void testToSortedSet_removeDuplicates() {
+    assertThat(fluent(1, 4, 1, 3).toSortedSet(Ordering.<Integer>natural().reverse()))
+      .containsExactly(4, 3, 1);
+  }
+
+  // public void testToMap() {
+  // assertThat(fluent(1, 2, 3).toMap(Functions.toStringFunction()).entrySet())
+  // .containsExactly(
+  // Maps.immutableEntry(1, "1"),
+  // Maps.immutableEntry(2, "2"),
+  // Maps.immutableEntry(3, "3"));
+  // }
+  //
+  // public void testToMap_nullKey() {
+  // try {
+  // fluent(1, null, 2).toMap(Functions.constant("foo"));
+  // fail();
+  // } catch (NullPointerException expected) {
+  // }
+  // }
+  //
+  // public void testToMap_nullValue() {
+  // try {
+  // fluent(1, 2, 3).toMap(Functions.constant(null));
+  // fail();
+  // } catch (NullPointerException expected) {
+  // }
+  // }
+
+  public void testIndex() {
+    ImmutableListMultimap<Integer, String> expected =
+      ImmutableListMultimap.<Integer, String>builder()
+        .putAll(3, "one", "two")
+        .put(5, "three")
+        .put(4, "four")
+        .build();
+    ImmutableListMultimap<Integer, String> index =
+      FluentIterable.from(asList("one", "two", "three", "four")).index(
+        new Function<String, Integer>() {
+          @Override
+          public Integer apply(String input) {
+            return input.length();
+          }
+        });
+    assertEquals(expected, index);
+  }
+
+  public void testIndex_nullKey() {
+    try {
+      fluent(1, 2, 3).index(Functions.constant(null));
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  public void testIndex_nullValue() {
+    try {
+      fluent(1, null, 2).index(Functions.constant("foo"));
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  public void testUniqueIndex() {
+    ImmutableMap<Integer, String> expected =
+      ImmutableMap.of(3, "two", 5, "three", 4, "four");
+    ImmutableMap<Integer, String> index =
+      FluentIterable.from(asList("two", "three", "four")).uniqueIndex(
+        new Function<String, Integer>() {
+          @Override
+          public Integer apply(String input) {
+            return input.length();
+          }
+        });
+    assertEquals(expected, index);
+  }
+
+  public void testUniqueIndex_duplicateKey() {
+    try {
+      FluentIterable.from(asList("one", "two", "three", "four")).uniqueIndex(
+        new Function<String, Integer>() {
+          @Override
+          public Integer apply(String input) {
+            return input.length();
+          }
+        });
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  public void testUniqueIndex_nullKey() {
+    try {
+      fluent(1, 2, 3).uniqueIndex(Functions.constant(null));
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  public void testUniqueIndex_nullValue() {
+    try {
+      fluent(1, null, 2).uniqueIndex(new Function<Integer, Object>() {
+        @Override
+        public Object apply(@Nullable Integer input) {
+          return String.valueOf(input);
+        }
+      });
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  public void testCopyInto_List() {
+    assertThat(fluent(1, 3, 5).copyInto(Lists.newArrayList(1, 2)))
+      .containsExactly(1, 2, 1, 3, 5);
+  }
+
+  public void testCopyInto_Set() {
+    assertThat(fluent(1, 3, 5).copyInto(Sets.newHashSet(1, 2)))
+      .containsExactly(1, 2, 3, 5);
+  }
+
+  public void testCopyInto_SetAllDuplicates() {
+    assertThat(fluent(1, 3, 5).copyInto(Sets.newHashSet(1, 2, 3, 5)))
+      .containsExactly(1, 2, 3, 5);
+  }
+
+  public void testCopyInto_NonCollection() {
+    final ArrayList<Integer> list = Lists.newArrayList(1, 2, 3);
+
+    final ArrayList<Integer> iterList = Lists.newArrayList(9, 8, 7);
+    Iterable<Integer> iterable = new Iterable<Integer>() {
+      @Override
+      public Iterator<Integer> iterator() {
+        return iterList.iterator();
+      }
+    };
+
+    assertThat(FluentIterable.from(iterable).copyInto(list))
+      .containsExactly(1, 2, 3, 9, 8, 7);
+  }
+
+  public void testJoin() {
+    assertEquals("2,1,3,4", fluent(2, 1, 3, 4).join(Joiner.on(",")));
+  }
+
+  public void testJoin_empty() {
+    assertEquals("", fluent().join(Joiner.on(",")));
+  }
+
+  public void testGet() {
+    assertEquals("a", FluentIterable
+      .from(Lists.newArrayList("a", "b", "c")).get(0));
+    assertEquals("b", FluentIterable
+      .from(Lists.newArrayList("a", "b", "c")).get(1));
+    assertEquals("c", FluentIterable
+      .from(Lists.newArrayList("a", "b", "c")).get(2));
+  }
+
+  public void testGet_outOfBounds() {
+    try {
+      FluentIterable.from(Lists.newArrayList("a", "b", "c")).get(-1);
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+    }
+
+    try {
+      FluentIterable.from(Lists.newArrayList("a", "b", "c")).get(3);
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+    }
+  }
+
+  private static void assertCanIterateAgain(Iterable<?> iterable) {
+    for (@SuppressWarnings("unused")
+    Object obj : iterable) {
+    }
+  }
+
+  private static FluentIterable<Integer> fluent(Integer... elements) {
+    return FluentIterable.from(Lists.newArrayList(elements));
+  }
+
+  private static Iterable<String> iterable(String... elements) {
+    final List<String> list = asList(elements);
+    return new Iterable<String>() {
+      @Override
+      public Iterator<String> iterator() {
+        return list.iterator();
+      }
+    };
+  }
+}


### PR DESCRIPTION
FluentIterable is a very useful class to write functionnal code in Java 7 but was introduced with Guava 12. Good thing is, only 2 methods rely on code not available in Guava 10 so the fork is quite easy.
Unit test was also forked from Guava's

Please note that I added guava's guava-testlib library as a new dependency (was used by `FluentIterable` test) which contains pretty convenient classes such as `NullPointerTester`