### PR TITLE
SONAR-6384 add java WS to cancel all plugins install/update/uninstall

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/platform/ServerComponents.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/platform/ServerComponents.java
@@ -223,6 +223,7 @@ import org.sonar.server.plugins.ServerPluginRepository;
 import org.sonar.server.plugins.UpdateCenterClient;
 import org.sonar.server.plugins.UpdateCenterMatrixFactory;
 import org.sonar.server.plugins.ws.AvailablePluginsWsAction;
+import org.sonar.server.plugins.ws.CancelAllPluginsWsAction;
 import org.sonar.server.plugins.ws.InstallPluginsWsAction;
 import org.sonar.server.plugins.ws.InstalledPluginsWsAction;
 import org.sonar.server.plugins.ws.PendingPluginsWsAction;
@@ -899,6 +900,7 @@ class ServerComponents {
     pico.addSingleton(InstallPluginsWsAction.class);
     pico.addSingleton(UpdatePluginsWsAction.class);
     pico.addSingleton(UninstallPluginsWsAction.class);
+    pico.addSingleton(CancelAllPluginsWsAction.class);
     pico.addSingleton(PluginsWs.class);
 
     // Compute engine

--- a/server/sonar-server/src/main/java/org/sonar/server/plugins/ws/CancelAllPluginsWsAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/plugins/ws/CancelAllPluginsWsAction.java
@@ -1,0 +1,59 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.plugins.ws;
+
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.Response;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.core.permission.GlobalPermissions;
+import org.sonar.server.plugins.PluginDownloader;
+import org.sonar.server.plugins.ServerPluginJarsInstaller;
+import org.sonar.server.user.UserSession;
+
+public class CancelAllPluginsWsAction implements PluginsWsAction {
+
+  private final PluginDownloader pluginDownloader;
+  private final ServerPluginJarsInstaller pluginJarsInstaller;
+
+  public CancelAllPluginsWsAction(PluginDownloader pluginDownloader, ServerPluginJarsInstaller pluginJarsInstaller) {
+    this.pluginDownloader = pluginDownloader;
+    this.pluginJarsInstaller = pluginJarsInstaller;
+  }
+
+  @Override
+  public void define(WebService.NewController controller) {
+    controller.createAction("cancel_all")
+      .setPost(true)
+      .setDescription("Cancels any operation pending on any plugin (install, update or uninstall)" +
+        "<br/>" +
+        "Requires user to be authenticated with Administer System permissions")
+      .setHandler(this);
+  }
+
+  @Override
+  public void handle(Request request, Response response) throws Exception {
+    UserSession.get().checkGlobalPermission(GlobalPermissions.SYSTEM_ADMIN);
+
+    pluginDownloader.cancelDownloads();
+    pluginJarsInstaller.cancelUninstalls();
+
+    response.noContent();
+  }
+}

--- a/server/sonar-server/src/test/java/org/sonar/server/plugins/ws/CancelAllPluginsWsActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/plugins/ws/CancelAllPluginsWsActionTest.java
@@ -1,0 +1,97 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.plugins.ws;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.sonar.api.server.ws.Request;
+import org.sonar.api.server.ws.WebService;
+import org.sonar.core.permission.GlobalPermissions;
+import org.sonar.server.exceptions.ForbiddenException;
+import org.sonar.server.plugins.PluginDownloader;
+import org.sonar.server.plugins.ServerPluginJarsInstaller;
+import org.sonar.server.user.MockUserSession;
+import org.sonar.server.ws.WsTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class CancelAllPluginsWsActionTest {
+  private static final String DUMMY_CONTROLLER_KEY = "dummy";
+
+  private PluginDownloader pluginDownloader = mock(PluginDownloader.class);
+  private ServerPluginJarsInstaller pluginJarsInstaller = mock(ServerPluginJarsInstaller.class);
+  private CancelAllPluginsWsAction underTest = new CancelAllPluginsWsAction(pluginDownloader, pluginJarsInstaller);
+
+  private Request request = mock(Request.class);
+  private WsTester.TestResponse response = new WsTester.TestResponse();
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setUp() throws Exception {
+    MockUserSession.set().setGlobalPermissions(GlobalPermissions.SYSTEM_ADMIN);
+  }
+
+  @Test
+  public void action_cancel_all_is_defined() throws Exception {
+    WsTester wsTester = new WsTester();
+    WebService.NewController newController = wsTester.context().createController(DUMMY_CONTROLLER_KEY);
+
+    underTest.define(newController);
+    newController.done();
+
+    WebService.Controller controller = wsTester.controller(DUMMY_CONTROLLER_KEY);
+    assertThat(controller.actions()).extracting("key").containsExactly("cancel_all");
+
+    WebService.Action action = controller.actions().iterator().next();
+    assertThat(action.isPost()).isTrue();
+    assertThat(action.description()).isNotEmpty();
+    assertThat(action.responseExample()).isNull();
+
+    assertThat(action.params()).isEmpty();
+  }
+
+  @Test
+  public void user_must_have_system_admin_permission() throws Exception {
+    expectedException.expect(ForbiddenException.class);
+    expectedException.expectMessage("Insufficient privileges");
+
+    // no permission on user
+    MockUserSession.set().setGlobalPermissions();
+
+    underTest.handle(request, response);
+  }
+
+  @Test
+  public void triggers_cancel_for_downloads_and_uninstalls() throws Exception {
+    underTest.handle(request, response);
+
+    verify(pluginDownloader, times(1)).cancelDownloads();
+    verify(pluginJarsInstaller, times(1)).cancelUninstalls();
+    assertThat(response.outputAsString()).isEmpty();
+  }
+
+}


### PR DESCRIPTION
adds new WS in Java to cancel all updates/installs of plugins (ie. download) and uninstalls
new WS is bound to URL /api/plugins/cancel_all