### PR TITLE
Update environment.rb for Oracle optimizations

### DIFF
--- a/server/sonar-web/src/main/webapp/WEB-INF/config/environment.rb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/config/environment.rb
@@ -208,7 +208,7 @@ class ActiveRecord::Migration
           FOR EACH ROW
         BEGIN
            IF :new.id IS null THEN
-             SELECT #{table}_seq.nextval INTO :new.id FROM dual;
+             :new.id := #{table}_seq.nextval;
            END IF;
         END;})
   end


### PR DESCRIPTION
Instead of using a SELECT to fetch sequence #, assign value directly from the sequence; it would lower cursor usage for people with tight DB restrictions and could improve performance by up to 50% based on this: http://oracle-base.com/articles/11g/plsql-new-features-and-enhancements-11gr1.php#sequences_in_plsql_expressions.

However it would only be compatible with Oracle 11g and up, but Oracle 10g (even R2) was dropped from even extended support for almost 2 years. If support for Oracle 10g must be kept, perhaps a support for specific dialects like "Oracle9g", "Oracle10g", "Oracle11g" and "Oracle12c" would be necessary (a bit like Hibernate does although they stopped at 10g).