### PR TITLE
SONAR-6379 fix response to display many updates per plugin

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/platform/ServerComponents.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/platform/ServerComponents.java
@@ -227,6 +227,7 @@ import org.sonar.server.plugins.ws.CancelAllPluginsWsAction;
 import org.sonar.server.plugins.ws.InstallPluginsWsAction;
 import org.sonar.server.plugins.ws.InstalledPluginsWsAction;
 import org.sonar.server.plugins.ws.PendingPluginsWsAction;
+import org.sonar.server.plugins.ws.PluginUpdateAggregator;
 import org.sonar.server.plugins.ws.PluginWSCommons;
 import org.sonar.server.plugins.ws.PluginsWs;
 import org.sonar.server.plugins.ws.UninstallPluginsWsAction;
@@ -893,6 +894,7 @@ class ServerComponents {
 
     // Plugins WS
     pico.addSingleton(PluginWSCommons.class);
+    pico.addSingleton(PluginUpdateAggregator.class);
     pico.addSingleton(InstalledPluginsWsAction.class);
     pico.addSingleton(AvailablePluginsWsAction.class);
     pico.addSingleton(UpdatesPluginsWsAction.class);

--- a/server/sonar-server/src/main/java/org/sonar/server/plugins/ws/PluginUpdateAggregator.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/plugins/ws/PluginUpdateAggregator.java
@@ -1,0 +1,119 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.plugins.ws;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.sonar.updatecenter.common.Plugin;
+import org.sonar.updatecenter.common.PluginUpdate;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.transform;
+import static java.lang.String.format;
+
+public class PluginUpdateAggregator {
+
+  public Collection<PluginUpdateAggregate> aggregate(@Nullable Collection<PluginUpdate> pluginUpdates) {
+    if (pluginUpdates == null || pluginUpdates.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    Map<Plugin, PluginUpdateAggregateBuilder> builders = Maps.newHashMap();
+    for (PluginUpdate pluginUpdate : pluginUpdates) {
+      Plugin plugin = pluginUpdate.getPlugin();
+      PluginUpdateAggregateBuilder builder = builders.get(plugin);
+      if (builder == null) {
+        builder = PluginUpdateAggregateBuilder.builderFor(plugin);
+        builders.put(plugin, builder);
+      }
+      builder.add(pluginUpdate);
+    }
+
+    return Lists.newArrayList(transform(builders.values(), BuilderToPluginUpdateAggregate.INSTANCE));
+  }
+
+  private enum BuilderToPluginUpdateAggregate implements Function<PluginUpdateAggregateBuilder, PluginUpdateAggregate> {
+    INSTANCE;
+
+    @Override
+    public PluginUpdateAggregate apply(@Nonnull PluginUpdateAggregateBuilder input) {
+      return input.build();
+    }
+  }
+
+  @VisibleForTesting
+  static class PluginUpdateAggregateBuilder {
+    private final Plugin plugin;
+
+    private final List<PluginUpdate> updates = Lists.newArrayListWithExpectedSize(1);
+
+    // use static method
+    private PluginUpdateAggregateBuilder(Plugin plugin) {
+      this.plugin = plugin;
+    }
+
+    public static PluginUpdateAggregateBuilder builderFor(Plugin plugin) {
+      return new PluginUpdateAggregateBuilder(checkNotNull(plugin));
+    }
+
+    public PluginUpdateAggregateBuilder add(PluginUpdate pluginUpdate) {
+      checkArgument(
+        this.plugin.equals(pluginUpdate.getPlugin()),
+        format("This builder only accepts PluginUpdate instances for plugin %s", plugin));
+      this.updates.add(pluginUpdate);
+      return this;
+    }
+
+    public PluginUpdateAggregate build() {
+      return new PluginUpdateAggregate(this);
+    }
+  }
+
+  public static class PluginUpdateAggregate {
+    private final Plugin plugin;
+
+    private final Collection<PluginUpdate> updates;
+
+    protected PluginUpdateAggregate(PluginUpdateAggregateBuilder builder) {
+      this.plugin = builder.plugin;
+      this.updates = ImmutableList.copyOf(builder.updates);
+    }
+
+    public Plugin getPlugin() {
+      return plugin;
+    }
+
+    public Collection<PluginUpdate> getUpdates() {
+      return updates;
+    }
+
+  }
+}

--- a/server/sonar-server/src/main/resources/org/sonar/server/plugins/ws/example-updates_plugins.json
+++ b/server/sonar-server/src/main/resources/org/sonar/server/plugins/ws/example-updates_plugins.json
@@ -9,18 +9,32 @@
       "organizationName": "SonarSource",
       "organizationUrl": "http://www.sonarsource.com",
       "termsAndConditionsUrl": "http://dist.sonarsource.com/SonarSource_Terms_And_Conditions.pdf",
-      "release": {
-        "version": "3.2",
-        "date": "2015-03-10",
-        "artifact": {
-          "name": "sonar-abap-plugin-3.2.jar",
-          "url": "http://dist.sonarsource.com/abap/download/sonar-abap-plugin-3.2.jar"
+      "updates": [
+        {
+          "release": {
+            "version": "3.1",
+            "date": "2014-12-21",
+            "artifact": {
+              "name": "sonar-abap-plugin-3.1.jar",
+              "url": "http://dist.sonarsource.com/abap/download/sonar-abap-plugin-3.1.jar"
+            }
+          },
+          "status": "INCOMPATIBLE",
+          "requires": []
+        },
+        {
+          "release": {
+            "version": "3.2",
+            "date": "2015-03-10",
+            "artifact": {
+              "name": "sonar-abap-plugin-3.2.jar",
+              "url": "http://dist.sonarsource.com/abap/download/sonar-abap-plugin-3.2.jar"
+            }
+          },
+          "status": "COMPATIBLE",
+          "requires": []
         }
-      },
-      "update": {
-        "status": "COMPATIBLE",
-        "requires": []
-      }
+      ]
     },
     {
       "key": "android",
@@ -30,24 +44,26 @@
       "license": "GNU LGPL 3",
       "organizationName": "SonarSource and Jerome Van Der Linden, Stephane Nicolas, Florian Roncari, Thomas Bores",
       "organizationUrl": "http://www.sonarsource.com",
-      "release": {
-        "version": "1.0",
-        "date": "2014-03-31",
-        "artifact": {
-          "name": "sonar-android-plugin-1.0.jar",
-          "url": "http://repository.codehaus.org/org/codehaus/sonar-plugins/android/sonar-android-plugin/1.0/sonar-android-plugin-1.0.jar"
+      "updates": [
+        {
+          "release": {
+            "version": "1.0",
+            "date": "2014-03-31",
+            "artifact": {
+              "name": "sonar-android-plugin-1.0.jar",
+              "url": "http://repository.codehaus.org/org/codehaus/sonar-plugins/android/sonar-android-plugin/1.0/sonar-android-plugin-1.0.jar"
+            }
+          },
+          "status": "COMPATIBLE",
+          "requires": [
+            {
+              "key": "java",
+              "name": "Java",
+              "description": "SonarQube rule engine."
+            }
+          ]
         }
-      },
-      "update": {
-        "status": "COMPATIBLE",
-        "requires": [
-          {
-            "key": "java",
-            "name": "Java",
-            "description": "SonarQube rule engine."
-          }
-        ]
-      }
+      ]
     }
   ]
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/plugins/ws/AbstractUpdateCenterBasedPluginsWsActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/plugins/ws/AbstractUpdateCenterBasedPluginsWsActionTest.java
@@ -21,7 +21,6 @@ package org.sonar.server.plugins.ws;
 
 import org.junit.Before;
 import org.sonar.api.server.ws.Request;
-import org.sonar.api.utils.DateUtils;
 import org.sonar.server.plugins.UpdateCenterMatrixFactory;
 import org.sonar.server.ws.WsTester;
 import org.sonar.updatecenter.common.Plugin;
@@ -47,19 +46,6 @@ public class AbstractUpdateCenterBasedPluginsWsActionTest {
   protected static final Plugin PLUGIN_1 = new Plugin("p_key_1").setName("p_name_1");
   protected static final Plugin PLUGIN_2 = new Plugin("p_key_2").setName("p_name_2").setDescription("p_desc_2");
 
-  protected static final Plugin FULL_PROPERTIES_PLUGIN = new Plugin("p_key")
-    .setName("p_name")
-    .setCategory("p_category")
-    .setDescription("p_description")
-    .setLicense("p_license")
-    .setOrganization("p_orga_name")
-    .setOrganizationUrl("p_orga_url")
-    .setTermsConditionsUrl("p_t_and_c_url");
-  protected static final Release FULL_PROPERTIES_PLUGIN_RELEASE = release(FULL_PROPERTIES_PLUGIN, "1.12.1")
-    .setDate(DateUtils.parseDate("2015-04-16"))
-    .setDownloadUrl("http://p_file.jar")
-    .addOutgoingDependency(release(PLUGIN_1, "0.3.6"))
-    .addOutgoingDependency(release(PLUGIN_2, "1.0.0"));
 
   protected UpdateCenterMatrixFactory updateCenterFactory = mock(UpdateCenterMatrixFactory.class);
   protected UpdateCenter updateCenter = mock(UpdateCenter.class);
@@ -81,9 +67,9 @@ public class AbstractUpdateCenterBasedPluginsWsActionTest {
 
   protected static PluginUpdate pluginUpdate(String key, String name) {
     return PluginUpdate.createWithStatus(
-        new Release(new Plugin(key).setName(name), Version.create("1.0")),
-        COMPATIBLE
-    );
+      new Release(new Plugin(key).setName(name), Version.create("1.0")),
+      COMPATIBLE
+      );
   }
 
   @Before

--- a/server/sonar-server/src/test/java/org/sonar/server/plugins/ws/AvailablePluginsWsActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/plugins/ws/AvailablePluginsWsActionTest.java
@@ -21,11 +21,11 @@ package org.sonar.server.plugins.ws;
 
 import org.junit.Test;
 import org.sonar.api.server.ws.WebService;
+import org.sonar.api.utils.DateUtils;
 import org.sonar.server.ws.WsTester;
 import org.sonar.updatecenter.common.Plugin;
 import org.sonar.updatecenter.common.PluginUpdate;
 import org.sonar.updatecenter.common.Release;
-import org.sonar.updatecenter.common.Version;
 
 import static com.google.common.collect.ImmutableList.of;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +37,20 @@ import static org.sonar.updatecenter.common.PluginUpdate.Status.INCOMPATIBLE;
 import static org.sonar.updatecenter.common.PluginUpdate.Status.REQUIRE_SONAR_UPGRADE;
 
 public class AvailablePluginsWsActionTest extends AbstractUpdateCenterBasedPluginsWsActionTest {
+
+  private static final Plugin FULL_PROPERTIES_PLUGIN = new Plugin("p_key")
+      .setName("p_name")
+      .setCategory("p_category")
+      .setDescription("p_description")
+      .setLicense("p_license")
+      .setOrganization("p_orga_name")
+      .setOrganizationUrl("p_orga_url")
+      .setTermsConditionsUrl("p_t_and_c_url");
+  private static final Release FULL_PROPERTIES_PLUGIN_RELEASE = release(FULL_PROPERTIES_PLUGIN, "1.12.1")
+      .setDate(DateUtils.parseDate("2015-04-16"))
+      .setDownloadUrl("http://p_file.jar")
+      .addOutgoingDependency(release(PLUGIN_1, "0.3.6"))
+      .addOutgoingDependency(release(PLUGIN_2, "1.0.0"));
 
   private AvailablePluginsWsAction underTest = new AvailablePluginsWsAction(updateCenterFactory, new PluginWSCommons());
 

--- a/server/sonar-server/src/test/java/org/sonar/server/plugins/ws/PluginUpdateAggregateBuilderTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/plugins/ws/PluginUpdateAggregateBuilderTest.java
@@ -1,0 +1,58 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.plugins.ws;
+
+import org.junit.Test;
+import org.sonar.server.plugins.ws.PluginUpdateAggregator.PluginUpdateAggregateBuilder;
+import org.sonar.updatecenter.common.Plugin;
+import org.sonar.updatecenter.common.PluginUpdate;
+import org.sonar.updatecenter.common.Release;
+import org.sonar.updatecenter.common.Version;
+
+public class PluginUpdateAggregateBuilderTest {
+
+  private static final Plugin PLUGIN_1 = new Plugin("key1");
+  private static final Plugin PLUGIN_2 = new Plugin("key2");
+  private static final Version SOME_VERSION = Version.create("1.0");
+  private static final PluginUpdate.Status SOME_STATUS = PluginUpdate.Status.COMPATIBLE;
+
+  @Test(expected = NullPointerException.class)
+  public void plugin_can_not_be_null_and_builderFor_enforces_it_with_NPE() throws Exception {
+    PluginUpdateAggregateBuilder.builderFor(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void add_throws_IAE_when_plugin_is_not_equal_to_the_one_of_the_builder() throws Exception {
+    PluginUpdateAggregateBuilder builder = PluginUpdateAggregateBuilder.builderFor(PLUGIN_1);
+
+    builder.add(createPluginUpdate(PLUGIN_2));
+  }
+
+  @Test
+  public void add_uses_equals_which_takes_only_key_into_account() throws Exception {
+    PluginUpdateAggregateBuilder builder = PluginUpdateAggregateBuilder.builderFor(PLUGIN_1);
+
+    builder.add(createPluginUpdate(new Plugin(PLUGIN_1.getKey())));
+  }
+
+  private static PluginUpdate createPluginUpdate(Plugin plugin) {
+    return PluginUpdate.createWithStatus(new Release(plugin, SOME_VERSION), SOME_STATUS);
+  }
+}

--- a/server/sonar-server/src/test/java/org/sonar/server/plugins/ws/PluginUpdateAggregatorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/plugins/ws/PluginUpdateAggregatorTest.java
@@ -1,0 +1,86 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.plugins.ws;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.sonar.updatecenter.common.Plugin;
+import org.sonar.updatecenter.common.PluginUpdate;
+import org.sonar.updatecenter.common.Release;
+import org.sonar.updatecenter.common.Version;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PluginUpdateAggregatorTest {
+
+  public static final Version SOME_VERSION = Version.create("1.0");
+  public static final PluginUpdate.Status SOME_STATUS = PluginUpdate.Status.COMPATIBLE;
+  private PluginUpdateAggregator underTest = new PluginUpdateAggregator();
+
+  @Test
+  public void aggregates_returns_an_empty_collection_when_plugin_collection_is_null() throws Exception {
+    assertThat(underTest.aggregate(null)).isEmpty();
+  }
+
+  @Test
+  public void aggregates_returns_an_empty_collection_when_plugin_collection_is_empty() throws Exception {
+    assertThat(underTest.aggregate(Collections.<PluginUpdate>emptyList())).isEmpty();
+  }
+
+  @Test
+  public void aggregates_groups_pluginUpdate_per_plugin_key() throws Exception {
+    Collection<PluginUpdateAggregator.PluginUpdateAggregate> aggregates = underTest.aggregate(ImmutableList.of(
+      createPluginUpdate("key1"),
+      createPluginUpdate("key1"),
+      createPluginUpdate("key0"),
+      createPluginUpdate("key2"),
+      createPluginUpdate("key0")
+      ));
+
+    assertThat(aggregates).hasSize(3);
+    assertThat(aggregates).extracting("plugin.key").containsOnlyOnce("key1", "key0", "key2");
+  }
+
+  @Test
+  public void aggregate_put_pluginUpdates_with_same_plugin_in_the_same_PluginUpdateAggregate() throws Exception {
+    PluginUpdate pluginUpdate1 = createPluginUpdate("key1");
+    PluginUpdate pluginUpdate2 = createPluginUpdate("key1");
+    PluginUpdate pluginUpdate3 = createPluginUpdate("key1");
+    Collection<PluginUpdateAggregator.PluginUpdateAggregate> aggregates = underTest.aggregate(ImmutableList.of(
+      pluginUpdate1,
+      pluginUpdate2,
+      pluginUpdate3
+      ));
+
+    assertThat(aggregates).hasSize(1);
+    Collection<PluginUpdate> releases = aggregates.iterator().next().getUpdates();
+    assertThat(releases).hasSize(3);
+    assertThat(releases).contains(pluginUpdate1);
+    assertThat(releases).contains(pluginUpdate2);
+    assertThat(releases).contains(pluginUpdate3);
+  }
+
+  private PluginUpdate createPluginUpdate(String pluginKey) {
+    return PluginUpdate.createWithStatus(new Release(new Plugin(pluginKey), SOME_VERSION), SOME_STATUS);
+  }
+}


### PR DESCRIPTION
this PR modifies the WS code to aggregate PluginUpdate objects from UpdateCenter so that the WS sends out information in the target format (multiple release per plugin object instead of one plugin for each release)

also, it modifies the unit test to test the sample response instead of some other json response specific to the unit test