### PR TITLE
SONAR-6730 Create an API for plugins to be able compute new measures

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/ComputationSteps.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/ComputationSteps.java
@@ -67,6 +67,8 @@ public class ComputationSteps {
       // SQALE measures depend on issues
       SqaleMeasuresStep.class,
 
+      ComputePluginMeasuresStep.class,
+
       // Must be executed after computation of all measures
       FillMeasuresWithVariationsStep.class,
 

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/ComputePluginMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/ComputePluginMeasuresStep.java
@@ -1,0 +1,195 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.server.computation.step;
+
+import com.google.common.base.Optional;
+import java.util.List;
+import org.sonar.api.config.Settings;
+import org.sonar.api.measures.MetricDefinition;
+import org.sonar.server.computation.component.DepthTraversalTypeAwareVisitor;
+import org.sonar.server.computation.component.ProjectSettingsRepository;
+import org.sonar.server.computation.component.TreeRootHolder;
+import org.sonar.server.computation.measure.MeasureRepository;
+import org.sonar.server.computation.metric.MetricRepository;
+
+import static org.sonar.server.computation.component.Component.Type.FILE;
+import static org.sonar.server.computation.component.ComponentVisitor.Order.PRE_ORDER;
+import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
+
+/**
+ * TODO
+ */
+public class ComputePluginMeasuresStep implements ComputationStep {
+
+  private final TreeRootHolder treeRootHolder;
+  private final MetricRepository metricRepository;
+  private final MeasureRepository measureRepository;
+
+  // TODO We should not inject MetricsDefinition[] but a list of Metrics (took from the parent pico)
+  private final MetricDefinition[] metricDefinitions;
+  private final ProjectSettingsRepository settings;
+
+  public ComputePluginMeasuresStep(TreeRootHolder treeRootHolder, MetricRepository metricRepository, MeasureRepository measureRepository, MetricDefinition[] metricDefinitions,
+    ProjectSettingsRepository settings) {
+    this.treeRootHolder = treeRootHolder;
+    this.metricRepository = metricRepository;
+    this.measureRepository = measureRepository;
+    this.metricDefinitions = metricDefinitions;
+    this.settings = settings;
+  }
+
+  @Override
+  public void execute() {
+    new NewMetricDefinitionsVisitor().visit(treeRootHolder.getRoot());
+  }
+
+  private class NewMetricDefinitionsVisitor extends DepthTraversalTypeAwareVisitor {
+    public NewMetricDefinitionsVisitor() {
+      super(FILE, PRE_ORDER);
+    }
+
+    @Override
+    public void visitAny(org.sonar.server.computation.component.Component component) {
+      MetricDefinition.NewMetricContext newMetricContext = new MetricDefinition.NewMetricContext();
+      for (MetricDefinition metricDefinition : metricDefinitions) {
+        metricDefinition.define(newMetricContext);
+      }
+
+      // TODO use DirectAcyclicGraph to execute measure computation in the right order
+      for (MetricDefinition.Metric metric : newMetricContext.getMetrics()) {
+        MeasureComputerContextImpl measureComputerContext = new MeasureComputerContextImpl(component, metric);
+        metric.getComputer().getMeasureComputer().compute(measureComputerContext);
+      }
+    }
+  }
+
+  @Override
+  public String getDescription() {
+    return "Compute measures from plugin";
+  }
+
+  private class MeasureComputerContextImpl implements MetricDefinition.MeasureComputerContext {
+
+    private final org.sonar.server.computation.component.Component component;
+    private final MetricDefinition.Metric metricDefinition;
+
+    public MeasureComputerContextImpl(org.sonar.server.computation.component.Component component, MetricDefinition.Metric metricDefinition) {
+      this.component = component;
+      this.metricDefinition = metricDefinition;
+    }
+
+    @Override
+    public Settings getSettings() {
+      return settings.getProjectSettings(component.getKey());
+    }
+
+    @Override
+    public MetricDefinition.Component getComponent() {
+      return new ComponentImpl(component);
+    }
+
+    @Override
+    public MetricDefinition.Measure getMeasure(String metricKey) {
+      // TODO Validate that this metric owns to the metric input metrics
+      Optional<org.sonar.server.computation.measure.Measure> measure = measureRepository.getRawMeasure(component, metricRepository.getByKey(metricKey));
+      if (measure.isPresent()) {
+        return new MeasureImpl(measure.get());
+      }
+      return null;
+    }
+
+    @Override
+    public List<MetricDefinition.Measure> getChildrenMeasures(String metricKey) {
+      // TODO Validate that this metric owns to the metric input metrics
+      return null;
+    }
+
+    @Override
+    public void saveMeasure(int value) {
+      measureRepository.add(component, metricRepository.getByKey(metricDefinition.getKey()), newMeasureBuilder().create(value));
+    }
+
+    @Override
+    public void saveMeasure(double value) {
+      measureRepository.add(component, metricRepository.getByKey(metricDefinition.getKey()), newMeasureBuilder().create(value));
+    }
+
+    @Override
+    public void saveMeasure(long value) {
+      measureRepository.add(component, metricRepository.getByKey(metricDefinition.getKey()), newMeasureBuilder().create(value));
+    }
+
+    @Override
+    public void saveMeasure(String value) {
+      measureRepository.add(component, metricRepository.getByKey(metricDefinition.getKey()), newMeasureBuilder().create(value));
+    }
+  }
+
+  private static class ComponentImpl implements MetricDefinition.Component {
+
+    private final Type type;
+    private final boolean isUnitTest;
+
+    public ComponentImpl(org.sonar.server.computation.component.Component component) {
+      this.type = Type.valueOf(component.getType().name());
+      this.isUnitTest = component.getFileAttributes().isUnitTest();
+    }
+
+    @Override
+    public Type getType() {
+      return type;
+    }
+
+    @Override
+    public boolean isUnitTest() {
+      return isUnitTest;
+    }
+  }
+
+  private static class MeasureImpl implements MetricDefinition.Measure {
+
+    private final org.sonar.server.computation.measure.Measure measure;
+
+    private MeasureImpl(org.sonar.server.computation.measure.Measure measure) {
+      this.measure = measure;
+    }
+
+    @Override
+    public int getIntValue() {
+      return measure.getIntValue();
+    }
+
+    @Override
+    public long getLongValue() {
+      return measure.getLongValue();
+    }
+
+    @Override
+    public double getDoubleValue() {
+      return measure.getDoubleValue();
+    }
+
+    @Override
+    public String getStringValue() {
+      return measure.getStringValue();
+    }
+  }
+}

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ComputePluginMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ComputePluginMeasuresStepTest.java
@@ -1,0 +1,132 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.server.computation.step;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.api.measures.MetricDefinition;
+import org.sonar.server.computation.batch.TreeRootHolderRule;
+import org.sonar.server.computation.measure.MeasureRepositoryRule;
+import org.sonar.server.computation.metric.Metric;
+import org.sonar.server.computation.metric.MetricImpl;
+import org.sonar.server.computation.metric.MetricRepositoryRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.api.measures.CoreMetrics.COMMENT_LINES;
+import static org.sonar.api.measures.CoreMetrics.COMMENT_LINES_KEY;
+import static org.sonar.api.measures.CoreMetrics.NCLOC;
+import static org.sonar.api.measures.CoreMetrics.NCLOC_KEY;
+import static org.sonar.server.computation.component.Component.Type.DIRECTORY;
+import static org.sonar.server.computation.component.Component.Type.FILE;
+import static org.sonar.server.computation.component.Component.Type.MODULE;
+import static org.sonar.server.computation.component.Component.Type.PROJECT;
+import static org.sonar.server.computation.component.DumbComponent.builder;
+import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
+import static org.sonar.server.computation.measure.MeasureRepoEntry.entryOf;
+import static org.sonar.server.computation.measure.MeasureRepoEntry.toEntries;
+
+public class ComputePluginMeasuresStepTest {
+
+  private static final String NEW_METRIC_KEY = "new_metric_key";
+  private static final String NEW_METRIC_NAME = "new metric name";
+
+  private static final int ROOT_REF = 1;
+  private static final int MODULE_REF = 12;
+  private static final int DIRECTORY_REF = 123;
+  private static final int FILE_1_REF = 1231;
+  private static final int FILE_2_REF = 1232;
+
+  @Rule
+  public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule();
+
+  @Rule
+  public MetricRepositoryRule metricRepository = new MetricRepositoryRule()
+    .add(1, NCLOC)
+    .add(2, COMMENT_LINES)
+    .add(new MetricImpl(3, NEW_METRIC_KEY, NEW_METRIC_NAME, Metric.MetricType.INT));
+
+  @Rule
+  public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
+
+  @Before
+  public void setUp() throws Exception {
+    treeRootHolder.setRoot(
+      builder(PROJECT, ROOT_REF)
+        .addChildren(
+          builder(MODULE, MODULE_REF)
+            .addChildren(
+              builder(DIRECTORY, DIRECTORY_REF)
+                .addChildren(
+                  builder(FILE, FILE_1_REF).build(),
+                  builder(FILE, FILE_2_REF).build()
+                ).build()
+            ).build()
+        ).build());
+  }
+
+  @Test
+  public void compute_plugin_measure() throws Exception {
+    measureRepository.addRawMeasure(FILE_1_REF, NCLOC_KEY, newMeasureBuilder().create(10));
+    measureRepository.addRawMeasure(FILE_1_REF, COMMENT_LINES_KEY, newMeasureBuilder().create(2));
+    measureRepository.addRawMeasure(FILE_2_REF, NCLOC_KEY, newMeasureBuilder().create(40));
+    measureRepository.addRawMeasure(FILE_2_REF, COMMENT_LINES_KEY, newMeasureBuilder().create(5));
+    measureRepository.addRawMeasure(DIRECTORY_REF, NCLOC_KEY, newMeasureBuilder().create(50));
+    measureRepository.addRawMeasure(DIRECTORY_REF, COMMENT_LINES_KEY, newMeasureBuilder().create(7));
+    measureRepository.addRawMeasure(MODULE_REF, NCLOC_KEY, newMeasureBuilder().create(50));
+    measureRepository.addRawMeasure(MODULE_REF, COMMENT_LINES_KEY, newMeasureBuilder().create(7));
+    measureRepository.addRawMeasure(ROOT_REF, NCLOC_KEY, newMeasureBuilder().create(50));
+    measureRepository.addRawMeasure(ROOT_REF, COMMENT_LINES_KEY, newMeasureBuilder().create(7));
+
+    MetricDefinition[] metricDefinitions = new MetricDefinition[]{new NewMetricDefinition()};
+    ComputationStep underTest = new ComputePluginMeasuresStep(treeRootHolder, metricRepository, measureRepository, metricDefinitions, null);
+    underTest.execute();
+
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(FILE_1_REF))).containsOnly(entryOf(NEW_METRIC_KEY, newMeasureBuilder().create(12)));
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(FILE_2_REF))).containsOnly(entryOf(NEW_METRIC_KEY, newMeasureBuilder().create(45)));
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(DIRECTORY_REF))).containsOnly(entryOf(NEW_METRIC_KEY, newMeasureBuilder().create(57)));
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(MODULE_REF))).containsOnly(entryOf(NEW_METRIC_KEY, newMeasureBuilder().create(57)));
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(ROOT_REF))).containsOnly(entryOf(NEW_METRIC_KEY, newMeasureBuilder().create(57)));
+  }
+
+  public class NewMetricDefinition implements MetricDefinition {
+    @Override
+    public void define(NewMetricContext newMetricContext) {
+      newMetricContext.createNewMetric()
+        .setKey(NEW_METRIC_KEY)
+        .setName(NEW_METRIC_NAME)
+        .createMeasureComputer()
+        .setInputMetricKeys(NCLOC_KEY, COMMENT_LINES_KEY)
+        .setMeasureComputer(new MetricDefinition.MeasureComputer() {
+          @Override
+          public void compute(MetricDefinition.MeasureComputerContext context) {
+            Measure ncloc = context.getMeasure(NCLOC_KEY);
+            Measure comment = context.getMeasure(COMMENT_LINES_KEY);
+            if (ncloc != null && comment != null) {
+              context.saveMeasure(ncloc.getIntValue() + comment.getIntValue());
+            }
+          }
+        })
+        .done()
+        .done();
+    }
+  }
+}

--- a/sonar-plugin-api/src/main/java/org/sonar/api/measures/MetricDefinition.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/measures/MetricDefinition.java
@@ -1,0 +1,265 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.api.measures;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.CheckForNull;
+import org.sonar.api.config.Settings;
+
+/**
+ * TODO
+ *
+ *
+ */
+public interface MetricDefinition {
+
+  class NewMetricContext {
+    private final Map<String, Metric> metricsByKey = Maps.newHashMap();
+
+    public NewMetric createNewMetric() {
+      return new NewMetricImpl(this);
+    }
+
+    @CheckForNull
+    public Metric getMetric(String metricKey) {
+      return metricsByKey.get(metricKey);
+    }
+
+    public List<Metric> getMetrics(){
+      return ImmutableList.copyOf(metricsByKey.values());
+    }
+
+    private void registerMetric(NewMetricImpl newMetric) {
+      // TODO check metric does not already exists
+      metricsByKey.put(newMetric.key, new MetricImpl(newMetric));
+    }
+  }
+
+  interface NewMetric {
+    NewMetric setKey(String s);
+
+    NewMetric setName(String s);
+
+    // TODO add all fields needed on metric : domain, type, best value, direction, qualitative, etc.
+
+    NewComputer createMeasureComputer();
+
+    void done();
+  }
+
+  class NewMetricImpl implements NewMetric {
+    private final NewMetricContext context;
+
+    private String key;
+
+    private String name;
+
+    private Computer computer;
+
+    public NewMetricImpl(NewMetricContext context) {
+      this.context = context;
+    }
+
+    @Override
+    public NewMetric setKey(String s) {
+      this.key = s;
+      return this;
+    }
+
+    @Override
+    public NewMetric setName(String s) {
+      this.name = s;
+      return this;
+    }
+
+    @Override
+    public NewComputer createMeasureComputer() {
+      return new NewComputerImpl(this);
+    }
+
+    void setNewComputerImpl(NewComputerImpl newComputer){
+      this.computer = new ComputerImpl(newComputer);
+    }
+
+    @Override
+    public void done() {
+      // TODO fail if no computer
+      context.registerMetric(this);
+    }
+  }
+
+  interface Metric {
+    String getKey();
+
+    String getName();
+
+    Computer getComputer();
+  }
+
+  class MetricImpl implements Metric {
+    private final String key;
+    private final String name;
+    private final Computer computer;
+
+    public MetricImpl(NewMetricImpl newMetric) {
+      this.key = newMetric.key;
+      this.name = newMetric.name;
+      this.computer = newMetric.computer;
+    }
+
+    @Override
+    public String getKey() {
+      return key;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public Computer getComputer() {
+      return computer;
+    }
+
+    @Override
+    public String toString() {
+      return "Metric{" +
+        "key='" + key + '\'' +
+        '}';
+    }
+  }
+
+  interface NewComputer {
+    NewComputer setInputMetricKeys(String... metricKeys);
+
+    NewComputer setMeasureComputer(MeasureComputer measureComputer);
+
+    NewMetric done();
+  }
+
+  class NewComputerImpl implements NewComputer {
+
+    private final NewMetricImpl newMetric;
+
+    public NewComputerImpl(NewMetricImpl newMetric) {
+      this.newMetric = newMetric;
+    }
+
+    private String[] inputMetricKeys;
+    private MeasureComputer measureComputer;
+
+    @Override
+    public NewComputer setInputMetricKeys(String... metricKeys) {
+      this.inputMetricKeys = metricKeys;
+      return this;
+    }
+
+    @Override
+    public NewComputer setMeasureComputer(MeasureComputer measureComputer) {
+      this.measureComputer = measureComputer;
+      return this;
+    }
+
+    @Override
+    public NewMetric done() {
+      // TODO fail if no metrics or no computer
+      newMetric.setNewComputerImpl(this);
+      return newMetric;
+    }
+  }
+
+  interface MeasureComputer {
+    void compute(MeasureComputerContext context);
+  }
+
+  interface MeasureComputerContext {
+    Settings getSettings();
+
+    Component getComponent();
+
+    @CheckForNull
+    Measure getMeasure(String metric);
+
+    List<Measure> getChildrenMeasures(String metric);
+
+    void saveMeasure(int value);
+
+    void saveMeasure(double value);
+
+    void saveMeasure(long value);
+
+    void saveMeasure(String value);
+  }
+
+  interface Measure {
+    int getIntValue();
+
+    long getLongValue();
+
+    double getDoubleValue();
+
+    String getStringValue();
+  }
+
+  interface Component {
+    enum Type {
+      PROJECT, MODULE, DIRECTORY, FILE
+    }
+
+    Type getType();
+
+    boolean isUnitTest();
+  }
+
+  interface Computer {
+    String[] getInputMetricKeys();
+
+    MeasureComputer getMeasureComputer();
+  }
+
+  class ComputerImpl implements Computer {
+
+    private final String[] inputMetricKeys;
+    private final MeasureComputer measureComputer;
+
+    public ComputerImpl(NewComputerImpl newComputer) {
+      this.inputMetricKeys = newComputer.inputMetricKeys;
+      this.measureComputer = newComputer.measureComputer;
+    }
+
+    @Override
+    public String[] getInputMetricKeys() {
+      return inputMetricKeys;
+    }
+
+    @Override
+    public MeasureComputer getMeasureComputer() {
+      return measureComputer;
+    }
+  }
+
+  void define(NewMetricContext newMetricContext);
+
+}

--- a/sonar-plugin-api/src/test/java/org/sonar/api/measures/MetricDefinitionTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/measures/MetricDefinitionTest.java
@@ -1,0 +1,57 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.api.measures;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricDefinitionTest {
+
+  MetricDefinition.NewMetricContext newMetricContext = new MetricDefinition.NewMetricContext();
+
+  @Test
+  public void define_metric() throws Exception {
+    assertThat(newMetricContext.getMetrics()).isEmpty();
+
+    newMetricContext.createNewMetric()
+      .setKey("key")
+      .setName("name")
+      .createMeasureComputer()
+      .setInputMetricKeys("key1", "key2")
+      .setMeasureComputer(new MetricDefinition.MeasureComputer() {
+        @Override
+        public void compute(MetricDefinition.MeasureComputerContext context) {
+
+        }
+      })
+      .done()
+      .done();
+
+    assertThat(newMetricContext.getMetrics()).hasSize(1);
+
+    MetricDefinition.Metric metric = newMetricContext.getMetric("key");
+    assertThat(metric).isNotNull();
+    assertThat(metric.getKey()).isEqualTo("key");
+    assertThat(metric.getName()).isEqualTo("name");
+    assertThat(metric.getComputer()).isNotNull();
+  }
+}


### PR DESCRIPTION
First PR to get feedback on the MetricsDefinition API.
Exemple of its usage can be found in MetricsDefinitionTest or ComputePluginMeasuresStepTest

Not yet done : 
- Usage of the DAG to get ordered metrics
- Registration of metrics in RegisterMetrics and injection of the list of metrics in the step