### PR TITLE
ServerTester don't do startup tasks by default anymore

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/platform/Platform.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/platform/Platform.java
@@ -83,6 +83,10 @@ public class Platform {
 
   // Platform is injected in Pico, so do not rename this method "start"
   public void doStart() {
+    doStart(Startup.ALL);
+  }
+
+  protected void doStart(Startup startup) {
     if (started && !isInSafeMode()) {
       return;
     }
@@ -94,7 +98,7 @@ public class Platform {
       started = true;
     } else {
       startLevel34Containers();
-      executeStartupTasks();
+      executeStartupTasks(startup);
       // switch current container last to avoid giving access to a partially initialized container
       currentContainer = level4Container;
       started = true;
@@ -105,6 +109,10 @@ public class Platform {
   }
 
   public void restart() {
+    restart(Startup.ALL);
+  }
+
+  protected void restart(Startup startup) {
     // switch currentContainer on level1 now to avoid exposing a container in the process of stopping
     currentContainer = level1Container;
 
@@ -115,7 +123,7 @@ public class Platform {
     // no need to initialize database connection, so level 1 is skipped
     startLevel2Container();
     startLevel34Containers();
-    executeStartupTasks();
+    executeStartupTasks(startup);
     currentContainer = level4Container;
   }
 
@@ -175,7 +183,13 @@ public class Platform {
   }
 
   public void executeStartupTasks() {
-    serverComponents.executeStartupTasks(level4Container);
+    executeStartupTasks(Startup.ALL);
+  }
+
+  private void executeStartupTasks(Startup startup) {
+    if (startup.ordinal() >= Startup.ALL.ordinal()) {
+      serverComponents.executeStartupTasks(level4Container);
+    }
   }
 
   private void startSafeModeContainer() {
@@ -255,5 +269,9 @@ public class Platform {
 
   public enum Status {
     BOOTING, SAFEMODE, UP;
+  }
+
+  public enum Startup {
+    NO_STARTUP_TASKS, ALL
   }
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/activity/ws/ActivitiesWsMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/activity/ws/ActivitiesWsMediumTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ActivitiesWsMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester();
+  public static ServerTester tester = new ServerTester().withStartupTasks();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/ws/HistoryActionMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/ws/HistoryActionMediumTest.java
@@ -41,7 +41,7 @@ import java.util.Date;
 public class HistoryActionMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester();
+  public static ServerTester tester = new ServerTester().withStartupTasks();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/IssueBulkChangeServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/IssueBulkChangeServiceMediumTest.java
@@ -62,7 +62,7 @@ import static org.junit.Assert.fail;
 public class IssueBulkChangeServiceMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester();
+  public static ServerTester tester = new ServerTester().withStartupTasks();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/IssueCommentServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/IssueCommentServiceMediumTest.java
@@ -58,7 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class IssueCommentServiceMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester();
+  public static ServerTester tester = new ServerTester().withStartupTasks();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/IssueServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/IssueServiceMediumTest.java
@@ -79,7 +79,7 @@ import static org.junit.Assert.fail;
 public class IssueServiceMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester();
+  public static ServerTester tester = new ServerTester().withStartupTasks();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionComponentsMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionComponentsMediumTest.java
@@ -59,7 +59,7 @@ import static com.google.common.collect.Lists.newArrayList;
 public class SearchActionComponentsMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester();
+  public static ServerTester tester = new ServerTester().withStartupTasks();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionMediumTest.java
@@ -63,7 +63,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SearchActionMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester();
+  public static ServerTester tester = new ServerTester().withStartupTasks();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/permission/InternalPermissionServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/permission/InternalPermissionServiceMediumTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class InternalPermissionServiceMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester();
+  public static ServerTester tester = new ServerTester().withStartupTasks();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/platform/ServerTesterPlatform.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/platform/ServerTesterPlatform.java
@@ -1,0 +1,38 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.platform;
+
+public class ServerTesterPlatform extends Platform {
+  /**
+   * Override to make public
+   */
+  @Override
+  public void doStart(Startup startup) {
+    super.doStart(startup);
+  }
+
+  /**
+   * Override to make public
+   */
+  @Override
+  public void restart(Startup startup) {
+    super.restart(startup);
+  }
+}

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/QProfileExportersTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/QProfileExportersTest.java
@@ -54,7 +54,7 @@ import static org.junit.Assert.fail;
 public class QProfileExportersTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().addXoo().addComponents(
+  public static ServerTester tester = new ServerTester().withStartupTasks().addXoo().addComponents(
     XooRulesDefinition.class, XooProfileDefinition.class,
     XooExporter.class, StandardExporter.class,
     XooProfileImporter.class, XooProfileImporterWithMessages.class, XooProfileImporterWithError.class);

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/QProfileServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/QProfileServiceMediumTest.java
@@ -64,7 +64,7 @@ import static org.sonar.server.qualityprofile.QProfileTesting.XOO_P2_KEY;
 public class QProfileServiceMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().addComponents(XooProfileImporter.class, XooExporter.class);
+  public static ServerTester tester = new ServerTester().withStartupTasks().addComponents(XooProfileImporter.class, XooExporter.class);
   @org.junit.Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/RegisterQualityProfilesMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/RegisterQualityProfilesMediumTest.java
@@ -63,7 +63,7 @@ public class RegisterQualityProfilesMediumTest {
 
   @Test
   public void register_existing_profile_definitions() {
-    tester = new ServerTester().addXoo().addComponents(XooRulesDefinition.class, XooProfileDefinition.class);
+    tester = new ServerTester().withStartupTasks().addXoo().addComponents(XooRulesDefinition.class, XooProfileDefinition.class);
     tester.start();
     dbSession = dbClient().openSession(false);
 
@@ -106,7 +106,7 @@ public class RegisterQualityProfilesMediumTest {
 
   @Test
   public void register_profile_definitions() {
-    tester = new ServerTester().addXoo().addComponents(XooRulesDefinition.class, XooProfileDefinition.class);
+    tester = new ServerTester().withStartupTasks().addXoo().addComponents(XooRulesDefinition.class, XooProfileDefinition.class);
     tester.start();
     dbSession = dbClient().openSession(false);
 
@@ -164,7 +164,7 @@ public class RegisterQualityProfilesMediumTest {
 
   @Test
   public void mark_profile_as_default() {
-    tester = new ServerTester().addXoo().addComponents(new SimpleProfileDefinition("one", false), new SimpleProfileDefinition("two", true));
+    tester = new ServerTester().withStartupTasks().addXoo().addComponents(new SimpleProfileDefinition("one", false), new SimpleProfileDefinition("two", true));
 
     tester.start();
     verifyDefaultProfile("xoo", "two");
@@ -172,7 +172,7 @@ public class RegisterQualityProfilesMediumTest {
 
   @Test
   public void use_sonar_way_as_default_profile_if_none_are_marked_as_default() {
-    tester = new ServerTester().addXoo().addComponents(new SimpleProfileDefinition("Sonar way", false), new SimpleProfileDefinition("Other way", false));
+    tester = new ServerTester().withStartupTasks().addXoo().addComponents(new SimpleProfileDefinition("Sonar way", false), new SimpleProfileDefinition("Other way", false));
 
     tester.start();
     verifyDefaultProfile("xoo", "Sonar way");
@@ -180,7 +180,7 @@ public class RegisterQualityProfilesMediumTest {
 
   @Test
   public void do_not_reset_default_profile_if_still_valid() {
-    tester = new ServerTester().addXoo().addComponents(new SimpleProfileDefinition("one", true), new SimpleProfileDefinition("two", false));
+    tester = new ServerTester().withStartupTasks().addXoo().addComponents(new SimpleProfileDefinition("one", true), new SimpleProfileDefinition("two", false));
     tester.start();
 
     QualityProfileDao profileDao = dbClient().qualityProfileDao();

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/CompareActionMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/CompareActionMediumTest.java
@@ -46,7 +46,7 @@ import org.sonar.server.ws.WsTester;
 public class CompareActionMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().addXoo()
+  public static ServerTester tester = new ServerTester().withStartupTasks().addXoo()
     .addComponents(new RulesDefinition() {
       @Override
       public void define(Context context) {

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/CreateActionMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/CreateActionMediumTest.java
@@ -45,7 +45,7 @@ public class CreateActionMediumTest {
 
   // TODO Replace with simpler test with DbTester / EsTester after removal of DaoV2
   @ClassRule
-  public static ServerTester tester = new ServerTester().addXoo().addComponents(
+  public static ServerTester tester = new ServerTester().withStartupTasks().addXoo().addComponents(
     XooRulesDefinition.class, XooProfileDefinition.class,
     XooExporter.class, StandardExporter.class,
     XooProfileImporter.class, XooProfileImporterWithMessages.class, XooProfileImporterWithError.class);

--- a/server/sonar-server/src/test/java/org/sonar/server/view/index/ViewIndexerMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/view/index/ViewIndexerMediumTest.java
@@ -62,7 +62,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ViewIndexerMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester();
+  public static ServerTester tester = new ServerTester().withStartupTasks();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 


### PR DESCRIPTION
this PR introduces a small (10s faster build on my box) optimization to ServerTester by not launching level5 (ie. startup tasks) by default
unit tests using `ServerTester` must now call `withStartupTasks()` method to trigger startyp tasks when `ServerTester` is created