### PR TITLE
SONAR-6434 Stop the support of Oracle 10g

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/db/DatabaseChecker.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/db/DatabaseChecker.java
@@ -35,6 +35,8 @@ import java.sql.SQLException;
 
 public class DatabaseChecker implements ServerComponent, Startable {
 
+  public static final int ORACLE_MIN_MAJOR_VERSION = 11;
+
   private final Database db;
 
   public DatabaseChecker(Database db) {
@@ -65,9 +67,9 @@ public class DatabaseChecker implements ServerComponent, Startable {
       // check version of db
       // See http://jira.codehaus.org/browse/SONAR-6434
       int majorVersion = connection.getMetaData().getDatabaseMajorVersion();
-      if (majorVersion < 11) {
+      if (majorVersion < ORACLE_MIN_MAJOR_VERSION) {
         throw MessageException.of(String.format(
-          "Unsupported Oracle version: %s. Minimal required version is 11g.", connection.getMetaData().getDatabaseProductVersion()));
+          "Unsupported Oracle version: %s. Minimal required version is %d.", connection.getMetaData().getDatabaseProductVersion(), ORACLE_MIN_MAJOR_VERSION));
       }
 
       // check version of driver

--- a/server/sonar-server/src/test/java/org/sonar/server/db/DatabaseCheckerTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/db/DatabaseCheckerTest.java
@@ -19,8 +19,10 @@
  */
 package org.sonar.server.db;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.sonar.api.utils.MessageException;
 import org.sonar.core.persistence.Database;
 import org.sonar.core.persistence.dialect.Dialect;
 import org.sonar.core.persistence.dialect.H2;
@@ -37,31 +39,59 @@ import static org.mockito.Mockito.when;
 public class DatabaseCheckerTest {
 
   @Test
-  public void require_oracle_11_2() throws Exception {
-    Database db = mockDb(new Oracle(), "11.2.0.0.1");
+  public void requires_oracle_driver_11_2() throws Exception {
+    Database db = mockDb(new Oracle(), "11.2.1", "11.2.0.0.1");
     new DatabaseChecker(db).start();
     // no error
 
-    db = mockDb(new Oracle(), "11.3.1");
+    db = mockDb(new Oracle(), "11.2.1", "11.3.1");
     new DatabaseChecker(db).start();
     // no error
 
-    db = mockDb(new Oracle(), "12.0.2");
+    db = mockDb(new Oracle(), "11.2.1", "12.0.2");
     new DatabaseChecker(db).start();
     // no error
 
-    db = mockDb(new Oracle(), "11.1.0.2");
+    db = mockDb(new Oracle(), "11.2.1", "11.1.0.2");
     try {
       new DatabaseChecker(db).start();
       fail();
-    } catch (IllegalStateException e) {
+    } catch (MessageException e) {
       assertThat(e).hasMessage("Unsupported Oracle JDBC driver version: 11.1.0.2. Minimal required version is 11.2.");
     }
   }
 
   @Test
+  public void requires_oracle_11g_or_greater() throws Exception {
+    // oracle 11.0 is ok
+    Database db = mockDb(new Oracle(), "11.0.1", "11.2.0.0.1");
+    new DatabaseChecker(db).start();
+
+    // oracle 11.1 is ok
+    db = mockDb(new Oracle(), "11.1.1", "11.2.0.0.1");
+    new DatabaseChecker(db).start();
+
+    // oracle 11.2 is ok
+    db = mockDb(new Oracle(), "11.2.1", "11.2.0.0.1");
+    new DatabaseChecker(db).start();
+
+    // oracle 12 is ok
+    db = mockDb(new Oracle(), "12.0.1", "11.2.0.0.1");
+    new DatabaseChecker(db).start();
+
+    // oracle 10 is not supported
+    db = mockDb(new Oracle(), "10.2.1",  "11.2.0.0.1");
+    try {
+      new DatabaseChecker(db).start();
+      fail();
+    } catch (MessageException e) {
+      assertThat(e).hasMessage("Unsupported Oracle version: 10.2.1. Minimal required version is 11g.");
+    }
+  }
+
+  @Test
   public void log_warning_if_h2() throws Exception {
-    Database db = mockDb(new H2(), "13.4");
+    Database db = mockDb(new H2(), "13.4", "13.4");
     DatabaseChecker checker = new DatabaseChecker(db);
     checker.start();
     checker.stop();
@@ -70,14 +100,16 @@ public class DatabaseCheckerTest {
 
   @Test
   public void do_not_fail_if_mysql() throws Exception {
-    Database db = mockDb(new MySql(), "5.7");
+    Database db = mockDb(new MySql(), "5.7", "5.7");
     new DatabaseChecker(db).start();
     // no error
   }
 
-  private Database mockDb(Dialect dialect, String driverVersion) throws SQLException {
+  private Database mockDb(Dialect dialect, String dbVersion, String driverVersion) throws SQLException {
     Database db = mock(Database.class, Mockito.RETURNS_DEEP_STUBS);
     when(db.getDialect()).thenReturn(dialect);
+    when(db.getDataSource().getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(Integer.parseInt(StringUtils.substringBefore(dbVersion, ".")));
+    when(db.getDataSource().getConnection().getMetaData().getDatabaseProductVersion()).thenReturn(dbVersion);
     when(db.getDataSource().getConnection().getMetaData().getDriverVersion()).thenReturn(driverVersion);
     return db;
   }

--- a/server/sonar-server/src/test/java/org/sonar/server/db/DatabaseCheckerTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/db/DatabaseCheckerTest.java
@@ -85,7 +85,7 @@ public class DatabaseCheckerTest {
       new DatabaseChecker(db).start();
       fail();
     } catch (MessageException e) {
-      assertThat(e).hasMessage("Unsupported Oracle version: 10.2.1. Minimal required version is 11g.");
+      assertThat(e).hasMessage("Unsupported Oracle version: 10.2.1. Minimal required version is 11.");
     }
   }
 

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -25,13 +25,13 @@
 
 #----- MySQL 5.x
 # Only InnoDB storage engine is supported (not myISAM).
-# Only the bundled driver is supported.
+# Only the bundled driver is supported. It can not be changed.
 #sonar.jdbc.url=jdbc:mysql://localhost:3306/sonar?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true&useConfigs=maxPerformance
 
 
-#----- Oracle 10g/11g
+#----- Oracle 11g and greater
 # - Only thin client is supported
-# - Only versions 11.2.* of Oracle JDBC driver are supported, even if connecting to lower Oracle versions.
+# - Only versions 11.2.* and greater of Oracle JDBC driver are supported
 # - The JDBC driver must be copied into the directory extensions/jdbc-driver/oracle/
 # - If you need to set the schema, please refer to http://jira.codehaus.org/browse/SONAR-5000
 #sonar.jdbc.url=jdbc:oracle:thin:@localhost/XE

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -29,9 +29,9 @@
 #sonar.jdbc.url=jdbc:mysql://localhost:3306/sonar?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true&useConfigs=maxPerformance
 
 
-#----- Oracle 11g and greater
+#----- Oracle 11g
 # - Only thin client is supported
-# - Only versions 11.2.* and greater of Oracle JDBC driver are supported
+# - Only versions 11.2.* of Oracle JDBC driver are supported
 # - The JDBC driver must be copied into the directory extensions/jdbc-driver/oracle/
 # - If you need to set the schema, please refer to http://jira.codehaus.org/browse/SONAR-5000
 #sonar.jdbc.url=jdbc:oracle:thin:@localhost/XE


### PR DESCRIPTION
- server does not start if oracle < 11g
- sonar.properties is up-to-date