### PR TITLE
do not create ES indexes for every ServerTester instances

### DIFF
--- a/server/sonar-server/src/test/java/org/sonar/server/activity/ws/ActivitiesWsMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/activity/ws/ActivitiesWsMediumTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ActivitiesWsMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().withStartupTasks();
+  public static ServerTester tester = new ServerTester().withStartupTasks().withEsIndexes();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/ws/HistoryActionMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/ws/HistoryActionMediumTest.java
@@ -41,7 +41,7 @@ import java.util.Date;
 public class HistoryActionMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().withStartupTasks();
+  public static ServerTester tester = new ServerTester().withStartupTasks().withEsIndexes();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/es/EsTester.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/es/EsTester.java
@@ -41,6 +41,7 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.junit.rules.ExternalResource;
+import org.sonar.api.config.Settings;
 import org.sonar.core.platform.ComponentContainer;
 import org.sonar.server.search.BaseDoc;
 import org.sonar.test.TestUtils;
@@ -101,6 +102,7 @@ public class EsTester extends ExternalResource {
 
     if (!definitions.isEmpty()) {
       ComponentContainer container = new ComponentContainer();
+      container.addSingleton(new Settings());
       container.addSingletons(definitions);
       container.addSingleton(client);
       container.addSingleton(IndexDefinitions.class);

--- a/server/sonar-server/src/test/java/org/sonar/server/es/IndexCreatorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/es/IndexCreatorTest.java
@@ -29,6 +29,7 @@ import javax.annotation.CheckForNull;
 
 import java.io.IOException;
 import java.util.Map;
+import org.sonar.api.config.Settings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +42,7 @@ public class IndexCreatorTest {
   public void create_index() throws Exception {
     assertThat(mappings()).isEmpty();
 
-    IndexDefinitions registry = new IndexDefinitions(new IndexDefinition[] {new FakeIndexDefinition()});
+    IndexDefinitions registry = new IndexDefinitions(new IndexDefinition[] {new FakeIndexDefinition()}, new Settings());
     registry.start();
     IndexCreator creator = new IndexCreator(es.client(), registry);
     creator.start();
@@ -66,7 +67,7 @@ public class IndexCreatorTest {
     assertThat(mappings()).isEmpty();
 
     // v1
-    IndexDefinitions registry = new IndexDefinitions(new IndexDefinition[] {new FakeIndexDefinition()});
+    IndexDefinitions registry = new IndexDefinitions(new IndexDefinition[] {new FakeIndexDefinition()}, new Settings());
     registry.start();
     IndexCreator creator = new IndexCreator(es.client(), registry);
     creator.start();
@@ -75,7 +76,7 @@ public class IndexCreatorTest {
     assertThat(hashV1).isNotEmpty();
 
     // v2
-    registry = new IndexDefinitions(new IndexDefinition[] {new FakeIndexDefinitionV2()});
+    registry = new IndexDefinitions(new IndexDefinition[] {new FakeIndexDefinitionV2()}, new Settings());
     registry.start();
     creator = new IndexCreator(es.client(), registry);
     creator.start();

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/IssueBulkChangeServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/IssueBulkChangeServiceMediumTest.java
@@ -62,7 +62,7 @@ import static org.junit.Assert.fail;
 public class IssueBulkChangeServiceMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().withStartupTasks();
+  public static ServerTester tester = new ServerTester().withStartupTasks().withEsIndexes();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/IssueCommentServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/IssueCommentServiceMediumTest.java
@@ -58,7 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class IssueCommentServiceMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().withStartupTasks();
+  public static ServerTester tester = new ServerTester().withStartupTasks().withEsIndexes();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/IssueServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/IssueServiceMediumTest.java
@@ -79,7 +79,7 @@ import static org.junit.Assert.fail;
 public class IssueServiceMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().withStartupTasks();
+  public static ServerTester tester = new ServerTester().withStartupTasks().withEsIndexes();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionComponentsMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionComponentsMediumTest.java
@@ -59,7 +59,7 @@ import static com.google.common.collect.Lists.newArrayList;
 public class SearchActionComponentsMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().withStartupTasks();
+  public static ServerTester tester = new ServerTester().withStartupTasks().withEsIndexes();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/ws/SearchActionMediumTest.java
@@ -63,7 +63,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SearchActionMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().withStartupTasks();
+  public static ServerTester tester = new ServerTester().withStartupTasks().withEsIndexes();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/permission/InternalPermissionServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/permission/InternalPermissionServiceMediumTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class InternalPermissionServiceMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().withStartupTasks();
+  public static ServerTester tester = new ServerTester().withStartupTasks().withEsIndexes();
   @Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/QProfileServiceMediumTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/QProfileServiceMediumTest.java
@@ -64,7 +64,7 @@ import static org.sonar.server.qualityprofile.QProfileTesting.XOO_P2_KEY;
 public class QProfileServiceMediumTest {
 
   @ClassRule
-  public static ServerTester tester = new ServerTester().withStartupTasks().addComponents(XooProfileImporter.class, XooExporter.class);
+  public static ServerTester tester = new ServerTester().withStartupTasks().withEsIndexes().addComponents(XooProfileImporter.class, XooExporter.class);
   @org.junit.Rule
   public UserSessionRule userSessionRule = UserSessionRule.forServerTester(tester);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/tester/ServerTester.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/tester/ServerTester.java
@@ -70,9 +70,15 @@ public class ServerTester extends ExternalResource {
   private final ServletContext servletContext = new AttributeHolderServletContext();
   private URL updateCenterUrl;
   private boolean startupTasks = false;
+  private boolean esIndexes = false;
 
   public ServerTester withStartupTasks() {
     this.startupTasks = true;
+    return this;
+  }
+
+  public ServerTester withEsIndexes() {
+    this.esIndexes = true;
     return this;
   }
 
@@ -110,6 +116,9 @@ public class ServerTester extends ExternalResource {
         if (key.startsWith(PROP_PREFIX)) {
           properties.put(StringUtils.substringAfter(key, PROP_PREFIX), entry.getValue());
         }
+      }
+      if (!esIndexes) {
+        properties.put("sonar.internal.es.disableIndexes", true);
       }
       platform = new ServerTesterPlatform();
       platform.init(properties, servletContext);


### PR DESCRIPTION
now, to use `ServerTester` with ES indexes, one must call `ServerTester.withEsIndexes()`, only few medium test actually require ES indexes