### PR TITLE
SONAR-6366 threads should be named

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/db/migrations/PlatformDatabaseMigrationExecutorServiceImpl.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/db/migrations/PlatformDatabaseMigrationExecutorServiceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.server.db.migrations;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.sonar.server.util.AbstractStoppableExecutorService;
 
 import java.util.concurrent.Executors;
@@ -32,6 +33,12 @@ public class PlatformDatabaseMigrationExecutorServiceImpl
   implements PlatformDatabaseMigrationExecutorService {
 
   public PlatformDatabaseMigrationExecutorServiceImpl() {
-    super(Executors.newSingleThreadExecutor());
+    super(
+      Executors.newSingleThreadExecutor(
+        new ThreadFactoryBuilder()
+          .setDaemon(false)
+          .setNameFormat("DB_migration-%d")
+          .build()
+        ));
   }
 }


### PR DESCRIPTION
small follow-up PR for SONAR-6366

threads should be named, especially long living one, thread name can be very helpful with reading a thread dump