### PR TITLE
SONAR-6445 Decrease the max memory used by server bootstrapper process

### DIFF
--- a/sonar-application/src/main/assembly/conf/wrapper.conf
+++ b/sonar-application/src/main/assembly/conf/wrapper.conf
@@ -19,8 +19,7 @@ wrapper.java.classpath.2=../../lib/*.jar
 wrapper.java.library.path.1=./lib
 wrapper.app.parameter.1=org.sonar.application.App
 wrapper.java.initmemory=3
-# Xmx can't be set to a lower value because of compatibility with Java 6
-wrapper.java.maxmemory=32
+wrapper.java.maxmemory=8
 
 #********************************************************************
 # Wrapper Logs


### PR DESCRIPTION
See https://jira.codehaus.org/browse/SONAR-6445. Decreasing to 8Mb is now possible with Java 7.