### PR TITLE
feature/fix_mssql_role

### DIFF
--- a/server/sonar-web/src/main/webapp/WEB-INF/app/controllers/metrics_controller.rb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/controllers/metrics_controller.rb
@@ -92,6 +92,7 @@ class MetricsController < ApplicationController
       metric.domain = params[:newdomain]
     end
     metric.direction = 0
+    metric.qualitative = false
     metric.user_managed = true
     metric.origin = Metric::ORIGIN_GUI
     metric.enabled = true unless @reactivate_metric

--- a/server/sonar-web/src/main/webapp/WEB-INF/app/controllers/users_controller.rb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/controllers/users_controller.rb
@@ -44,6 +44,7 @@ class UsersController < ApplicationController
       end
     else
       user=prepare_user
+      user.active = true
       if user.save
         # case user: don't exist, no errors when create
         user.notify_creation_handlers
@@ -51,7 +52,7 @@ class UsersController < ApplicationController
         render :text => 'ok', :status => 200
       else
         # case user: don't exist, WITH ERRORS when create
-        # case user: exist and ACTIVE, whith or without errors when create
+        # case user: exist and ACTIVE, with or without errors when create
         @user = user
         user.errors.full_messages.each { |msg| @errors<<msg }
         render :partial => 'users/create_form', :status => 400


### PR DESCRIPTION
When permission db_owner is not granted, then two INSERT requests are incomplete and set NULL values instead of booleans.
See https://jira.codehaus.org/browse/SONAR-6529 and https://jira.codehaus.org/browse/SONAR-6530