### PR TITLE
add -D option to start.sh to remote debug web server

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
+###############################
+# usage: use -D option to enable remote debugging of the web server on port 5005
+###############################
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   OS='macosx-universal-64'
+  SED_DISABLE_BACKUP=" ''"
 else
   OS='linux-x86-64'
+  SED_DISABLE_BACKUP=""
 fi
 
 ls sonar-application/target/sonarqube-*.zip 1> /dev/null 2>&1
@@ -18,6 +23,14 @@ if [ "$?" != "0" ]; then
   unzip sonarqube-*.zip
 fi
 cd sonarqube-*
+
+if [ "$1" = "-D" ]; then
+  echo "enabling debug in conf/sonar.properties, listening on port 5005"
+  sed -i $SED_DISABLE_BACKUP '/javaAdditionalOpts/d' conf/sonar.properties
+  echo "" >> conf/sonar.properties
+  echo "sonar.web.javaAdditionalOpts=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005" >> conf/sonar.properties
+fi
+
 bin/$OS/sonar.sh restart
 sleep 1
 tail -100f logs/sonar.log


### PR DESCRIPTION
this PR adds support for a `-D` option to start the webserver with remote debugging enabled on port 5005

this PR needs to be reviewed by someone with a MAC to make sure the script works correctly on this platform

thanks