### PR TITLE
Changes in SQ to make views run and extends supported measures

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/AverageFormula.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/AverageFormula.java
@@ -123,7 +123,7 @@ public class AverageFormula implements Formula<AverageFormula.AverageCounter> {
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
+    public void initialize(CounterInitializationContext context) {
       Optional<Double> mainValueOptional = getDoubleValue(context.getMeasure(mainMetric));
       if (!mainValueOptional.isPresent() && fallbackMetric != null) {
         mainValueOptional = getDoubleValue(context.getMeasure(fallbackMetric));

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/Counter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/Counter.java
@@ -28,14 +28,15 @@ import static org.sonar.server.computation.component.Component.Type;
 public interface Counter<T extends Counter<T>> {
 
   /**
-   * This method is used on not leaf levels, to aggregate the value of counter from a child
+   * This method is used on not leaf levels, to aggregate the value of the specified counter of a child to the counter
+   * of the current component.
    */
   void aggregate(T counter);
 
   /**
-   * This method is called on {@link Type#FILE} or {@link Type#PROJECT_VIEW} levels (aka. leaf levels), in order to
-   * populate the counter with one or more leaf measures.
+   * This method is called on leaves of the Component tree (usually a {@link Type#FILE} or a {@link Type#PROJECT_VIEW}
+   * but can also be a {@link Type#SUBVIEW} or {@link Type#VIEW}) to initialize the counter.
    */
-  void aggregate(LeafAggregateContext context);
+  void initialize(CounterInitializationContext context);
 
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/CounterInitializationContext.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/CounterInitializationContext.java
@@ -27,9 +27,9 @@ import org.sonar.server.computation.measure.Measure;
 import org.sonar.server.computation.period.Period;
 
 /**
- * The context passing information to {@link Counter#aggregate(LeafAggregateContext)}.
+ * The context passing information to {@link Counter#initialize(CounterInitializationContext)}.
  */
-public interface LeafAggregateContext {
+public interface CounterInitializationContext {
 
   /**
    * The Component representing the currently processed leaf.

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/DistributionFormula.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/DistributionFormula.java
@@ -68,7 +68,7 @@ public class DistributionFormula implements Formula<DistributionFormula.Distribu
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
+    public void initialize(CounterInitializationContext context) {
       Optional<Measure> measureOptional = context.getMeasure(metricKey);
       String data = measureOptional.isPresent() ? measureOptional.get().getData() : null;
       if (data != null) {

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/DistributionFormula.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/DistributionFormula.java
@@ -21,16 +21,18 @@
 package org.sonar.server.computation.formula;
 
 import com.google.common.base.Optional;
-import java.util.Objects;
 import org.sonar.server.computation.component.Component;
+import org.sonar.server.computation.component.CrawlerDepthLimit;
 import org.sonar.server.computation.measure.Measure;
+
+import static java.util.Objects.requireNonNull;
 
 public class DistributionFormula implements Formula<DistributionFormula.DistributionCounter> {
 
   private final String metricKey;
 
   public DistributionFormula(String metricKey) {
-    this.metricKey = Objects.requireNonNull(metricKey, "Metric key cannot be null");
+    this.metricKey = requireNonNull(metricKey, "Metric key cannot be null");
   }
 
   @Override
@@ -42,7 +44,7 @@ public class DistributionFormula implements Formula<DistributionFormula.Distribu
   public Optional<Measure> createMeasure(DistributionCounter counter, CreateMeasureContext context) {
     Component.Type componentType = context.getComponent().getType();
     Optional<String> value = counter.getValue();
-    if (value.isPresent() && componentType.isHigherThan(Component.Type.FILE)) {
+    if (value.isPresent() && CrawlerDepthLimit.LEAVES.isDeeperThan(componentType)) {
       return Optional.of(Measure.newMeasureBuilder().create(value.get()));
     }
     return Optional.absent();

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/FormulaExecutorComponentVisitor.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/FormulaExecutorComponentVisitor.java
@@ -151,10 +151,10 @@ public class FormulaExecutorComponentVisitor extends PathAwareVisitorAdapter<For
   }
 
   private void processLeaf(Component file, Path<FormulaExecutorComponentVisitor.Counters> path) {
-    LeafAggregateContext counterContext = new LeafAggregateContextImpl(file);
+    CounterInitializationContext counterContext = new CounterInitializationContextImpl(file);
     for (Formula formula : formulas) {
       Counter counter = formula.createNewCounter();
-      counter.aggregate(counterContext);
+      counter.initialize(counterContext);
       for (String metricKey : formula.getOutputMetricKeys()) {
         addNewMeasure(file, metricKey, formula, counter);
       }
@@ -180,10 +180,10 @@ public class FormulaExecutorComponentVisitor extends PathAwareVisitorAdapter<For
     }
   }
 
-  private class LeafAggregateContextImpl implements LeafAggregateContext {
+  private class CounterInitializationContextImpl implements CounterInitializationContext {
     private final Component file;
 
-    public LeafAggregateContextImpl(Component file) {
+    public CounterInitializationContextImpl(Component file) {
       this.file = file;
     }
 

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/FormulaExecutorComponentVisitor.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/FormulaExecutorComponentVisitor.java
@@ -65,7 +65,7 @@ public class FormulaExecutorComponentVisitor extends PathAwareVisitorAdapter<For
   private final MeasureRepository measureRepository;
   private final List<Formula> formulas;
 
-  private FormulaExecutorComponentVisitor(Builder builder, List<Formula> formulas) {
+  private FormulaExecutorComponentVisitor(Builder builder, Iterable<Formula> formulas) {
     super(CrawlerDepthLimit.LEAVES, ComponentVisitor.Order.POST_ORDER, COUNTERS_FACTORY);
     this.periodsHolder = builder.periodsHolder;
     this.measureRepository = builder.measureRepository;
@@ -97,7 +97,7 @@ public class FormulaExecutorComponentVisitor extends PathAwareVisitorAdapter<For
       return this;
     }
 
-    public FormulaExecutorComponentVisitor buildFor(List<Formula> formulas) {
+    public FormulaExecutorComponentVisitor buildFor(Iterable<Formula> formulas) {
       return new FormulaExecutorComponentVisitor(this, formulas);
     }
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/counter/IntSumCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/counter/IntSumCounter.java
@@ -21,7 +21,7 @@
 package org.sonar.server.computation.formula.counter;
 
 import com.google.common.base.Optional;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.measure.Measure;
 
 /**
@@ -46,7 +46,7 @@ public class IntSumCounter implements SumCounter<Integer, IntSumCounter> {
   }
 
   @Override
-  public void aggregate(LeafAggregateContext context) {
+  public void initialize(CounterInitializationContext context) {
     Optional<Measure> measureOptional = context.getMeasure(metricKey);
     if (measureOptional.isPresent()) {
       addValue(measureOptional.get().getIntValue());

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/counter/LongSumCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/counter/LongSumCounter.java
@@ -21,7 +21,7 @@
 package org.sonar.server.computation.formula.counter;
 
 import com.google.common.base.Optional;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.measure.Measure;
 
 /**
@@ -46,7 +46,7 @@ public class LongSumCounter implements SumCounter<Long, LongSumCounter> {
   }
 
   @Override
-  public void aggregate(LeafAggregateContext context) {
+  public void initialize(CounterInitializationContext context) {
     Optional<Measure> measureOptional = context.getMeasure(metricKey);
     if (measureOptional.isPresent()) {
       addValue(measureOptional.get().getLongValue());

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/CoverageUtils.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/CoverageUtils.java
@@ -20,9 +20,6 @@
 package org.sonar.server.computation.formula.coverage;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import java.util.List;
-import javax.annotation.Nonnull;
 import org.sonar.server.computation.component.Component;
 import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.formula.CreateMeasureContext;
@@ -32,6 +29,7 @@ import org.sonar.server.computation.period.Period;
 
 import static com.google.common.collect.FluentIterable.from;
 import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
+import static org.sonar.server.computation.period.PeriodPredicates.viewsRestrictedPeriods;
 
 public final class CoverageUtils {
   private static final Measure DEFAULT_MEASURE = newMeasureBuilder().create(0L);
@@ -87,19 +85,11 @@ public final class CoverageUtils {
     return supportedPeriods(context.getLeaf().getType(), context.getPeriods());
   }
 
-  private static Iterable<Period> supportedPeriods(Component.Type type, List<Period> periods) {
+  private static Iterable<Period> supportedPeriods(Component.Type type, Iterable<Period> periods) {
     if (type.isReportType()) {
       return periods;
     }
-    return from(periods).filter(ViewsSupportedPeriods.INSTANCE);
+    return from(periods).filter(viewsRestrictedPeriods());
   }
 
-  private enum ViewsSupportedPeriods implements Predicate<Period> {
-    INSTANCE;
-
-    @Override
-    public boolean apply(@Nonnull Period input) {
-      return input.getIndex() < 4;
-    }
-  }
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/CoverageUtils.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/CoverageUtils.java
@@ -20,7 +20,7 @@
 package org.sonar.server.computation.formula.coverage;
 
 import com.google.common.base.Optional;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.measure.Measure;
 import org.sonar.server.computation.measure.MeasureVariations;
 import org.sonar.server.computation.period.Period;
@@ -39,7 +39,7 @@ public final class CoverageUtils {
     return (100.0 * coveredLines) / lines;
   }
 
-  static long getLongMeasureValue(LeafAggregateContext counterContext, String metricKey) {
+  static long getLongMeasureValue(CounterInitializationContext counterContext, String metricKey) {
     Measure measure = counterContext.getMeasure(metricKey).or(DEFAULT_MEASURE);
     if (measure.getValueType() == Measure.ValueType.NO_VALUE) {
       return 0L;
@@ -50,7 +50,7 @@ public final class CoverageUtils {
     return measure.getLongValue();
   }
 
-  static MeasureVariations getMeasureVariations(LeafAggregateContext counterContext, String metricKey) {
+  static MeasureVariations getMeasureVariations(CounterInitializationContext counterContext, String metricKey) {
     Optional<Measure> measure = counterContext.getMeasure(metricKey);
     if (!measure.isPresent() || !measure.get().hasVariations()) {
       return DEFAULT_VARIATIONS;

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/CoverageVariationFormula.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/CoverageVariationFormula.java
@@ -28,6 +28,7 @@ import org.sonar.server.computation.measure.MeasureVariations;
 import org.sonar.server.computation.period.Period;
 
 import static org.sonar.server.computation.formula.coverage.CoverageUtils.calculateCoverage;
+import static org.sonar.server.computation.formula.coverage.CoverageUtils.supportedPeriods;
 import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
 
 /**
@@ -48,7 +49,7 @@ public abstract class CoverageVariationFormula<T extends ElementsAndCoveredEleme
 
   private MeasureVariations.Builder createAndPopulateBuilder(T counter, CreateMeasureContext context) {
     MeasureVariations.Builder builder = MeasureVariations.newMeasureVariationsBuilder();
-    for (Period period : context.getPeriods()) {
+    for (Period period : supportedPeriods(context)) {
       LongVariationValue elements = counter.elements.get(period);
       if (elements.isSet() && elements.getValue() > 0d) {
         LongVariationValue coveredElements = counter.coveredElements.get(period);
@@ -57,5 +58,4 @@ public abstract class CoverageVariationFormula<T extends ElementsAndCoveredEleme
     }
     return builder;
   }
-
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/ElementsAndCoveredElementsCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/ElementsAndCoveredElementsCounter.java
@@ -21,7 +21,7 @@ package org.sonar.server.computation.formula.coverage;
 
 import org.sonar.server.computation.component.Component;
 import org.sonar.server.computation.formula.Counter;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 
 /**
  * A counter used to create a measure which are based on a count of elements and coveredElements.
@@ -37,13 +37,13 @@ public abstract class ElementsAndCoveredElementsCounter implements Counter<Eleme
   }
 
   @Override
-  public void aggregate(LeafAggregateContext context) {
+  public void initialize(CounterInitializationContext context) {
     Component component = context.getLeaf();
     if (component.getType().isReportType() && component.getFileAttributes().isUnitTest()) {
       return;
     }
-    aggregateForSupportedLeaf(context);
+    initializeForSupportedLeaf(context);
   }
 
-  protected abstract void aggregateForSupportedLeaf(LeafAggregateContext counterContext);
+  protected abstract void initializeForSupportedLeaf(CounterInitializationContext counterContext);
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/ElementsAndCoveredElementsVariationCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/ElementsAndCoveredElementsVariationCounter.java
@@ -38,7 +38,7 @@ public abstract class ElementsAndCoveredElementsVariationCounter implements Coun
 
   @Override
   public void initialize(CounterInitializationContext context) {
-    if (context.getLeaf().getFileAttributes().isUnitTest()) {
+    if (context.getLeaf().getType().isReportType() && context.getLeaf().getFileAttributes().isUnitTest()) {
       return;
     }
     initializeForSupportedLeaf(context);

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/ElementsAndCoveredElementsVariationCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/ElementsAndCoveredElementsVariationCounter.java
@@ -20,7 +20,7 @@
 package org.sonar.server.computation.formula.coverage;
 
 import org.sonar.server.computation.formula.Counter;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.formula.counter.LongVariationValue;
 
 /**
@@ -37,12 +37,12 @@ public abstract class ElementsAndCoveredElementsVariationCounter implements Coun
   }
 
   @Override
-  public void aggregate(LeafAggregateContext context) {
+  public void initialize(CounterInitializationContext context) {
     if (context.getLeaf().getFileAttributes().isUnitTest()) {
       return;
     }
-    aggregateForSupportedFile(context);
+    initializeForSupportedLeaf(context);
   }
 
-  protected abstract void aggregateForSupportedFile(LeafAggregateContext counterContext);
+  protected abstract void initializeForSupportedLeaf(CounterInitializationContext counterContext);
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/LinesAndConditionsWithUncoveredCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/LinesAndConditionsWithUncoveredCounter.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.server.computation.formula.coverage;
 
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 
 import static org.sonar.server.computation.formula.coverage.CoverageUtils.getLongMeasureValue;
 
@@ -31,7 +31,7 @@ public final class LinesAndConditionsWithUncoveredCounter extends ElementsAndCov
   }
 
   @Override
-  protected void aggregateForSupportedLeaf(LeafAggregateContext counterContext) {
+  protected void initializeForSupportedLeaf(CounterInitializationContext counterContext) {
     this.elements = getLongMeasureValue(counterContext, metricKeys.getLines())
       + getLongMeasureValue(counterContext, metricKeys.getConditions());
     this.coveredElements = this.elements

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/LinesAndConditionsWithUncoveredVariationCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/LinesAndConditionsWithUncoveredVariationCounter.java
@@ -25,6 +25,8 @@ import org.sonar.server.computation.measure.Measure;
 import org.sonar.server.computation.measure.MeasureVariations;
 import org.sonar.server.computation.period.Period;
 
+import static org.sonar.server.computation.formula.coverage.CoverageUtils.supportedPeriods;
+
 public final class LinesAndConditionsWithUncoveredVariationCounter extends ElementsAndCoveredElementsVariationCounter {
   private final LinesAndConditionsWithUncoveredMetricKeys metricKeys;
 
@@ -43,7 +45,7 @@ public final class LinesAndConditionsWithUncoveredVariationCounter extends Eleme
     MeasureVariations newConditions = CoverageUtils.getMeasureVariations(counterContext, metricKeys.getConditions());
     MeasureVariations uncoveredLines = CoverageUtils.getMeasureVariations(counterContext, metricKeys.getUncoveredLines());
     MeasureVariations uncoveredConditions = CoverageUtils.getMeasureVariations(counterContext, metricKeys.getUncoveredConditions());
-    for (Period period : counterContext.getPeriods()) {
+    for (Period period : supportedPeriods(counterContext)) {
       if (!newLines.hasVariation(period.getIndex())) {
         continue;
       }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/LinesAndConditionsWithUncoveredVariationCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/LinesAndConditionsWithUncoveredVariationCounter.java
@@ -25,6 +25,7 @@ import org.sonar.server.computation.measure.Measure;
 import org.sonar.server.computation.measure.MeasureVariations;
 import org.sonar.server.computation.period.Period;
 
+import static org.sonar.server.computation.formula.coverage.CoverageUtils.getLongVariation;
 import static org.sonar.server.computation.formula.coverage.CoverageUtils.supportedPeriods;
 
 public final class LinesAndConditionsWithUncoveredVariationCounter extends ElementsAndCoveredElementsVariationCounter {
@@ -49,11 +50,11 @@ public final class LinesAndConditionsWithUncoveredVariationCounter extends Eleme
       if (!newLines.hasVariation(period.getIndex())) {
         continue;
       }
-      long elements = (long) newLines.getVariation(period.getIndex()) + CoverageUtils.getLongVariation(newConditions, period);
+      long elements = (long) newLines.getVariation(period.getIndex()) + getLongVariation(newConditions, period);
       this.elements.increment(period, elements);
       coveredElements.increment(
         period,
-        elements - CoverageUtils.getLongVariation(uncoveredConditions, period) - CoverageUtils.getLongVariation(uncoveredLines, period));
+        elements - getLongVariation(uncoveredConditions, period) - getLongVariation(uncoveredLines, period));
     }
   }
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/LinesAndConditionsWithUncoveredVariationCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/LinesAndConditionsWithUncoveredVariationCounter.java
@@ -20,7 +20,7 @@
 package org.sonar.server.computation.formula.coverage;
 
 import com.google.common.base.Optional;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.measure.Measure;
 import org.sonar.server.computation.measure.MeasureVariations;
 import org.sonar.server.computation.period.Period;
@@ -33,7 +33,7 @@ public final class LinesAndConditionsWithUncoveredVariationCounter extends Eleme
   }
 
   @Override
-  public void aggregateForSupportedFile(LeafAggregateContext counterContext) {
+  public void initializeForSupportedLeaf(CounterInitializationContext counterContext) {
     Optional<Measure> newLinesMeasure = counterContext.getMeasure(metricKeys.getLines());
     if (!newLinesMeasure.isPresent() || !newLinesMeasure.get().hasVariations()) {
       return;

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/NewCoverageVariationSumFormula.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/NewCoverageVariationSumFormula.java
@@ -1,0 +1,110 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.computation.formula.coverage;
+
+import com.google.common.base.Optional;
+import org.sonar.server.computation.component.CrawlerDepthLimit;
+import org.sonar.server.computation.formula.Counter;
+import org.sonar.server.computation.formula.CounterInitializationContext;
+import org.sonar.server.computation.formula.CreateMeasureContext;
+import org.sonar.server.computation.formula.Formula;
+import org.sonar.server.computation.formula.counter.DoubleVariationValue;
+import org.sonar.server.computation.measure.Measure;
+import org.sonar.server.computation.measure.MeasureVariations;
+import org.sonar.server.computation.period.Period;
+
+import static java.util.Objects.requireNonNull;
+import static org.sonar.server.computation.formula.coverage.CoverageUtils.supportedPeriods;
+import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
+
+/**
+ * A Formula which aggregates a new coverage measure by simply making the sums of its variations.
+ */
+public class NewCoverageVariationSumFormula implements Formula<NewCoverageVariationSumFormula.VariationSumCounter> {
+  private final String metricKey;
+
+  public NewCoverageVariationSumFormula(String metricKey) {
+    this.metricKey = requireNonNull(metricKey, "Metric key cannot be null");
+  }
+
+  @Override
+  public VariationSumCounter createNewCounter() {
+    return new VariationSumCounter(metricKey);
+  }
+
+  @Override
+  public Optional<Measure> createMeasure(VariationSumCounter counter, CreateMeasureContext context) {
+    if (!CrawlerDepthLimit.LEAVES.isDeeperThan(context.getComponent().getType())) {
+      return Optional.absent();
+    }
+    MeasureVariations.Builder variations = createAndPopulateBuilder(counter.array, context);
+    if (variations.isEmpty()) {
+      return Optional.absent();
+    }
+    return Optional.of(newMeasureBuilder().setVariations(variations.build()).createNoValue());
+  }
+
+  private static MeasureVariations.Builder createAndPopulateBuilder(DoubleVariationValue.Array array, CreateMeasureContext context) {
+    MeasureVariations.Builder builder = MeasureVariations.newMeasureVariationsBuilder();
+    for (Period period : supportedPeriods(context)) {
+      DoubleVariationValue elements = array.get(period);
+      if (elements.isSet()) {
+        builder.setVariation(period, elements.getValue());
+      }
+    }
+    return builder;
+  }
+
+  @Override
+  public String[] getOutputMetricKeys() {
+    return new String[] { metricKey };
+  }
+
+  public static final class VariationSumCounter implements Counter<VariationSumCounter> {
+    private final DoubleVariationValue.Array array = DoubleVariationValue.newArray();
+    private final String metricKey;
+
+    private VariationSumCounter(String metricKey) {
+      this.metricKey = metricKey;
+    }
+
+    @Override
+    public void aggregate(VariationSumCounter counter) {
+      array.incrementAll(counter.array);
+    }
+
+    @Override
+    public void initialize(CounterInitializationContext context) {
+      Optional<Measure> measure = context.getMeasure(metricKey);
+      if (!measure.isPresent() || !measure.get().hasVariations()) {
+        return;
+      }
+      MeasureVariations variations = measure.get().getVariations();
+      for (Period period : supportedPeriods(context)) {
+        if (variations.hasVariation(period.getIndex())) {
+          double variation = variations.getVariation(period.getIndex());
+          if (variation > 0) {
+            array.increment(period, variations.getVariation(period.getIndex()));
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/SingleWithUncoveredCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/SingleWithUncoveredCounter.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.server.computation.formula.coverage;
 
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 
 import static org.sonar.server.computation.formula.coverage.CoverageUtils.getLongMeasureValue;
 
@@ -31,7 +31,7 @@ public final class SingleWithUncoveredCounter extends ElementsAndCoveredElements
   }
 
   @Override
-  protected void aggregateForSupportedLeaf(LeafAggregateContext counterContext) {
+  protected void initializeForSupportedLeaf(CounterInitializationContext counterContext) {
     this.elements = getLongMeasureValue(counterContext, metricKeys.getCovered());
     this.coveredElements = this.elements - getLongMeasureValue(counterContext, metricKeys.getUncovered());
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/SingleWithUncoveredVariationCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/SingleWithUncoveredVariationCounter.java
@@ -26,6 +26,7 @@ import org.sonar.server.computation.period.Period;
 import static java.util.Objects.requireNonNull;
 import static org.sonar.server.computation.formula.coverage.CoverageUtils.getLongVariation;
 import static org.sonar.server.computation.formula.coverage.CoverageUtils.getMeasureVariations;
+import static org.sonar.server.computation.formula.coverage.CoverageUtils.supportedPeriods;
 
 public final class SingleWithUncoveredVariationCounter extends ElementsAndCoveredElementsVariationCounter {
   private final SingleWithUncoveredMetricKeys metricKeys;
@@ -38,7 +39,7 @@ public final class SingleWithUncoveredVariationCounter extends ElementsAndCovere
   protected void initializeForSupportedLeaf(CounterInitializationContext counterContext) {
     MeasureVariations newConditions = getMeasureVariations(counterContext, metricKeys.getCovered());
     MeasureVariations uncoveredConditions = getMeasureVariations(counterContext, metricKeys.getUncovered());
-    for (Period period : counterContext.getPeriods()) {
+    for (Period period : supportedPeriods(counterContext)) {
       long elements = getLongVariation(newConditions, period);
       this.elements.increment(period, elements);
       coveredElements.increment(period, elements - getLongVariation(uncoveredConditions, period));

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/SingleWithUncoveredVariationCounter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/formula/coverage/SingleWithUncoveredVariationCounter.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.server.computation.formula.coverage;
 
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.measure.MeasureVariations;
 import org.sonar.server.computation.period.Period;
 
@@ -35,7 +35,7 @@ public final class SingleWithUncoveredVariationCounter extends ElementsAndCovere
   }
 
   @Override
-  protected void aggregateForSupportedFile(LeafAggregateContext counterContext) {
+  protected void initializeForSupportedLeaf(CounterInitializationContext counterContext) {
     MeasureVariations newConditions = getMeasureVariations(counterContext, metricKeys.getCovered());
     MeasureVariations uncoveredConditions = getMeasureVariations(counterContext, metricKeys.getUncovered());
     for (Period period : counterContext.getPeriods()) {

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/measure/QualityGateStatus.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/measure/QualityGateStatus.java
@@ -60,6 +60,23 @@ public final class QualityGateStatus {
   }
 
   @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    QualityGateStatus that = (QualityGateStatus) o;
+    return status == that.status && java.util.Objects.equals(text, that.text);
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(status, text);
+  }
+
+  @Override
   public String toString() {
     return Objects.toStringHelper(this)
         .add("status", status)

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/period/PeriodPredicates.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/period/PeriodPredicates.java
@@ -1,0 +1,47 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.computation.period;
+
+import com.google.common.base.Predicate;
+import javax.annotation.Nonnull;
+
+public final class PeriodPredicates {
+  private PeriodPredicates() {
+    // prevents instantiation
+  }
+
+  /**
+   * Since Periods 4 and 5 can be customized per project and/or per view/subview, aggregating variation on these periods
+   * for NEW_* metrics will only generate garbage data which will make no sense. These Periods should be ignored
+   * when processing views/subviews.
+   */
+  public static Predicate<Period> viewsRestrictedPeriods() {
+    return ViewsSupportedPeriods.INSTANCE;
+  }
+
+  private enum ViewsSupportedPeriods implements Predicate<Period> {
+    INSTANCE;
+
+    @Override
+    public boolean apply(@Nonnull Period input) {
+      return input.getIndex() < 4;
+    }
+  }
+}

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/CommentMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/CommentMeasuresStep.java
@@ -29,7 +29,7 @@ import org.sonar.server.computation.formula.Counter;
 import org.sonar.server.computation.formula.CreateMeasureContext;
 import org.sonar.server.computation.formula.Formula;
 import org.sonar.server.computation.formula.FormulaExecutorComponentVisitor;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.formula.counter.IntSumCounter;
 import org.sonar.server.computation.formula.counter.SumCounter;
 import org.sonar.server.computation.measure.Measure;
@@ -184,9 +184,9 @@ public class CommentMeasuresStep implements ComputationStep {
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
-      publicApiCounter.aggregate(context);
-      publicUndocumentedApiCounter.aggregate(context);
+    public void initialize(CounterInitializationContext context) {
+      publicApiCounter.initialize(context);
+      publicUndocumentedApiCounter.initialize(context);
     }
 
     public Optional<Integer> getPublicApiValue() {

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/ComplexityMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/ComplexityMeasuresStep.java
@@ -53,15 +53,13 @@ public class ComplexityMeasuresStep implements ComputationStep {
     createIntSumFormula(COMPLEXITY_KEY),
     createIntSumFormula(COMPLEXITY_IN_CLASSES_KEY),
     createIntSumFormula(COMPLEXITY_IN_FUNCTIONS_KEY),
-
-  new DistributionFormula(FUNCTION_COMPLEXITY_DISTRIBUTION_KEY),
+    new DistributionFormula(FUNCTION_COMPLEXITY_DISTRIBUTION_KEY),
     new DistributionFormula(FILE_COMPLEXITY_DISTRIBUTION_KEY),
     new DistributionFormula(CLASS_COMPLEXITY_DISTRIBUTION_KEY),
-
-  AverageFormula.Builder.newBuilder().setOutputMetricKey(FILE_COMPLEXITY_KEY)
-    .setMainMetricKey(COMPLEXITY_KEY)
-    .setByMetricKey(FILES_KEY)
-    .build(),
+    AverageFormula.Builder.newBuilder().setOutputMetricKey(FILE_COMPLEXITY_KEY)
+      .setMainMetricKey(COMPLEXITY_KEY)
+      .setByMetricKey(FILES_KEY)
+      .build(),
     AverageFormula.Builder.newBuilder().setOutputMetricKey(CLASS_COMPLEXITY_KEY)
       .setMainMetricKey(COMPLEXITY_IN_CLASSES_KEY)
       .setByMetricKey(CLASSES_KEY)

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/ComputeQProfileMeasureStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/ComputeQProfileMeasureStep.java
@@ -57,15 +57,15 @@ public class ComputeQProfileMeasureStep implements ComputationStep {
   @Override
   public void execute() {
     Metric qProfilesMetric = metricRepository.getByKey(CoreMetrics.QUALITY_PROFILES_KEY);
-    new PathAwareCrawler<>(new NewCoverageAggregationComponentCrawler(qProfilesMetric))
+    new PathAwareCrawler<>(new NewCoverageAggregationComponentVisitor(qProfilesMetric))
       .visit(treeRootHolder.getRoot());
   }
 
-  private class NewCoverageAggregationComponentCrawler extends PathAwareVisitorAdapter<QProfiles> {
+  private class NewCoverageAggregationComponentVisitor extends PathAwareVisitorAdapter<QProfiles> {
 
     private final Metric qProfilesMetric;
 
-    public NewCoverageAggregationComponentCrawler(Metric qProfilesMetric) {
+    public NewCoverageAggregationComponentVisitor(Metric qProfilesMetric) {
       super(CrawlerDepthLimit.MODULE, POST_ORDER, new SimpleStackElementFactory<QProfiles>() {
         @Override
         public QProfiles createForAny(Component component) {

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/DuplicationMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/DuplicationMeasuresStep.java
@@ -31,7 +31,7 @@ import org.sonar.server.computation.formula.CreateMeasureContext;
 import org.sonar.server.computation.formula.Formula;
 import org.sonar.server.computation.formula.FormulaExecutorComponentVisitor;
 import org.sonar.server.computation.formula.counter.IntSumCounter;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.measure.Measure;
 import org.sonar.server.computation.measure.MeasureRepository;
 import org.sonar.server.computation.metric.Metric;
@@ -187,7 +187,7 @@ public class DuplicationMeasuresStep implements ComputationStep {
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
+    public void initialize(CounterInitializationContext context) {
       Optional<Measure> measureOptional = context.getMeasure(metricKey);
       if (measureOptional.isPresent()) {
         value += measureOptional.get().getIntValue();

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/LanguageDistributionMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/LanguageDistributionMeasuresStep.java
@@ -32,7 +32,7 @@ import org.sonar.server.computation.component.PathAwareCrawler;
 import org.sonar.server.computation.component.TreeRootHolder;
 import org.sonar.server.computation.formula.Counter;
 import org.sonar.server.computation.formula.CreateMeasureContext;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.formula.Formula;
 import org.sonar.server.computation.formula.FormulaExecutorComponentVisitor;
 import org.sonar.server.computation.measure.Measure;
@@ -115,7 +115,7 @@ public class LanguageDistributionMeasuresStep implements ComputationStep {
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
+    public void initialize(CounterInitializationContext context) {
       String language = context.getLeaf().getFileAttributes().getLanguageKey();
       Optional<Measure> ncloc = context.getMeasure(CoreMetrics.NCLOC_KEY);
       if (ncloc.isPresent()) {

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/NewCoverageMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/NewCoverageMeasuresStep.java
@@ -36,7 +36,7 @@ import org.sonar.server.computation.component.Component;
 import org.sonar.server.computation.component.PathAwareCrawler;
 import org.sonar.server.computation.component.TreeRootHolder;
 import org.sonar.server.computation.formula.CreateMeasureContext;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.formula.Formula;
 import org.sonar.server.computation.formula.FormulaExecutorComponentVisitor;
 import org.sonar.server.computation.formula.counter.IntVariationValue;
@@ -297,7 +297,7 @@ public class NewCoverageMeasuresStep implements ComputationStep {
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
+    public void initialize(CounterInitializationContext context) {
       Component fileComponent = context.getLeaf();
       BatchReport.Changesets componentScm = batchReportReader.readChangesets(fileComponent.getReportAttributes().getRef());
       if (componentScm == null) {

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/PersistComponentsStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/PersistComponentsStep.java
@@ -44,7 +44,7 @@ import org.sonar.server.computation.component.MutableDbIdsRepository;
 import org.sonar.server.computation.component.TreeRootHolder;
 
 /**
- * Persist components
+ * Persist report components
  * Also feed the components cache {@link DbIdsRepositoryImpl} with component ids
  */
 public class PersistComponentsStep implements ComputationStep {

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/PurgeDatastoresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/PurgeDatastoresStep.java
@@ -21,14 +21,20 @@
 package org.sonar.server.computation.step;
 
 import org.sonar.core.computation.dbcleaner.ProjectCleaner;
+import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
-import org.sonar.db.MyBatis;
 import org.sonar.db.purge.IdUuidPair;
 import org.sonar.server.computation.component.Component;
 import org.sonar.server.computation.component.DbIdsRepository;
+import org.sonar.server.computation.component.DepthTraversalTypeAwareCrawler;
 import org.sonar.server.computation.component.SettingsRepository;
 import org.sonar.server.computation.component.TreeRootHolder;
-import org.sonar.db.DbClient;
+import org.sonar.server.computation.component.TypeAwareVisitorAdapter;
+
+import static org.sonar.server.computation.component.Component.Type.PROJECT;
+import static org.sonar.server.computation.component.Component.Type.VIEW;
+import static org.sonar.server.computation.component.ComponentVisitor.Order.PRE_ORDER;
+import static org.sonar.server.computation.component.CrawlerDepthLimit.reportMaxDepth;
 
 public class PurgeDatastoresStep implements ComputationStep {
 
@@ -49,13 +55,27 @@ public class PurgeDatastoresStep implements ComputationStep {
 
   @Override
   public void execute() {
+    new DepthTraversalTypeAwareCrawler(
+      new TypeAwareVisitorAdapter(reportMaxDepth(PROJECT).withViewsMaxDepth(VIEW), PRE_ORDER) {
+        @Override
+        public void visitProject(Component project) {
+          execute(project);
+        }
+
+        @Override
+        public void visitView(Component view) {
+          execute(view);
+        }
+      }).visit(treeRootHolder.getRoot());
+  }
+
+  private void execute(Component root) {
     DbSession session = dbClient.openSession(true);
     try {
-      Component project = treeRootHolder.getRoot();
-      projectCleaner.purge(session, new IdUuidPair(dbIdsRepository.getComponentId(project), project.getUuid()), settingsRepository.getSettings(project));
+      projectCleaner.purge(session, new IdUuidPair(dbIdsRepository.getComponentId(root), root.getUuid()), settingsRepository.getSettings(root));
       session.commit();
     } finally {
-      MyBatis.closeQuietly(session);
+      dbClient.closeSession(session);
     }
   }
 

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/UnitTestMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/UnitTestMeasuresStep.java
@@ -29,7 +29,7 @@ import org.sonar.server.computation.formula.Counter;
 import org.sonar.server.computation.formula.CreateMeasureContext;
 import org.sonar.server.computation.formula.Formula;
 import org.sonar.server.computation.formula.FormulaExecutorComponentVisitor;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.formula.counter.IntSumCounter;
 import org.sonar.server.computation.measure.Measure;
 import org.sonar.server.computation.measure.MeasureRepository;
@@ -138,10 +138,10 @@ public class UnitTestMeasuresStep implements ComputationStep {
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
-      testsCounter.aggregate(context);
-      testsErrorsCounter.aggregate(context);
-      testsFailuresCounter.aggregate(context);
+    public void initialize(CounterInitializationContext context) {
+      testsCounter.initialize(context);
+      testsErrorsCounter.initialize(context);
+      testsFailuresCounter.initialize(context);
     }
   }
 

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/UnitTestMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/UnitTestMeasuresStep.java
@@ -23,6 +23,7 @@ package org.sonar.server.computation.step;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.sonar.server.computation.component.Component;
+import org.sonar.server.computation.component.CrawlerDepthLimit;
 import org.sonar.server.computation.component.PathAwareCrawler;
 import org.sonar.server.computation.component.TreeRootHolder;
 import org.sonar.server.computation.formula.Counter;
@@ -97,8 +98,10 @@ public class UnitTestMeasuresStep implements ComputationStep {
     }
 
     private static Optional<Measure> createMeasure(Component.Type componentType, Optional<Integer> metricValue) {
-      return (componentType.isHigherThan(Component.Type.FILE) && metricValue.isPresent()) ? Optional.of(Measure.newMeasureBuilder().create(metricValue.get()))
-        : Optional.<Measure>absent();
+      if (metricValue.isPresent() && CrawlerDepthLimit.LEAVES.isDeeperThan(componentType)) {
+        return Optional.of(Measure.newMeasureBuilder().create(metricValue.get()));
+      }
+      return Optional.absent();
     }
 
     private static Optional<Measure> createDensityMeasure(UnitTestsCounter counter) {

--- a/server/sonar-server/src/test/java/org/sonar/server/component/SnapshotTesting.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/component/SnapshotTesting.java
@@ -41,7 +41,12 @@ public class SnapshotTesting {
 
   public static SnapshotDto createForProject(ComponentDto project) {
     return createBasicSnapshot(project, project.getId())
-      .setPath("");
+        .setPath("");
+  }
+
+  public static SnapshotDto createForView(ComponentDto view) {
+    return createBasicSnapshot(view, view.getId())
+        .setPath("");
   }
 
   private static SnapshotDto createBasicSnapshot(ComponentDto component, Long rootProjectId) {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/formula/AverageFormulaTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/formula/AverageFormulaTest.java
@@ -50,7 +50,7 @@ public class AverageFormulaTest {
     .setByMetricKey(FUNCTIONS_KEY)
     .build();
 
-  LeafAggregateContext leafAggregateContext = mock(LeafAggregateContext.class);
+  CounterInitializationContext counterInitializationContext = mock(CounterInitializationContext.class);
   CreateMeasureContext createMeasureContext = new DumbCreateMeasureContext(
       ReportComponent.builder(Component.Type.PROJECT, 1).build(), mock(Metric.class), mock(PeriodsHolder.class));
 
@@ -108,7 +108,7 @@ public class AverageFormulaTest {
     AverageFormula.AverageCounter counter = BASIC_AVERAGE_FORMULA.createNewCounter();
     addMeasure(COMPLEXITY_IN_FUNCTIONS_KEY, 10d);
     addMeasure(FUNCTIONS_KEY, 2d);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     assertThat(BASIC_AVERAGE_FORMULA.createMeasure(counter, createMeasureContext).get().getDoubleValue()).isEqualTo(5d);
   }
@@ -118,7 +118,7 @@ public class AverageFormulaTest {
     AverageFormula.AverageCounter anotherCounter = BASIC_AVERAGE_FORMULA.createNewCounter();
     addMeasure(COMPLEXITY_IN_FUNCTIONS_KEY, 10d);
     addMeasure(FUNCTIONS_KEY, 2d);
-    anotherCounter.aggregate(leafAggregateContext);
+    anotherCounter.initialize(counterInitializationContext);
 
     AverageFormula.AverageCounter counter = BASIC_AVERAGE_FORMULA.createNewCounter();
     counter.aggregate(anotherCounter);
@@ -131,7 +131,7 @@ public class AverageFormulaTest {
     AverageFormula.AverageCounter counter = BASIC_AVERAGE_FORMULA.createNewCounter();
     addMeasure(COMPLEXITY_IN_FUNCTIONS_KEY, 10d);
     addMeasure(FUNCTIONS_KEY, 2d);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     assertThat(BASIC_AVERAGE_FORMULA.createMeasure(counter, createMeasureContext).get().getDoubleValue()).isEqualTo(5d);
   }
@@ -141,7 +141,7 @@ public class AverageFormulaTest {
     AverageFormula.AverageCounter counter = BASIC_AVERAGE_FORMULA.createNewCounter();
     addMeasure(COMPLEXITY_IN_FUNCTIONS_KEY, 10);
     addMeasure(FUNCTIONS_KEY, 2);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     assertThat(BASIC_AVERAGE_FORMULA.createMeasure(counter, createMeasureContext).get().getDoubleValue()).isEqualTo(5);
   }
@@ -151,7 +151,7 @@ public class AverageFormulaTest {
     AverageFormula.AverageCounter counter = BASIC_AVERAGE_FORMULA.createNewCounter();
     addMeasure(COMPLEXITY_IN_FUNCTIONS_KEY, 10L);
     addMeasure(FUNCTIONS_KEY, 2L);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     assertThat(BASIC_AVERAGE_FORMULA.createMeasure(counter, createMeasureContext).get().getDoubleValue()).isEqualTo(5L);
   }
@@ -160,8 +160,8 @@ public class AverageFormulaTest {
   public void not_create_measure_when_aggregated_measure_has_no_value() {
     AverageFormula.AverageCounter counter = BASIC_AVERAGE_FORMULA.createNewCounter();
     addMeasure(COMPLEXITY_IN_FUNCTIONS_KEY, 10L);
-    when(leafAggregateContext.getMeasure(FUNCTIONS_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().createNoValue()));
-    counter.aggregate(leafAggregateContext);
+    when(counterInitializationContext.getMeasure(FUNCTIONS_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().createNoValue()));
+    counter.initialize(counterInitializationContext);
 
     Assertions.assertThat(BASIC_AVERAGE_FORMULA.createMeasure(counter, createMeasureContext)).isAbsent();
   }
@@ -173,8 +173,8 @@ public class AverageFormulaTest {
 
     AverageFormula.AverageCounter counter = BASIC_AVERAGE_FORMULA.createNewCounter();
     addMeasure(COMPLEXITY_IN_FUNCTIONS_KEY, 10L);
-    when(leafAggregateContext.getMeasure(FUNCTIONS_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().create("data")));
-    counter.aggregate(leafAggregateContext);
+    when(counterInitializationContext.getMeasure(FUNCTIONS_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().create("data")));
+    counter.initialize(counterInitializationContext);
 
     BASIC_AVERAGE_FORMULA.createMeasure(counter, createMeasureContext);
   }
@@ -182,8 +182,8 @@ public class AverageFormulaTest {
   @Test
   public void no_measure_created_when_counter_has_no_value() {
     AverageFormula.AverageCounter counter = BASIC_AVERAGE_FORMULA.createNewCounter();
-    when(leafAggregateContext.getMeasure(anyString())).thenReturn(Optional.<Measure>absent());
-    counter.aggregate(leafAggregateContext);
+    when(counterInitializationContext.getMeasure(anyString())).thenReturn(Optional.<Measure>absent());
+    counter.initialize(counterInitializationContext);
 
     Assertions.assertThat(BASIC_AVERAGE_FORMULA.createMeasure(counter, createMeasureContext)).isAbsent();
   }
@@ -192,8 +192,8 @@ public class AverageFormulaTest {
   public void not_create_measure_when_only_one_measure() {
     AverageFormula.AverageCounter counter = BASIC_AVERAGE_FORMULA.createNewCounter();
     addMeasure(COMPLEXITY_IN_FUNCTIONS_KEY, 10L);
-    when(leafAggregateContext.getMeasure(FUNCTIONS_KEY)).thenReturn(Optional.<Measure>absent());
-    counter.aggregate(leafAggregateContext);
+    when(counterInitializationContext.getMeasure(FUNCTIONS_KEY)).thenReturn(Optional.<Measure>absent());
+    counter.initialize(counterInitializationContext);
 
     Assertions.assertThat(BASIC_AVERAGE_FORMULA.createMeasure(counter, createMeasureContext)).isAbsent();
   }
@@ -203,7 +203,7 @@ public class AverageFormulaTest {
     AverageFormula.AverageCounter counter = BASIC_AVERAGE_FORMULA.createNewCounter();
     addMeasure(COMPLEXITY_IN_FUNCTIONS_KEY, 10d);
     addMeasure(FUNCTIONS_KEY, 0d);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     Assertions.assertThat(BASIC_AVERAGE_FORMULA.createMeasure(counter, createMeasureContext)).isAbsent();
   }
@@ -218,10 +218,10 @@ public class AverageFormulaTest {
       .build();
 
     AverageFormula.AverageCounter counter = underTest.createNewCounter();
-    when(leafAggregateContext.getMeasure(COMPLEXITY_IN_FUNCTIONS_KEY)).thenReturn(Optional.<Measure>absent());
+    when(counterInitializationContext.getMeasure(COMPLEXITY_IN_FUNCTIONS_KEY)).thenReturn(Optional.<Measure>absent());
     addMeasure(COMPLEXITY_KEY, 10d);
     addMeasure(FUNCTIONS_KEY, 2d);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     assertThat(underTest.createMeasure(counter, createMeasureContext).get().getDoubleValue()).isEqualTo(5d);
   }
@@ -239,21 +239,21 @@ public class AverageFormulaTest {
     addMeasure(COMPLEXITY_IN_FUNCTIONS_KEY, 10d);
     addMeasure(COMPLEXITY_KEY, 12d);
     addMeasure(FUNCTIONS_KEY, 2d);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     assertThat(underTest.createMeasure(counter, createMeasureContext).get().getDoubleValue()).isEqualTo(5d);
   }
 
   private void addMeasure(String metricKey, double value) {
-    when(leafAggregateContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
+    when(counterInitializationContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
   }
 
   private void addMeasure(String metricKey, int value) {
-    when(leafAggregateContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
+    when(counterInitializationContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
   }
 
   private void addMeasure(String metricKey, long value) {
-    when(leafAggregateContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
+    when(counterInitializationContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
   }
 
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/formula/DistributionFormulaTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/formula/DistributionFormulaTest.java
@@ -43,7 +43,7 @@ public class DistributionFormulaTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  LeafAggregateContext leafAggregateContext = mock(LeafAggregateContext.class);
+  CounterInitializationContext counterInitializationContext = mock(CounterInitializationContext.class);
   CreateMeasureContext projectCreateMeasureContext = new DumbCreateMeasureContext(
       ReportComponent.builder(Component.Type.PROJECT, 1).build(), mock(Metric.class), mock(PeriodsHolder.class));
   CreateMeasureContext fileCreateMeasureContext = new DumbCreateMeasureContext(
@@ -71,7 +71,7 @@ public class DistributionFormulaTest {
   public void create_measure() {
     DistributionFormula.DistributionCounter counter = BASIC_DISTRIBUTION_FORMULA.createNewCounter();
     addMeasure(FUNCTION_COMPLEXITY_DISTRIBUTION_KEY, "0=3;3=7;6=10");
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     assertThat(BASIC_DISTRIBUTION_FORMULA.createMeasure(counter, projectCreateMeasureContext).get().getData()).isEqualTo("0=3;3=7;6=10");
   }
@@ -80,7 +80,7 @@ public class DistributionFormulaTest {
   public void create_measure_when_counter_is_aggregating_from_another_counter() {
     DistributionFormula.DistributionCounter anotherCounter = BASIC_DISTRIBUTION_FORMULA.createNewCounter();
     addMeasure(FUNCTION_COMPLEXITY_DISTRIBUTION_KEY, "0=3;3=7;6=10");
-    anotherCounter.aggregate(leafAggregateContext);
+    anotherCounter.initialize(counterInitializationContext);
 
     DistributionFormula.DistributionCounter counter = BASIC_DISTRIBUTION_FORMULA.createNewCounter();
     counter.aggregate(anotherCounter);
@@ -91,8 +91,8 @@ public class DistributionFormulaTest {
   @Test
   public void create_no_measure_when_no_value() {
     DistributionFormula.DistributionCounter counter = BASIC_DISTRIBUTION_FORMULA.createNewCounter();
-    when(leafAggregateContext.getMeasure(FUNCTION_COMPLEXITY_DISTRIBUTION_KEY)).thenReturn(Optional.<Measure>absent());
-    counter.aggregate(leafAggregateContext);
+    when(counterInitializationContext.getMeasure(FUNCTION_COMPLEXITY_DISTRIBUTION_KEY)).thenReturn(Optional.<Measure>absent());
+    counter.initialize(counterInitializationContext);
 
     Assertions.assertThat(BASIC_DISTRIBUTION_FORMULA.createMeasure(counter, projectCreateMeasureContext)).isAbsent();
   }
@@ -101,13 +101,13 @@ public class DistributionFormulaTest {
   public void not_create_measure_when_on_file() {
     DistributionFormula.DistributionCounter counter = BASIC_DISTRIBUTION_FORMULA.createNewCounter();
     addMeasure(FUNCTION_COMPLEXITY_DISTRIBUTION_KEY, "0=3;3=7;6=10");
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     Assertions.assertThat(BASIC_DISTRIBUTION_FORMULA.createMeasure(counter, fileCreateMeasureContext)).isAbsent();
   }
 
   private void addMeasure(String metricKey, String value) {
-    when(leafAggregateContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
+    when(counterInitializationContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
   }
 
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/formula/IntSumFormulaTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/formula/IntSumFormulaTest.java
@@ -46,7 +46,7 @@ public class IntSumFormulaTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  LeafAggregateContext leafAggregateContext = mock(LeafAggregateContext.class);
+  CounterInitializationContext counterInitializationContext = mock(CounterInitializationContext.class);
   CreateMeasureContext projectCreateMeasureContext = new DumbCreateMeasureContext(
     ReportComponent.builder(Component.Type.PROJECT, 1).build(), mock(Metric.class), mock(PeriodsHolder.class));
   CreateMeasureContext fileCreateMeasureContext = new DumbCreateMeasureContext(
@@ -74,7 +74,7 @@ public class IntSumFormulaTest {
   public void create_measure() {
     IntSumCounter counter = INT_SUM_FORMULA.createNewCounter();
     addMeasure(LINES_KEY, 10);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     assertThat(INT_SUM_FORMULA.createMeasure(counter, projectCreateMeasureContext).get().getIntValue()).isEqualTo(10);
   }
@@ -83,7 +83,7 @@ public class IntSumFormulaTest {
   public void create_measure_when_counter_is_aggregating_from_another_counter() {
     IntSumCounter anotherCounter = INT_SUM_FORMULA.createNewCounter();
     addMeasure(LINES_KEY, 10);
-    anotherCounter.aggregate(leafAggregateContext);
+    anotherCounter.initialize(counterInitializationContext);
 
     IntSumCounter counter = INT_SUM_FORMULA.createNewCounter();
     counter.aggregate(anotherCounter);
@@ -95,7 +95,7 @@ public class IntSumFormulaTest {
   public void not_create_measure_on_file() {
     IntSumCounter counter = INT_SUM_FORMULA.createNewCounter();
     addMeasure(LINES_KEY, 10);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     Assertions.assertThat(INT_SUM_FORMULA.createMeasure(counter, fileCreateMeasureContext)).isAbsent();
   }
@@ -103,14 +103,14 @@ public class IntSumFormulaTest {
   @Test
   public void do_not_create_measures_when_no_values() {
     IntSumCounter counter = INT_SUM_FORMULA.createNewCounter();
-    when(leafAggregateContext.getMeasure(LINES_KEY)).thenReturn(Optional.<Measure>absent());
-    counter.aggregate(leafAggregateContext);
+    when(counterInitializationContext.getMeasure(LINES_KEY)).thenReturn(Optional.<Measure>absent());
+    counter.initialize(counterInitializationContext);
 
     Assertions.assertThat(INT_SUM_FORMULA.createMeasure(counter, projectCreateMeasureContext)).isAbsent();
   }
 
   private void addMeasure(String metricKey, int value) {
-    when(leafAggregateContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
+    when(counterInitializationContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
   }
 
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/formula/LongSumFormulaTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/formula/LongSumFormulaTest.java
@@ -47,7 +47,7 @@ public class LongSumFormulaTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  LeafAggregateContext leafAggregateContext = mock(LeafAggregateContext.class);
+  CounterInitializationContext counterInitializationContext = mock(CounterInitializationContext.class);
   CreateMeasureContext projectCreateMeasureContext = new DumbCreateMeasureContext(
     ReportComponent.builder(Component.Type.PROJECT, 1).build(), mock(Metric.class), mock(PeriodsHolder.class));
   CreateMeasureContext fileCreateMeasureContext = new DumbCreateMeasureContext(
@@ -75,7 +75,7 @@ public class LongSumFormulaTest {
   public void create_measure() {
     LongSumCounter counter = LONG_SUM_FORMULA.createNewCounter();
     addMeasure(LINES_KEY, MEASURE_VALUE);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     assertThat(LONG_SUM_FORMULA.createMeasure(counter, projectCreateMeasureContext).get().getLongValue()).isEqualTo(MEASURE_VALUE);
   }
@@ -84,7 +84,7 @@ public class LongSumFormulaTest {
   public void create_measure_when_counter_is_aggregating_from_another_counter() {
     LongSumCounter anotherCounter = LONG_SUM_FORMULA.createNewCounter();
     addMeasure(LINES_KEY, MEASURE_VALUE);
-    anotherCounter.aggregate(leafAggregateContext);
+    anotherCounter.initialize(counterInitializationContext);
 
     LongSumCounter counter = LONG_SUM_FORMULA.createNewCounter();
     counter.aggregate(anotherCounter);
@@ -96,7 +96,7 @@ public class LongSumFormulaTest {
   public void not_create_measure_on_file() {
     LongSumCounter counter = LONG_SUM_FORMULA.createNewCounter();
     addMeasure(LINES_KEY, MEASURE_VALUE);
-    counter.aggregate(leafAggregateContext);
+    counter.initialize(counterInitializationContext);
 
     Assertions.assertThat(LONG_SUM_FORMULA.createMeasure(counter, fileCreateMeasureContext)).isAbsent();
   }
@@ -104,14 +104,14 @@ public class LongSumFormulaTest {
   @Test
   public void do_not_create_measures_when_no_values() {
     LongSumCounter counter = LONG_SUM_FORMULA.createNewCounter();
-    when(leafAggregateContext.getMeasure(LINES_KEY)).thenReturn(Optional.<Measure>absent());
-    counter.aggregate(leafAggregateContext);
+    when(counterInitializationContext.getMeasure(LINES_KEY)).thenReturn(Optional.<Measure>absent());
+    counter.initialize(counterInitializationContext);
 
     Assertions.assertThat(LONG_SUM_FORMULA.createMeasure(counter, projectCreateMeasureContext)).isAbsent();
   }
 
   private void addMeasure(String metricKey, long value) {
-    when(leafAggregateContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
+    when(counterInitializationContext.getMeasure(metricKey)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(value)));
   }
 
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/formula/ReportFormulaExecutorComponentVisitorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/formula/ReportFormulaExecutorComponentVisitorTest.java
@@ -286,7 +286,7 @@ public class ReportFormulaExecutorComponentVisitorTest {
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
+    public void initialize(CounterInitializationContext context) {
       // verify the context which is passed to the method
       assertThat(context.getLeaf().getReportAttributes().getRef()).isIn(1111, 1112, 1211);
       assertThat(context.getPeriods()).isEqualTo(periodsHolder.getPeriods());
@@ -337,7 +337,7 @@ public class ReportFormulaExecutorComponentVisitorTest {
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
+    public void initialize(CounterInitializationContext context) {
       // verify the context which is passed to the method
       assertThat(context.getLeaf().getReportAttributes().getRef()).isIn(1111, 1112, 1211);
       assertThat(context.getPeriods()).isEqualTo(periodsHolder.getPeriods());

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/formula/ViewsFormulaExecutorComponentVisitorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/formula/ViewsFormulaExecutorComponentVisitorTest.java
@@ -283,7 +283,7 @@ public class ViewsFormulaExecutorComponentVisitorTest {
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
+    public void initialize(CounterInitializationContext context) {
       verifyLeafContext(context);
 
       Optional<Measure> measureOptional = context.getMeasure(LINES_KEY);
@@ -332,7 +332,7 @@ public class ViewsFormulaExecutorComponentVisitorTest {
     }
 
     @Override
-    public void aggregate(LeafAggregateContext context) {
+    public void initialize(CounterInitializationContext context) {
       verifyLeafContext(context);
 
       Optional<Measure> measureOptional = context.getMeasure(NEW_LINES_TO_COVER_KEY);
@@ -366,7 +366,7 @@ public class ViewsFormulaExecutorComponentVisitorTest {
             entryOf(NEW_IT_COVERAGE_KEY, newMeasureBuilder().create(valueItCoverage)));
   }
 
-  private void verifyLeafContext(LeafAggregateContext context) {
+  private void verifyLeafContext(CounterInitializationContext context) {
     assertThat(context.getLeaf().getKey()).isIn(String.valueOf(PROJECT_VIEW_1_REF), String.valueOf(PROJECT_VIEW_2_REF), String.valueOf(PROJECT_VIEW_3_REF),
       String.valueOf(PROJECT_VIEW_4_REF));
     assertThat(context.getPeriods()).isEqualTo(periodsHolder.getPeriods());

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/formula/counter/IntSumCounterTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/formula/counter/IntSumCounterTest.java
@@ -22,7 +22,7 @@ package org.sonar.server.computation.formula.counter;
 
 import com.google.common.base.Optional;
 import org.junit.Test;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.measure.Measure;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,7 +35,7 @@ public class IntSumCounterTest {
 
   private final static String METRIC_KEY = "metric";
 
-  LeafAggregateContext leafAggregateContext = mock(LeafAggregateContext.class);
+  CounterInitializationContext counterInitializationContext = mock(CounterInitializationContext.class);
 
   SumCounter sumCounter = new IntSumCounter(METRIC_KEY);
 
@@ -46,27 +46,27 @@ public class IntSumCounterTest {
 
   @Test
   public void aggregate_from_context() {
-    when(leafAggregateContext.getMeasure(METRIC_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(10)));
+    when(counterInitializationContext.getMeasure(METRIC_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(10)));
 
-    sumCounter.aggregate(leafAggregateContext);
+    sumCounter.initialize(counterInitializationContext);
 
     assertThat(sumCounter.getValue().get()).isEqualTo(10);
   }
 
   @Test
   public void no_value_when_aggregate_from_context_but_no_measure() {
-    when(leafAggregateContext.getMeasure(anyString())).thenReturn(Optional.<Measure>absent());
+    when(counterInitializationContext.getMeasure(anyString())).thenReturn(Optional.<Measure>absent());
 
-    sumCounter.aggregate(leafAggregateContext);
+    sumCounter.initialize(counterInitializationContext);
 
     assertThat(sumCounter.getValue()).isAbsent();
   }
 
   @Test
   public void aggregate_from_counter() {
-    when(leafAggregateContext.getMeasure(METRIC_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(10)));
+    when(counterInitializationContext.getMeasure(METRIC_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(10)));
     SumCounter anotherCounter = new IntSumCounter(METRIC_KEY);
-    anotherCounter.aggregate(leafAggregateContext);
+    anotherCounter.initialize(counterInitializationContext);
 
     sumCounter.aggregate(anotherCounter);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/formula/counter/LongSumCounterTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/formula/counter/LongSumCounterTest.java
@@ -22,7 +22,7 @@ package org.sonar.server.computation.formula.counter;
 
 import com.google.common.base.Optional;
 import org.junit.Test;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.measure.Measure;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,7 +36,7 @@ public class LongSumCounterTest {
   private static final String METRIC_KEY = "metric";
   private static final long MEASURE_VALUE = 10L;
 
-  LeafAggregateContext leafAggregateContext = mock(LeafAggregateContext.class);
+  CounterInitializationContext counterInitializationContext = mock(CounterInitializationContext.class);
 
   SumCounter sumCounter = new LongSumCounter(METRIC_KEY);
 
@@ -47,27 +47,27 @@ public class LongSumCounterTest {
 
   @Test
   public void aggregate_from_context() {
-    when(leafAggregateContext.getMeasure(METRIC_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(MEASURE_VALUE)));
+    when(counterInitializationContext.getMeasure(METRIC_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(MEASURE_VALUE)));
 
-    sumCounter.aggregate(leafAggregateContext);
+    sumCounter.initialize(counterInitializationContext);
 
     assertThat(sumCounter.getValue().get()).isEqualTo(MEASURE_VALUE);
   }
 
   @Test
   public void no_value_when_aggregate_from_context_but_no_measure() {
-    when(leafAggregateContext.getMeasure(anyString())).thenReturn(Optional.<Measure>absent());
+    when(counterInitializationContext.getMeasure(anyString())).thenReturn(Optional.<Measure>absent());
 
-    sumCounter.aggregate(leafAggregateContext);
+    sumCounter.initialize(counterInitializationContext);
 
     assertThat(sumCounter.getValue()).isAbsent();
   }
 
   @Test
   public void aggregate_from_counter() {
-    when(leafAggregateContext.getMeasure(METRIC_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(MEASURE_VALUE)));
+    when(counterInitializationContext.getMeasure(METRIC_KEY)).thenReturn(Optional.of(Measure.newMeasureBuilder().create(MEASURE_VALUE)));
     SumCounter anotherCounter = new LongSumCounter(METRIC_KEY);
-    anotherCounter.aggregate(leafAggregateContext);
+    anotherCounter.initialize(counterInitializationContext);
 
     sumCounter.aggregate(anotherCounter);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/formula/coverage/CoverageUtilsTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/formula/coverage/CoverageUtilsTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.ExternalResource;
 import org.sonar.server.computation.component.Component;
-import org.sonar.server.computation.formula.LeafAggregateContext;
+import org.sonar.server.computation.formula.CounterInitializationContext;
 import org.sonar.server.computation.measure.Measure;
 import org.sonar.server.computation.measure.MeasureVariations;
 import org.sonar.server.computation.period.Period;
@@ -47,7 +47,7 @@ public class CoverageUtilsTest {
   public static final MeasureVariations DEFAULT_VARIATIONS = new MeasureVariations(0d, 0d, 0d, 0d, 0d);
 
   @Rule
-  public LeafAggregateContextRule fileAggregateContext = new LeafAggregateContextRule();
+  public CounterInitializationContextRule fileAggregateContext = new CounterInitializationContextRule();
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
@@ -127,10 +127,10 @@ public class CoverageUtilsTest {
     return new Period(periodIndex, "mode" + periodIndex, null, 963L + periodIndex, 9865L + periodIndex);
   }
 
-  private static class LeafAggregateContextRule extends ExternalResource implements LeafAggregateContext {
+  private static class CounterInitializationContextRule extends ExternalResource implements CounterInitializationContext {
     private final Map<String, Measure> measures = new HashMap<>();
 
-    public LeafAggregateContextRule put(String metricKey, Measure measure) {
+    public CounterInitializationContextRule put(String metricKey, Measure measure) {
       checkNotNull(metricKey);
       checkNotNull(measure);
       checkState(!measures.containsKey(metricKey));

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/period/PeriodPredicatesTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/period/PeriodPredicatesTest.java
@@ -1,0 +1,45 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.computation.period;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PeriodPredicatesTest {
+
+  @Test(expected = NullPointerException.class)
+  public void viewsRestrictedPeriods_throws_NPE_if_Period_is_null() {
+    PeriodPredicates.viewsRestrictedPeriods().apply(null);
+  }
+
+  @Test
+  public void viewsRestrictedPeriods() {
+    assertThat(PeriodPredicates.viewsRestrictedPeriods().apply(createPeriod(1))).isTrue();
+    assertThat(PeriodPredicates.viewsRestrictedPeriods().apply(createPeriod(2))).isTrue();
+    assertThat(PeriodPredicates.viewsRestrictedPeriods().apply(createPeriod(3))).isTrue();
+    assertThat(PeriodPredicates.viewsRestrictedPeriods().apply(createPeriod(4))).isFalse();
+    assertThat(PeriodPredicates.viewsRestrictedPeriods().apply(createPeriod(5))).isFalse();
+  }
+
+  private Period createPeriod(int index) {
+    return new Period(index, "don't care", null, 1l, 1l);
+  }
+}

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/LanguageDistributionMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/LanguageDistributionMeasuresStepTest.java
@@ -41,7 +41,7 @@ import static org.sonar.server.computation.component.Component.Type.PROJECT;
 import static org.sonar.server.computation.component.ReportComponent.builder;
 import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
 
-public class LanguageDistributionMeasuresTest {
+public class LanguageDistributionMeasuresStepTest {
 
   private static final String XOO_LANGUAGE = "xoo";
   private static final String JAVA_LANGUAGE = "java";

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/PurgeDatastoresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/PurgeDatastoresStepTest.java
@@ -20,40 +20,49 @@
 
 package org.sonar.server.computation.step;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import javax.annotation.Nullable;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.sonar.api.config.Settings;
-import org.sonar.batch.protocol.output.BatchReport;
 import org.sonar.core.computation.dbcleaner.ProjectCleaner;
 import org.sonar.db.DbSession;
 import org.sonar.db.purge.IdUuidPair;
-import org.sonar.server.computation.batch.BatchReportReaderRule;
 import org.sonar.server.computation.batch.TreeRootHolderRule;
 import org.sonar.server.computation.component.Component;
-import org.sonar.server.computation.component.DbIdsRepositoryImpl;
+import org.sonar.server.computation.component.MutableDbIdsRepositoryRule;
 import org.sonar.server.computation.component.ReportComponent;
 import org.sonar.server.computation.component.SettingsRepository;
+import org.sonar.server.computation.component.ViewsComponent;
 import org.sonar.server.db.DbClient;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+@RunWith(DataProviderRunner.class)
 public class PurgeDatastoresStepTest extends BaseStepTest {
 
   private static final String PROJECT_KEY = "PROJECT_KEY";
-
-  @Rule
-  public BatchReportReaderRule reportReader = new BatchReportReaderRule();
+  private static final long PROJECT_ID = 123L;
+  private static final String PROJECT_UUID = "UUID-1234";
 
   @Rule
   public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule();
-
-  DbIdsRepositoryImpl dbIdsRepository = new DbIdsRepositoryImpl();
+  @Rule
+  public MutableDbIdsRepositoryRule dbIdsRepository = MutableDbIdsRepositoryRule.standalone();
 
   ProjectCleaner projectCleaner = mock(ProjectCleaner.class);
   SettingsRepository settingsRepository = mock(SettingsRepository.class);
@@ -61,22 +70,86 @@ public class PurgeDatastoresStepTest extends BaseStepTest {
   PurgeDatastoresStep underTest = new PurgeDatastoresStep(mock(DbClient.class, Mockito.RETURNS_DEEP_STUBS), projectCleaner, dbIdsRepository, treeRootHolder, settingsRepository);
 
   @Test
-  public void call_purge_method_of_the_purge_task() {
-    Component project = ReportComponent.builder(Component.Type.PROJECT, 1).setUuid("UUID-1234").setKey(PROJECT_KEY).build();
+  public void call_purge_method_of_the_purge_task_for_project() {
+    Component project = ReportComponent.builder(Component.Type.PROJECT, 1).setUuid(PROJECT_UUID).setKey(PROJECT_KEY).build();
+
+    verify_call_purge_method_of_the_purge_task(project);
+  }
+
+  @Test
+  public void call_purge_method_of_the_purge_task_for_view() {
+    Component project = ViewsComponent.builder(Component.Type.VIEW, PROJECT_KEY).setUuid(PROJECT_UUID).build();
+
+    verify_call_purge_method_of_the_purge_task(project);
+  }
+
+  @DataProvider
+  public static Object[][] nonRootProjectComponentTypes() {
+    return dataproviderFromComponentTypeValues(new Predicate<Component.Type>() {
+      @Override
+      public boolean apply(Component.Type input) {
+        return input.isReportType() && input != Component.Type.PROJECT;
+      }
+    });
+  }
+
+  @Test
+  @UseDataProvider("nonRootProjectComponentTypes")
+  public void do_not_call_purge_method_of_the_purge_task_for_other_report_components(Component.Type type) {
+    Component component = ReportComponent.builder(type, 1).setUuid(PROJECT_UUID).setKey(PROJECT_KEY).build();
+
+    verify_do_not_call_purge_method_of_the_purge_task(component);
+  }
+
+  @DataProvider
+  public static Object[][] nonRootViewsComponentTypes() {
+    return dataproviderFromComponentTypeValues(new Predicate<Component.Type>() {
+      @Override
+      public boolean apply(Component.Type input) {
+        return input.isViewsType() && input != Component.Type.VIEW;
+      }
+    });
+  }
+
+  @Test
+  @UseDataProvider("nonRootViewsComponentTypes")
+  public void do_not_call_purge_method_of_the_purge_task_for_other_views_components(Component.Type type) {
+    Component component = ViewsComponent.builder(type, PROJECT_KEY).setUuid(PROJECT_UUID).build();
+
+    verify_do_not_call_purge_method_of_the_purge_task(component);
+  }
+
+  private void verify_do_not_call_purge_method_of_the_purge_task(Component component) {
+    treeRootHolder.setRoot(component);
+
+    underTest.execute();
+
+    verifyNoMoreInteractions(projectCleaner);
+  }
+
+  private void verify_call_purge_method_of_the_purge_task(Component project) {
     treeRootHolder.setRoot(project);
     when(settingsRepository.getSettings(project)).thenReturn(new Settings());
-    dbIdsRepository.setComponentId(project, 123L);
-
-    reportReader.setMetadata(BatchReport.Metadata.newBuilder()
-      .setRootComponentRef(1)
-      .build());
+    dbIdsRepository.setComponentId(project, PROJECT_ID);
 
     underTest.execute();
 
     ArgumentCaptor<IdUuidPair> argumentCaptor = ArgumentCaptor.forClass(IdUuidPair.class);
     verify(projectCleaner).purge(any(DbSession.class), argumentCaptor.capture(), any(Settings.class));
-    assertThat(argumentCaptor.getValue().getId()).isEqualTo(123L);
-    assertThat(argumentCaptor.getValue().getUuid()).isEqualTo("UUID-1234");
+    assertThat(argumentCaptor.getValue().getId()).isEqualTo(PROJECT_ID);
+    assertThat(argumentCaptor.getValue().getUuid()).isEqualTo(PROJECT_UUID);
+  }
+
+  private static Object[][] dataproviderFromComponentTypeValues(Predicate<Component.Type> predicate) {
+    return FluentIterable.from(asList(Component.Type.values()))
+        .filter(predicate)
+        .transform(new Function<Object, Object[]>() {
+          @Nullable
+          @Override
+          public Object[] apply(Object input) {
+            return new Object[]{input};
+          }
+        }).toArray(Object[].class);
   }
 
   @Override

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ReportComplexityMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ReportComplexityMeasuresStepTest.java
@@ -24,7 +24,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.server.computation.batch.BatchReportReaderRule;
 import org.sonar.server.computation.batch.TreeRootHolderRule;
-import org.sonar.server.computation.component.ReportComponent;
 import org.sonar.server.computation.measure.MeasureRepositoryRule;
 import org.sonar.server.computation.metric.MetricRepositoryRule;
 
@@ -63,7 +62,7 @@ import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
 import static org.sonar.server.computation.measure.MeasureRepoEntry.entryOf;
 import static org.sonar.server.computation.measure.MeasureRepoEntry.toEntries;
 
-public class ComplexityMeasuresStepTest {
+public class ReportComplexityMeasuresStepTest {
 
   private static final int ROOT_REF = 1;
   private static final int MODULE_REF = 11;
@@ -72,28 +71,24 @@ public class ComplexityMeasuresStepTest {
   private static final int FILE_1_REF = 11111;
   private static final int FILE_2_REF = 11121;
 
-  private static final ReportComponent MULTIPLE_FILES_TREE = builder(PROJECT, ROOT_REF)
-    .addChildren(
-      builder(MODULE, MODULE_REF)
-        .addChildren(
-          builder(MODULE, SUB_MODULE_REF)
-            .addChildren(
-              builder(DIRECTORY, DIRECTORY_REF)
-                .addChildren(
-                  builder(FILE, FILE_1_REF).build(),
-                  builder(FILE, FILE_2_REF).build()
-                ).build()
-            )
-            .build()
-        ).build()
-    ).build();
-
   @Rule
   public BatchReportReaderRule reportReader = new BatchReportReaderRule();
-
   @Rule
-  public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule().setRoot(MULTIPLE_FILES_TREE);
-
+  public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule()
+    .setRoot(builder(PROJECT, ROOT_REF)
+      .addChildren(
+        builder(MODULE, MODULE_REF)
+          .addChildren(
+            builder(MODULE, SUB_MODULE_REF)
+              .addChildren(
+                builder(DIRECTORY, DIRECTORY_REF)
+                  .addChildren(
+                    builder(FILE, FILE_1_REF).build(),
+                    builder(FILE, FILE_2_REF).build())
+                  .build())
+              .build())
+          .build())
+      .build());
   @Rule
   public MetricRepositoryRule metricRepository = new MetricRepositoryRule()
     .add(COMPLEXITY)
@@ -107,9 +102,7 @@ public class ComplexityMeasuresStepTest {
     .add(CLASS_COMPLEXITY)
     .add(CLASSES)
     .add(FUNCTION_COMPLEXITY)
-    .add(FUNCTIONS)
-    ;
-
+    .add(FUNCTIONS);
   @Rule
   public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
 
@@ -130,7 +123,7 @@ public class ComplexityMeasuresStepTest {
     verify_sum_aggregation(COMPLEXITY_IN_FUNCTIONS_KEY);
   }
 
-  private void verify_sum_aggregation(String metricKey){
+  private void verify_sum_aggregation(String metricKey) {
     measureRepository.addRawMeasure(FILE_1_REF, metricKey, newMeasureBuilder().create(10));
     measureRepository.addRawMeasure(FILE_2_REF, metricKey, newMeasureBuilder().create(40));
 
@@ -161,7 +154,7 @@ public class ComplexityMeasuresStepTest {
     verify_distribution_aggregation(CLASS_COMPLEXITY_DISTRIBUTION_KEY);
   }
 
-  private void verify_distribution_aggregation(String metricKey){
+  private void verify_distribution_aggregation(String metricKey) {
     measureRepository.addRawMeasure(FILE_1_REF, metricKey, newMeasureBuilder().create("0.5=3;3.5=5;6.5=9"));
     measureRepository.addRawMeasure(FILE_2_REF, metricKey, newMeasureBuilder().create("0.5=0;3.5=2;6.5=1"));
 
@@ -202,7 +195,7 @@ public class ComplexityMeasuresStepTest {
     verify_average_compute_and_aggregation(FUNCTION_COMPLEXITY_KEY, COMPLEXITY_KEY, FUNCTIONS_KEY);
   }
 
-  private void verify_average_compute_and_aggregation(String metricKey, String mainMetric, String byMetric){
+  private void verify_average_compute_and_aggregation(String metricKey, String mainMetric, String byMetric) {
     measureRepository.addRawMeasure(FILE_1_REF, mainMetric, newMeasureBuilder().create(5));
     measureRepository.addRawMeasure(FILE_1_REF, byMetric, newMeasureBuilder().create(2));
 

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ReportFillMeasuresWithVariationsStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ReportFillMeasuresWithVariationsStepTest.java
@@ -50,7 +50,7 @@ import static org.sonar.server.component.SnapshotTesting.createForComponent;
 import static org.sonar.server.component.SnapshotTesting.createForProject;
 
 @Category(DbTests.class)
-public class FillMeasuresWithVariationsStepTest {
+public class ReportFillMeasuresWithVariationsStepTest {
 
   static final Metric ISSUES_METRIC = new MetricImpl(1, "violations", "violations", Metric.MetricType.INT);
   static final Metric DEBT_METRIC = new MetricImpl(2, "sqale_index", "sqale_index", Metric.MetricType.WORK_DUR);

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ReportLanguageDistributionMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ReportLanguageDistributionMeasuresStepTest.java
@@ -41,7 +41,7 @@ import static org.sonar.server.computation.component.Component.Type.PROJECT;
 import static org.sonar.server.computation.component.ReportComponent.builder;
 import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
 
-public class LanguageDistributionMeasuresStepTest {
+public class ReportLanguageDistributionMeasuresStepTest {
 
   private static final String XOO_LANGUAGE = "xoo";
   private static final String JAVA_LANGUAGE = "java";
@@ -82,11 +82,11 @@ public class LanguageDistributionMeasuresStepTest {
                       builder(FILE, FILE_1_REF).setFileAttributes(new FileAttributes(false, XOO_LANGUAGE)).build(),
                       builder(FILE, FILE_2_REF).setFileAttributes(new FileAttributes(false, XOO_LANGUAGE)).build(),
                       builder(FILE, FILE_3_REF).setFileAttributes(new FileAttributes(false, JAVA_LANGUAGE)).build(),
-                      builder(FILE, FILE_4_REF).setFileAttributes(new FileAttributes(false, null)).build()
-                    ).build()
-                ).build()
-            ).build()
-        ).build());
+                      builder(FILE, FILE_4_REF).setFileAttributes(new FileAttributes(false, null)).build())
+                    .build())
+                .build())
+            .build())
+        .build());
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ReportNewCoverageMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ReportNewCoverageMeasuresStepTest.java
@@ -60,7 +60,7 @@ import static org.sonar.server.computation.measure.MeasureRepoEntry.entryOf;
 import static org.sonar.server.computation.measure.MeasureRepoEntry.toEntries;
 import static org.sonar.server.computation.measure.MeasureVariations.newMeasureVariationsBuilder;
 
-public class NewCoverageMeasuresStepTest {
+public class ReportNewCoverageMeasuresStepTest {
 
   private static final int ROOT_REF = 1;
   private static final int MODULE_REF = 11;

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ReportUnitTestMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ReportUnitTestMeasuresStepTest.java
@@ -21,7 +21,6 @@
 package org.sonar.server.computation.step;
 
 import org.assertj.core.data.Offset;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.server.computation.batch.TreeRootHolderRule;
@@ -52,7 +51,7 @@ import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
 import static org.sonar.server.computation.measure.MeasureRepoEntry.entryOf;
 import static org.sonar.server.computation.measure.MeasureRepoEntry.toEntries;
 
-public class UnitTestMeasuresStepTest {
+public class ReportUnitTestMeasuresStepTest {
 
   private static final Offset<Double> DEFAULT_OFFSET = Offset.offset(0.01d);
 
@@ -64,25 +63,8 @@ public class UnitTestMeasuresStepTest {
   private static final int FILE_2_REF = 12342;
 
   @Rule
-  public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule();
-
-  @Rule
-  public MetricRepositoryRule metricRepository = new MetricRepositoryRule()
-    .add(TESTS)
-    .add(TEST_ERRORS)
-    .add(TEST_FAILURES)
-    .add(TEST_EXECUTION_TIME)
-    .add(SKIPPED_TESTS)
-    .add(TEST_SUCCESS_DENSITY);
-
-  @Rule
-  public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
-
-  ComputationStep underTest = new UnitTestMeasuresStep(treeRootHolder, metricRepository, measureRepository);
-
-  @Before
-  public void setUp() throws Exception {
-    treeRootHolder.setRoot(
+  public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule()
+    .setRoot(
       builder(PROJECT, ROOT_REF)
         .addChildren(
           builder(MODULE, MODULE_REF)
@@ -92,12 +74,23 @@ public class UnitTestMeasuresStepTest {
                   builder(DIRECTORY, DIRECTORY_REF)
                     .addChildren(
                       builder(FILE, FILE_1_REF).setFileAttributes(new FileAttributes(true, null)).build(),
-                      builder(FILE, FILE_2_REF).setFileAttributes(new FileAttributes(true, null)).build()
-                    ).build()
-                ).build()
-            ).build()
-        ).build());
-  }
+                      builder(FILE, FILE_2_REF).setFileAttributes(new FileAttributes(true, null)).build())
+                    .build())
+                .build())
+            .build())
+        .build());
+  @Rule
+  public MetricRepositoryRule metricRepository = new MetricRepositoryRule()
+    .add(TESTS)
+    .add(TEST_ERRORS)
+    .add(TEST_FAILURES)
+    .add(TEST_EXECUTION_TIME)
+    .add(SKIPPED_TESTS)
+    .add(TEST_SUCCESS_DENSITY);
+  @Rule
+  public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
+
+  ComputationStep underTest = new UnitTestMeasuresStep(treeRootHolder, metricRepository, measureRepository);
 
   @Test
   public void aggregate_tests() {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ViewsComplexityMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ViewsComplexityMeasuresStepTest.java
@@ -1,0 +1,242 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.server.computation.step;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.server.computation.batch.BatchReportReaderRule;
+import org.sonar.server.computation.batch.TreeRootHolderRule;
+import org.sonar.server.computation.measure.MeasureRepositoryRule;
+import org.sonar.server.computation.metric.MetricRepositoryRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.guava.api.Assertions.assertThat;
+import static org.sonar.api.measures.CoreMetrics.CLASSES;
+import static org.sonar.api.measures.CoreMetrics.CLASSES_KEY;
+import static org.sonar.api.measures.CoreMetrics.CLASS_COMPLEXITY;
+import static org.sonar.api.measures.CoreMetrics.CLASS_COMPLEXITY_DISTRIBUTION;
+import static org.sonar.api.measures.CoreMetrics.CLASS_COMPLEXITY_DISTRIBUTION_KEY;
+import static org.sonar.api.measures.CoreMetrics.CLASS_COMPLEXITY_KEY;
+import static org.sonar.api.measures.CoreMetrics.COMPLEXITY;
+import static org.sonar.api.measures.CoreMetrics.COMPLEXITY_IN_CLASSES;
+import static org.sonar.api.measures.CoreMetrics.COMPLEXITY_IN_CLASSES_KEY;
+import static org.sonar.api.measures.CoreMetrics.COMPLEXITY_IN_FUNCTIONS;
+import static org.sonar.api.measures.CoreMetrics.COMPLEXITY_IN_FUNCTIONS_KEY;
+import static org.sonar.api.measures.CoreMetrics.COMPLEXITY_KEY;
+import static org.sonar.api.measures.CoreMetrics.FILES;
+import static org.sonar.api.measures.CoreMetrics.FILES_KEY;
+import static org.sonar.api.measures.CoreMetrics.FILE_COMPLEXITY;
+import static org.sonar.api.measures.CoreMetrics.FILE_COMPLEXITY_DISTRIBUTION;
+import static org.sonar.api.measures.CoreMetrics.FILE_COMPLEXITY_DISTRIBUTION_KEY;
+import static org.sonar.api.measures.CoreMetrics.FILE_COMPLEXITY_KEY;
+import static org.sonar.api.measures.CoreMetrics.FUNCTIONS;
+import static org.sonar.api.measures.CoreMetrics.FUNCTIONS_KEY;
+import static org.sonar.api.measures.CoreMetrics.FUNCTION_COMPLEXITY;
+import static org.sonar.api.measures.CoreMetrics.FUNCTION_COMPLEXITY_DISTRIBUTION;
+import static org.sonar.api.measures.CoreMetrics.FUNCTION_COMPLEXITY_DISTRIBUTION_KEY;
+import static org.sonar.api.measures.CoreMetrics.FUNCTION_COMPLEXITY_KEY;
+import static org.sonar.server.computation.component.Component.Type.PROJECT_VIEW;
+import static org.sonar.server.computation.component.Component.Type.SUBVIEW;
+import static org.sonar.server.computation.component.Component.Type.VIEW;
+import static org.sonar.server.computation.component.ViewsComponent.builder;
+import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
+import static org.sonar.server.computation.measure.MeasureRepoEntry.entryOf;
+import static org.sonar.server.computation.measure.MeasureRepoEntry.toEntries;
+
+public class ViewsComplexityMeasuresStepTest {
+
+  private static final int ROOT_REF = 1;
+  private static final int SUBVIEW_REF = 11;
+  private static final int SUB_SUBVIEW_1_REF = 111;
+  private static final int PROJECT_VIEW_1_REF = 11111;
+  private static final int PROJECT_VIEW_2_REF = 11121;
+  private static final int SUB_SUBVIEW_2_REF = 112;
+  private static final int PROJECT_VIEW_3_REF = 12;
+
+  @Rule
+  public BatchReportReaderRule reportReader = new BatchReportReaderRule();
+  @Rule
+  public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule()
+    .setRoot(builder(VIEW, ROOT_REF)
+      .addChildren(
+        builder(SUBVIEW, SUBVIEW_REF)
+          .addChildren(
+            builder(SUBVIEW, SUB_SUBVIEW_1_REF)
+              .addChildren(
+                builder(PROJECT_VIEW, PROJECT_VIEW_1_REF).build(),
+                builder(PROJECT_VIEW, PROJECT_VIEW_2_REF).build())
+              .build(),
+            builder(SUBVIEW, SUB_SUBVIEW_2_REF).build())
+          .build(),
+        builder(PROJECT_VIEW, PROJECT_VIEW_3_REF).build())
+      .build());
+  @Rule
+  public MetricRepositoryRule metricRepository = new MetricRepositoryRule()
+    .add(COMPLEXITY)
+    .add(COMPLEXITY_IN_CLASSES)
+    .add(COMPLEXITY_IN_FUNCTIONS)
+    .add(FUNCTION_COMPLEXITY_DISTRIBUTION)
+    .add(FILE_COMPLEXITY_DISTRIBUTION)
+    .add(CLASS_COMPLEXITY_DISTRIBUTION)
+    .add(FILE_COMPLEXITY)
+    .add(FILES)
+    .add(CLASS_COMPLEXITY)
+    .add(CLASSES)
+    .add(FUNCTION_COMPLEXITY)
+    .add(FUNCTIONS);
+  @Rule
+  public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
+
+  private ComputationStep underTest = new ComplexityMeasuresStep(treeRootHolder, metricRepository, measureRepository);
+
+  @Test
+  public void aggregate_complexity() throws Exception {
+    verify_sum_aggregation(COMPLEXITY_KEY);
+  }
+
+  @Test
+  public void aggregate_complexity_in_classes() throws Exception {
+    verify_sum_aggregation(COMPLEXITY_IN_CLASSES_KEY);
+  }
+
+  @Test
+  public void aggregate_complexity_in_functions() throws Exception {
+    verify_sum_aggregation(COMPLEXITY_IN_FUNCTIONS_KEY);
+  }
+
+  private void verify_sum_aggregation(String metricKey) {
+    addRawMeasureValue(PROJECT_VIEW_1_REF, metricKey, 10);
+    addRawMeasureValue(PROJECT_VIEW_2_REF, metricKey, 40);
+    addRawMeasureValue(PROJECT_VIEW_3_REF, metricKey, 20);
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertAddedRawMeasures(SUB_SUBVIEW_1_REF, metricKey, 50);
+    assertNoAddedRawMeasure(SUB_SUBVIEW_2_REF);
+    assertAddedRawMeasures(SUBVIEW_REF, metricKey, 50);
+    assertAddedRawMeasures(ROOT_REF, metricKey, 70);
+  }
+
+  @Test
+  public void aggregate_function_complexity_distribution() throws Exception {
+    verify_distribution_aggregation(FUNCTION_COMPLEXITY_DISTRIBUTION_KEY);
+  }
+
+  @Test
+  public void aggregate_file_complexity_distribution() throws Exception {
+    verify_distribution_aggregation(FILE_COMPLEXITY_DISTRIBUTION_KEY);
+  }
+
+  @Test
+  public void aggregate_class_complexity_distribution() throws Exception {
+    verify_distribution_aggregation(CLASS_COMPLEXITY_DISTRIBUTION_KEY);
+  }
+
+  private void verify_distribution_aggregation(String metricKey) {
+    addRawMeasure(PROJECT_VIEW_1_REF, metricKey, "0.5=3;3.5=5;6.5=9");
+    addRawMeasure(PROJECT_VIEW_2_REF, metricKey, "0.5=0;3.5=2;6.5=1");
+    addRawMeasure(PROJECT_VIEW_3_REF, metricKey, "0.5=1;3.5=1;6.5=0");
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertAddedRawMeasures(SUB_SUBVIEW_1_REF, metricKey, "0.5=3;3.5=7;6.5=10");
+    assertNoAddedRawMeasure(SUB_SUBVIEW_2_REF);
+    assertAddedRawMeasures(SUBVIEW_REF, metricKey, "0.5=3;3.5=7;6.5=10");
+    assertAddedRawMeasures(ROOT_REF, metricKey, "0.5=4;3.5=8;6.5=10");
+  }
+
+  @Test
+  public void compute_and_aggregate_file_complexity() throws Exception {
+    verify_average_compute_and_aggregation(FILE_COMPLEXITY_KEY, COMPLEXITY_KEY, FILES_KEY);
+  }
+
+  @Test
+  public void compute_and_aggregate_class_complexity() throws Exception {
+    verify_average_compute_and_aggregation(CLASS_COMPLEXITY_KEY, COMPLEXITY_IN_CLASSES_KEY, CLASSES_KEY);
+  }
+
+  @Test
+  public void compute_and_aggregate_class_complexity_with_fallback_metric() throws Exception {
+    verify_average_compute_and_aggregation(CLASS_COMPLEXITY_KEY, COMPLEXITY_KEY, CLASSES_KEY);
+  }
+
+  @Test
+  public void compute_and_aggregate_function_complexity() throws Exception {
+    verify_average_compute_and_aggregation(FUNCTION_COMPLEXITY_KEY, COMPLEXITY_IN_FUNCTIONS_KEY, FUNCTIONS_KEY);
+  }
+
+  @Test
+  public void compute_and_aggregate_function_complexity_with_fallback_metric() throws Exception {
+    verify_average_compute_and_aggregation(FUNCTION_COMPLEXITY_KEY, COMPLEXITY_KEY, FUNCTIONS_KEY);
+  }
+
+  private void verify_average_compute_and_aggregation(String metricKey, String mainMetric, String byMetric) {
+    addRawMeasureValue(PROJECT_VIEW_1_REF, mainMetric, 5);
+    addRawMeasureValue(PROJECT_VIEW_1_REF, byMetric, 2);
+
+    addRawMeasureValue(PROJECT_VIEW_2_REF, mainMetric, 1);
+    addRawMeasureValue(PROJECT_VIEW_2_REF, byMetric, 1);
+
+    addRawMeasureValue(PROJECT_VIEW_3_REF, mainMetric, 6);
+    addRawMeasureValue(PROJECT_VIEW_3_REF, byMetric, 8);
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertAddedRawMeasures(SUB_SUBVIEW_1_REF, metricKey, 2d);
+    assertNoAddedRawMeasure(SUB_SUBVIEW_2_REF);
+    assertAddedRawMeasures(SUBVIEW_REF, metricKey, 2d);
+    assertAddedRawMeasures(ROOT_REF, metricKey, 1.1d);
+  }
+
+  private void addRawMeasure(int componentRef, String metricKey, String value) {
+    measureRepository.addRawMeasure(componentRef, metricKey, newMeasureBuilder().create(value));
+  }
+
+  private void assertNoAddedRawMeasureOnProjectViews() {
+    assertNoAddedRawMeasure(PROJECT_VIEW_1_REF);
+    assertNoAddedRawMeasure(PROJECT_VIEW_2_REF);
+    assertNoAddedRawMeasure(PROJECT_VIEW_3_REF);
+  }
+
+  private void assertNoAddedRawMeasure(int componentRef) {
+    assertThat(measureRepository.getAddedRawMeasures(componentRef)).isEmpty();
+  }
+
+  private void assertAddedRawMeasures(int componentRef, String metricKey, String expected) {
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(componentRef))).contains(entryOf(metricKey, newMeasureBuilder().create(expected)));
+  }
+
+  private void assertAddedRawMeasures(int componentRef, String metricKey, int expected) {
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(componentRef))).contains(entryOf(metricKey, newMeasureBuilder().create(expected)));
+  }
+
+  private void assertAddedRawMeasures(int componentRef, String metricKey, double expected) {
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(componentRef))).contains(entryOf(metricKey, newMeasureBuilder().create(expected)));
+  }
+
+  private void addRawMeasureValue(int componentRef, String metricKey, int value) {
+    measureRepository.addRawMeasure(componentRef, metricKey, newMeasureBuilder().create(value));
+  }
+
+}

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ViewsFillMeasuresWithVariationsStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ViewsFillMeasuresWithVariationsStepTest.java
@@ -1,0 +1,241 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.server.computation.step;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.sonar.api.utils.System2;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.DbTester;
+import org.sonar.db.component.ComponentDto;
+import org.sonar.db.component.ComponentTesting;
+import org.sonar.db.component.SnapshotDto;
+import org.sonar.db.measure.MeasureDto;
+import org.sonar.server.computation.batch.BatchReportReaderRule;
+import org.sonar.server.computation.batch.TreeRootHolderRule;
+import org.sonar.server.computation.component.Component;
+import org.sonar.server.computation.component.ViewsComponent;
+import org.sonar.server.computation.measure.Measure;
+import org.sonar.server.computation.measure.MeasureRepositoryRule;
+import org.sonar.server.computation.metric.Metric;
+import org.sonar.server.computation.metric.MetricImpl;
+import org.sonar.server.computation.metric.MetricRepositoryRule;
+import org.sonar.server.computation.period.Period;
+import org.sonar.server.computation.period.PeriodsHolderRule;
+import org.sonar.test.DbTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.server.component.SnapshotTesting.createForComponent;
+import static org.sonar.server.component.SnapshotTesting.createForProject;
+import static org.sonar.server.component.SnapshotTesting.createForView;
+
+@Category(DbTests.class)
+public class ViewsFillMeasuresWithVariationsStepTest {
+
+  static final Metric ISSUES_METRIC = new MetricImpl(1, "violations", "violations", Metric.MetricType.INT);
+  static final Metric DEBT_METRIC = new MetricImpl(2, "sqale_index", "sqale_index", Metric.MetricType.WORK_DUR);
+  static final Metric FILE_COMPLEXITY_METRIC = new MetricImpl(3, "file_complexity", "file_complexity", Metric.MetricType.FLOAT);
+  static final Metric BUILD_BREAKER_METRIC = new MetricImpl(4, "build_breaker", "build_breaker", Metric.MetricType.BOOL);
+
+  static final ComponentDto VIEW_DTO = ComponentTesting.newView();
+
+  static final Component VIEW = ViewsComponent.builder(Component.Type.VIEW, 1).setUuid(VIEW_DTO.uuid()).build();
+
+  @Rule
+  public DbTester dbTester = DbTester.create(System2.INSTANCE);
+
+  @Rule
+  public BatchReportReaderRule reportReader = new BatchReportReaderRule();
+
+  @Rule
+  public PeriodsHolderRule periodsHolder = new PeriodsHolderRule();
+
+  @Rule
+  public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule();
+
+  @Rule
+  public MetricRepositoryRule metricRepository = new MetricRepositoryRule()
+    .add(ISSUES_METRIC)
+    .add(DEBT_METRIC)
+    .add(FILE_COMPLEXITY_METRIC)
+    .add(BUILD_BREAKER_METRIC);
+
+  @Rule
+  public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
+
+  DbSession session = dbTester.getSession();
+
+  DbClient dbClient = dbTester.getDbClient();
+
+  FillMeasuresWithVariationsStep underTest;
+
+  @Before
+  public void setUp() {
+    dbTester.truncateTables();
+    dbClient.componentDao().insert(session, VIEW_DTO);
+    session.commit();
+
+    underTest = new FillMeasuresWithVariationsStep(dbClient, treeRootHolder, periodsHolder, metricRepository, measureRepository);
+  }
+
+  @Test
+  public void do_nothing_when_no_raw_measure() {
+    SnapshotDto period1ViewSnapshot = createForView(VIEW_DTO);
+    dbClient.snapshotDao().insert(session, period1ViewSnapshot);
+    dbClient.measureDao().insert(session, newMeasureDto(ISSUES_METRIC.getId(), VIEW_DTO.getId(), period1ViewSnapshot.getId(), 60d));
+    session.commit();
+
+    periodsHolder.setPeriods(newPeriod(1, period1ViewSnapshot));
+
+    treeRootHolder.setRoot(VIEW);
+
+    underTest.execute();
+
+    assertThat(measureRepository.getRawMeasures(VIEW).keys()).isEmpty();
+  }
+
+  @Test
+  public void do_nothing_when_no_period() {
+    Component view = ViewsComponent.builder(Component.Type.VIEW, 1).setUuid(VIEW_DTO.uuid()).build();
+    treeRootHolder.setRoot(view);
+    periodsHolder.setPeriods();
+
+    underTest.execute();
+
+    assertThat(measureRepository.getRawMeasures(view).keys()).isEmpty();
+  }
+
+  @Test
+  public void set_variation() {
+    // View
+    SnapshotDto period1ViewSnapshot = createForView(VIEW_DTO);
+    dbClient.snapshotDao().insert(session, period1ViewSnapshot);
+    dbClient.measureDao().insert(session, newMeasureDto(ISSUES_METRIC.getId(), VIEW_DTO.getId(), period1ViewSnapshot.getId(), 60d));
+
+    // SubView
+    ComponentDto subviewDto = ComponentTesting.newSubView(VIEW_DTO, "dir", "who cares?");
+    dbClient.componentDao().insert(session, subviewDto);
+    SnapshotDto period1SubviewSnapshot = createForComponent(subviewDto, period1ViewSnapshot);
+    dbClient.snapshotDao().insert(session, period1SubviewSnapshot);
+    dbClient.measureDao().insert(session, newMeasureDto(ISSUES_METRIC.getId(), subviewDto.getId(), period1SubviewSnapshot.getId(), 10d));
+    session.commit();
+
+    periodsHolder.setPeriods(newPeriod(1, period1ViewSnapshot));
+
+    Component subview = ViewsComponent.builder(Component.Type.SUBVIEW, 2).setUuid(subviewDto.uuid()).build();
+    Component view = ViewsComponent.builder(Component.Type.VIEW, 1).setUuid(VIEW_DTO.uuid()).addChildren(subview).build();
+    treeRootHolder.setRoot(view);
+
+    addRawMeasure(view, ISSUES_METRIC, Measure.newMeasureBuilder().create(80, null));
+    addRawMeasure(subview, ISSUES_METRIC, Measure.newMeasureBuilder().create(20, null));
+
+    underTest.execute();
+
+    assertThat(measureRepository.getRawMeasure(view, ISSUES_METRIC).get().getVariations().getVariation1()).isEqualTo(20d);
+    assertThat(measureRepository.getRawMeasure(subview, ISSUES_METRIC).get().getVariations().getVariation1()).isEqualTo(10d);
+  }
+
+  @Test
+  public void set_variations_on_all_periods() {
+    SnapshotDto period1ViewSnapshot = createForProject(VIEW_DTO).setLast(false);
+    SnapshotDto period2ViewSnapshot = createForProject(VIEW_DTO).setLast(false);
+    SnapshotDto period3ViewSnapshot = createForProject(VIEW_DTO).setLast(false);
+    SnapshotDto period4ViewSnapshot = createForProject(VIEW_DTO).setLast(false);
+    SnapshotDto period5ViewSnapshot = createForProject(VIEW_DTO).setLast(false);
+    dbClient.snapshotDao().insert(session, period1ViewSnapshot, period2ViewSnapshot, period3ViewSnapshot, period4ViewSnapshot, period5ViewSnapshot);
+
+    dbClient.measureDao().insert(session,
+      newMeasureDto(ISSUES_METRIC.getId(), VIEW_DTO.getId(), period1ViewSnapshot.getId(), 0d),
+      newMeasureDto(ISSUES_METRIC.getId(), VIEW_DTO.getId(), period2ViewSnapshot.getId(), 20d),
+      newMeasureDto(ISSUES_METRIC.getId(), VIEW_DTO.getId(), period3ViewSnapshot.getId(), 40d),
+      newMeasureDto(ISSUES_METRIC.getId(), VIEW_DTO.getId(), period4ViewSnapshot.getId(), 80d),
+      newMeasureDto(ISSUES_METRIC.getId(), VIEW_DTO.getId(), period5ViewSnapshot.getId(), 100d));
+    session.commit();
+
+    periodsHolder.setPeriods(newPeriod(1, period1ViewSnapshot),
+      newPeriod(2, period2ViewSnapshot),
+      newPeriod(3, period3ViewSnapshot),
+      newPeriod(4, period4ViewSnapshot),
+      newPeriod(5, period5ViewSnapshot));
+
+    treeRootHolder.setRoot(VIEW);
+
+    addRawMeasure(VIEW, ISSUES_METRIC, Measure.newMeasureBuilder().create(80, null));
+
+    underTest.execute();
+
+    assertThat(measureRepository.getRawMeasures(VIEW).keys()).hasSize(1);
+
+    Measure measure = measureRepository.getRawMeasure(VIEW, ISSUES_METRIC).get();
+    assertThat(measure.hasVariations()).isTrue();
+    assertThat(measure.getVariations().getVariation1()).isEqualTo(80d);
+    assertThat(measure.getVariations().getVariation2()).isEqualTo(60d);
+    assertThat(measure.getVariations().getVariation3()).isEqualTo(40d);
+    assertThat(measure.getVariations().getVariation4()).isEqualTo(0d);
+    assertThat(measure.getVariations().getVariation5()).isEqualTo(-20d);
+  }
+
+  @Test
+  public void set_variation_on_all_numeric_metrics() {
+    SnapshotDto period1ViewSnapshot = createForProject(VIEW_DTO);
+    dbClient.snapshotDao().insert(session, period1ViewSnapshot);
+    dbClient.measureDao().insert(session,
+      newMeasureDto(ISSUES_METRIC.getId(), VIEW_DTO.getId(), period1ViewSnapshot.getId(), 60d),
+      newMeasureDto(DEBT_METRIC.getId(), VIEW_DTO.getId(), period1ViewSnapshot.getId(), 10d),
+      newMeasureDto(FILE_COMPLEXITY_METRIC.getId(), VIEW_DTO.getId(), period1ViewSnapshot.getId(), 2d),
+      newMeasureDto(BUILD_BREAKER_METRIC.getId(), VIEW_DTO.getId(), period1ViewSnapshot.getId(), 1d)
+    );
+    session.commit();
+
+    periodsHolder.setPeriods(newPeriod(1, period1ViewSnapshot));
+
+    treeRootHolder.setRoot(VIEW);
+
+    addRawMeasure(VIEW, ISSUES_METRIC, Measure.newMeasureBuilder().create(80, null));
+    addRawMeasure(VIEW, DEBT_METRIC, Measure.newMeasureBuilder().create(5L, null));
+    addRawMeasure(VIEW, FILE_COMPLEXITY_METRIC, Measure.newMeasureBuilder().create(3d, null));
+    addRawMeasure(VIEW, BUILD_BREAKER_METRIC, Measure.newMeasureBuilder().create(false, null));
+
+    underTest.execute();
+
+    assertThat(measureRepository.getRawMeasures(VIEW).keys()).hasSize(4);
+
+    assertThat(measureRepository.getRawMeasure(VIEW, ISSUES_METRIC).get().getVariations().getVariation1()).isEqualTo(20d);
+    assertThat(measureRepository.getRawMeasure(VIEW, DEBT_METRIC).get().getVariations().getVariation1()).isEqualTo(-5d);
+    assertThat(measureRepository.getRawMeasure(VIEW, FILE_COMPLEXITY_METRIC).get().getVariations().getVariation1()).isEqualTo(1d);
+    assertThat(measureRepository.getRawMeasure(VIEW, BUILD_BREAKER_METRIC).get().getVariations().getVariation1()).isEqualTo(-1d);
+  }
+
+  private static MeasureDto newMeasureDto(int metricId, long projectId, long snapshotId, double value) {
+    return new MeasureDto().setMetricId(metricId).setComponentId(projectId).setSnapshotId(snapshotId).setValue(value);
+  }
+
+  private static Period newPeriod(int index, SnapshotDto snapshotDto) {
+    return new Period(index, "mode", null, snapshotDto.getCreatedAt(), snapshotDto.getId());
+  }
+
+  private void addRawMeasure(Component component, Metric metric, Measure measure) {
+    measureRepository.add(component, metric, measure);
+  }
+}

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ViewsLanguageDistributionMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ViewsLanguageDistributionMeasuresStepTest.java
@@ -1,0 +1,118 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.server.computation.step;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.server.computation.batch.TreeRootHolderRule;
+import org.sonar.server.computation.measure.MeasureRepositoryRule;
+import org.sonar.server.computation.metric.MetricRepositoryRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.guava.api.Assertions.assertThat;
+import static org.sonar.api.measures.CoreMetrics.NCLOC_LANGUAGE_DISTRIBUTION;
+import static org.sonar.api.measures.CoreMetrics.NCLOC_LANGUAGE_DISTRIBUTION_KEY;
+import static org.sonar.server.computation.component.Component.Type.PROJECT_VIEW;
+import static org.sonar.server.computation.component.Component.Type.SUBVIEW;
+import static org.sonar.server.computation.component.Component.Type.VIEW;
+import static org.sonar.server.computation.component.ViewsComponent.builder;
+import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
+
+public class ViewsLanguageDistributionMeasuresStepTest {
+
+  private static final int ROOT_REF = 1;
+  private static final int SUBVIEW_1_REF = 12;
+  private static final int SUB_SUBVIEW_1_REF = 121;
+  private static final int PROJECT_VIEW_1_REF = 1211;
+  private static final int PROJECT_VIEW_2_REF = 1212;
+  private static final int PROJECT_VIEW_3_REF = 1213;
+  private static final int SUB_SUBVIEW_2_REF = 122;
+  private static final int SUBVIEW_2_REF = 13;
+  private static final int PROJECT_VIEW_4_REF = 131;
+  private static final int PROJECT_VIEW_5_REF = 14;
+
+  @Rule
+  public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule()
+    .setRoot(builder(VIEW, ROOT_REF)
+      .addChildren(
+        builder(SUBVIEW, SUBVIEW_1_REF)
+          .addChildren(
+            builder(SUBVIEW, SUB_SUBVIEW_1_REF)
+              .addChildren(
+                  builder(PROJECT_VIEW, PROJECT_VIEW_1_REF).build(),
+                  builder(PROJECT_VIEW, PROJECT_VIEW_2_REF).build(),
+                  builder(PROJECT_VIEW, PROJECT_VIEW_3_REF).build())
+              .build(),
+            builder(SUBVIEW, SUB_SUBVIEW_2_REF).build())
+          .build(),
+        builder(SUBVIEW, SUBVIEW_2_REF)
+          .addChildren(
+            builder(PROJECT_VIEW, PROJECT_VIEW_4_REF).build())
+          .build(),
+        builder(PROJECT_VIEW, PROJECT_VIEW_5_REF).build())
+      .build());
+  @Rule
+  public MetricRepositoryRule metricRepository = new MetricRepositoryRule()
+    .add(NCLOC_LANGUAGE_DISTRIBUTION);
+  @Rule
+  public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
+
+  ComputationStep underTest = new LanguageDistributionMeasuresStep(treeRootHolder, metricRepository, measureRepository);
+
+  @Test
+  public void compute_ncloc_language_distribution() {
+    addRawMeasure(PROJECT_VIEW_1_REF, NCLOC_LANGUAGE_DISTRIBUTION_KEY, "xoo=10");
+    addRawMeasure(PROJECT_VIEW_2_REF, NCLOC_LANGUAGE_DISTRIBUTION_KEY, "java=6");
+    addRawMeasure(PROJECT_VIEW_3_REF, NCLOC_LANGUAGE_DISTRIBUTION_KEY, "java=10;xoo=5");
+    // no raw measure on PROJECT_VIEW_4_REF
+    addRawMeasure(PROJECT_VIEW_5_REF, NCLOC_LANGUAGE_DISTRIBUTION_KEY, "<null>=3;foo=10");
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertAddedRawMeasure(SUB_SUBVIEW_1_REF, NCLOC_LANGUAGE_DISTRIBUTION_KEY, "java=16;xoo=15");
+    assertNoAddedRawMeasures(SUB_SUBVIEW_2_REF);
+    assertNoAddedRawMeasures(SUBVIEW_2_REF);
+    assertAddedRawMeasure(SUBVIEW_1_REF, NCLOC_LANGUAGE_DISTRIBUTION_KEY, "java=16;xoo=15");
+    assertAddedRawMeasure(ROOT_REF, NCLOC_LANGUAGE_DISTRIBUTION_KEY, "<null>=3;foo=10;java=16;xoo=15");
+  }
+
+  private void assertAddedRawMeasure(int componentRef, String metricKey, String value) {
+    assertThat(measureRepository.getAddedRawMeasure(componentRef, metricKey).get().getStringValue()).isEqualTo(value);
+  }
+
+  private void addRawMeasure(int componentRef, String metricKey, String value) {
+    measureRepository.addRawMeasure(componentRef, metricKey, newMeasureBuilder().create(value));
+  }
+
+  private void assertNoAddedRawMeasureOnProjectViews() {
+    assertNoAddedRawMeasures(PROJECT_VIEW_1_REF);
+    assertNoAddedRawMeasures(PROJECT_VIEW_2_REF);
+    assertNoAddedRawMeasures(PROJECT_VIEW_3_REF);
+    assertNoAddedRawMeasures(PROJECT_VIEW_4_REF);
+    assertNoAddedRawMeasures(PROJECT_VIEW_5_REF);
+  }
+
+  private void assertNoAddedRawMeasures(int componentRef) {
+    assertThat(measureRepository.getAddedRawMeasures(componentRef)).isEmpty();
+  }
+
+}

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ViewsNewCoverageMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ViewsNewCoverageMeasuresStepTest.java
@@ -1,0 +1,283 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.computation.step;
+
+import javax.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.api.measures.CoreMetrics;
+import org.sonar.server.computation.batch.TreeRootHolderRule;
+import org.sonar.server.computation.component.ViewsComponent;
+import org.sonar.server.computation.formula.coverage.LinesAndConditionsWithUncoveredMetricKeys;
+import org.sonar.server.computation.measure.Measure;
+import org.sonar.server.computation.measure.MeasureRepositoryRule;
+import org.sonar.server.computation.measure.MeasureVariations;
+import org.sonar.server.computation.metric.MetricRepositoryRule;
+import org.sonar.server.computation.period.Period;
+import org.sonar.server.computation.period.PeriodsHolderRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.guava.api.Assertions.assertThat;
+import static org.sonar.api.utils.DateUtils.parseDate;
+import static org.sonar.server.computation.component.Component.Type.PROJECT_VIEW;
+import static org.sonar.server.computation.component.Component.Type.SUBVIEW;
+import static org.sonar.server.computation.component.Component.Type.VIEW;
+import static org.sonar.server.computation.component.ViewsComponent.builder;
+import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
+import static org.sonar.server.computation.measure.MeasureRepoEntry.entryOf;
+import static org.sonar.server.computation.measure.MeasureRepoEntry.toEntries;
+import static org.sonar.server.computation.measure.MeasureVariations.newMeasureVariationsBuilder;
+
+public class ViewsNewCoverageMeasuresStepTest {
+
+  private static final int ROOT_REF = 1;
+  private static final int SUBVIEW_REF = 11;
+  private static final int SUB_SUBVIEW_1_REF = 111;
+  private static final int PROJECT_VIEW_1_REF = 1111;
+  private static final int SUB_SUBVIEW_2_REF = 112;
+  private static final int PROJECT_VIEW_2_REF = 1121;
+  private static final int PROJECT_VIEW_3_REF = 1122;
+  private static final int PROJECT_VIEW_4_REF = 12;
+
+  private static final ViewsComponent VIEWS_TREE = builder(VIEW, ROOT_REF)
+    .addChildren(
+      builder(SUBVIEW, SUBVIEW_REF)
+        .addChildren(
+          builder(SUBVIEW, SUB_SUBVIEW_1_REF)
+            .addChildren(
+              builder(PROJECT_VIEW, PROJECT_VIEW_1_REF).build())
+            .build(),
+          builder(SUBVIEW, SUB_SUBVIEW_2_REF)
+            .addChildren(
+              builder(PROJECT_VIEW, PROJECT_VIEW_2_REF).build(),
+              builder(PROJECT_VIEW, PROJECT_VIEW_3_REF).build())
+            .build(),
+          builder(PROJECT_VIEW, PROJECT_VIEW_4_REF).build())
+        .build())
+    .build();
+  private static final Double NO_PERIOD_4_OR_5_IN_VIEWS = null;
+
+  @Rule
+  public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule();
+  @Rule
+  public PeriodsHolderRule periodsHolder = new PeriodsHolderRule();
+  @Rule
+  public MetricRepositoryRule metricRepository = new MetricRepositoryRule()
+    .add(CoreMetrics.COVERAGE_LINE_HITS_DATA)
+    .add(CoreMetrics.CONDITIONS_BY_LINE)
+    .add(CoreMetrics.COVERED_CONDITIONS_BY_LINE)
+    .add(CoreMetrics.NEW_LINES_TO_COVER)
+    .add(CoreMetrics.NEW_UNCOVERED_LINES)
+    .add(CoreMetrics.NEW_CONDITIONS_TO_COVER)
+    .add(CoreMetrics.NEW_UNCOVERED_CONDITIONS)
+    .add(CoreMetrics.NEW_COVERAGE)
+    .add(CoreMetrics.NEW_BRANCH_COVERAGE)
+    .add(CoreMetrics.NEW_LINE_COVERAGE)
+
+  .add(CoreMetrics.IT_COVERAGE_LINE_HITS_DATA)
+    .add(CoreMetrics.IT_CONDITIONS_BY_LINE)
+    .add(CoreMetrics.IT_COVERED_CONDITIONS_BY_LINE)
+    .add(CoreMetrics.NEW_IT_LINES_TO_COVER)
+    .add(CoreMetrics.NEW_IT_UNCOVERED_LINES)
+    .add(CoreMetrics.NEW_IT_CONDITIONS_TO_COVER)
+    .add(CoreMetrics.NEW_IT_UNCOVERED_CONDITIONS)
+    .add(CoreMetrics.NEW_IT_COVERAGE)
+    .add(CoreMetrics.NEW_IT_BRANCH_COVERAGE)
+    .add(CoreMetrics.NEW_IT_LINE_COVERAGE)
+
+  .add(CoreMetrics.OVERALL_COVERAGE_LINE_HITS_DATA)
+    .add(CoreMetrics.OVERALL_CONDITIONS_BY_LINE)
+    .add(CoreMetrics.OVERALL_COVERED_CONDITIONS_BY_LINE)
+    .add(CoreMetrics.NEW_OVERALL_LINES_TO_COVER)
+    .add(CoreMetrics.NEW_OVERALL_UNCOVERED_LINES)
+    .add(CoreMetrics.NEW_OVERALL_CONDITIONS_TO_COVER)
+    .add(CoreMetrics.NEW_OVERALL_UNCOVERED_CONDITIONS)
+    .add(CoreMetrics.NEW_OVERALL_COVERAGE)
+    .add(CoreMetrics.NEW_OVERALL_BRANCH_COVERAGE)
+    .add(CoreMetrics.NEW_OVERALL_LINE_COVERAGE);
+  @Rule
+  public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
+
+  private NewCoverageMeasuresStep underTest = new NewCoverageMeasuresStep(treeRootHolder, periodsHolder,
+    measureRepository, metricRepository);
+
+  @Before
+  public void setUp() {
+    periodsHolder.setPeriods(
+      new Period(2, "mode_p_1", null, parseDate("2009-12-25").getTime(), 1),
+      new Period(5, "mode_p_5", null, parseDate("2011-02-18").getTime(), 2));
+  }
+
+  @Test
+  public void verify_aggregation_of_measures_for_new_conditions() {
+    String newLinesToCover = CoreMetrics.NEW_IT_LINES_TO_COVER_KEY;
+    String newUncoveredLines = CoreMetrics.NEW_IT_UNCOVERED_LINES_KEY;
+    String newConditionsToCover = CoreMetrics.NEW_IT_CONDITIONS_TO_COVER_KEY;
+    String newUncoveredConditions = CoreMetrics.NEW_IT_UNCOVERED_CONDITIONS_KEY;
+
+    MetricKeys metricKeys = new MetricKeys(newLinesToCover, newUncoveredLines, newConditionsToCover, newUncoveredConditions);
+
+    treeRootHolder.setRoot(VIEWS_TREE);
+    // PROJECT_VIEW_1_REF has no measure
+    measureRepository.addRawMeasure(PROJECT_VIEW_2_REF, newLinesToCover, createMeasure(1d, 2d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_2_REF, newUncoveredLines, createMeasure(10d, 20d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_2_REF, newConditionsToCover, createMeasure(4d, 5d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_2_REF, newUncoveredConditions, createMeasure(40d, 50d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_3_REF, newLinesToCover, createMeasure(11d, 12d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_3_REF, newUncoveredLines, createMeasure(20d, 30d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_3_REF, newConditionsToCover, createMeasure(14d, 15d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_3_REF, newUncoveredConditions, createMeasure(50d, 60d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_4_REF, newLinesToCover, createMeasure(21d, 22d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_4_REF, newUncoveredLines, createMeasure(30d, 40d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_4_REF, newConditionsToCover, createMeasure(24d, 25d));
+    measureRepository.addRawMeasure(PROJECT_VIEW_4_REF, newUncoveredConditions, createMeasure(60d, 70d));
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertNoAddedRawMeasures(SUB_SUBVIEW_1_REF);
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(SUB_SUBVIEW_2_REF))).contains(
+      entryOf(metricKeys.newLinesToCover, createMeasure(12d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+      entryOf(metricKeys.newUncoveredLines, createMeasure(30d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+      entryOf(metricKeys.newConditionsToCover, createMeasure(18d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+      entryOf(metricKeys.newUncoveredConditions, createMeasure(90d, NO_PERIOD_4_OR_5_IN_VIEWS)));
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(ROOT_REF))).contains(
+      entryOf(metricKeys.newLinesToCover, createMeasure(33d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+      entryOf(metricKeys.newUncoveredLines, createMeasure(60d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+      entryOf(metricKeys.newConditionsToCover, createMeasure(42d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+      entryOf(metricKeys.newUncoveredConditions, createMeasure(150d, NO_PERIOD_4_OR_5_IN_VIEWS)));
+  }
+
+  @Test
+  public void verify_aggregates_variations_for_new_code_line_and_branch_Coverage() {
+    LinesAndConditionsWithUncoveredMetricKeys metricKeys = new LinesAndConditionsWithUncoveredMetricKeys(
+      CoreMetrics.NEW_LINES_TO_COVER_KEY, CoreMetrics.NEW_CONDITIONS_TO_COVER_KEY,
+      CoreMetrics.NEW_UNCOVERED_LINES_KEY, CoreMetrics.NEW_UNCOVERED_CONDITIONS_KEY);
+    String codeCoverageKey = CoreMetrics.NEW_COVERAGE_KEY;
+    String lineCoverageKey = CoreMetrics.NEW_LINE_COVERAGE_KEY;
+    String branchCoverageKey = CoreMetrics.NEW_BRANCH_COVERAGE_KEY;
+
+    verify_aggregates_variations(metricKeys, codeCoverageKey, lineCoverageKey, branchCoverageKey);
+  }
+
+  @Test
+  public void verify_aggregates_variations_for_new_IT_code_line_and_branch_Coverage() {
+    LinesAndConditionsWithUncoveredMetricKeys metricKeys = new LinesAndConditionsWithUncoveredMetricKeys(
+      CoreMetrics.NEW_IT_LINES_TO_COVER_KEY, CoreMetrics.NEW_IT_CONDITIONS_TO_COVER_KEY,
+      CoreMetrics.NEW_IT_UNCOVERED_LINES_KEY, CoreMetrics.NEW_IT_UNCOVERED_CONDITIONS_KEY);
+    String codeCoverageKey = CoreMetrics.NEW_IT_COVERAGE_KEY;
+    String lineCoverageKey = CoreMetrics.NEW_IT_LINE_COVERAGE_KEY;
+    String branchCoverageKey = CoreMetrics.NEW_IT_BRANCH_COVERAGE_KEY;
+
+    verify_aggregates_variations(metricKeys, codeCoverageKey, lineCoverageKey, branchCoverageKey);
+  }
+
+  @Test
+  public void verify_aggregates_variations_for_new_Overall_code_line_and_branch_Coverage() {
+    LinesAndConditionsWithUncoveredMetricKeys metricKeys = new LinesAndConditionsWithUncoveredMetricKeys(
+      CoreMetrics.NEW_OVERALL_LINES_TO_COVER_KEY, CoreMetrics.NEW_OVERALL_CONDITIONS_TO_COVER_KEY,
+      CoreMetrics.NEW_OVERALL_UNCOVERED_LINES_KEY, CoreMetrics.NEW_OVERALL_UNCOVERED_CONDITIONS_KEY);
+    String codeCoverageKey = CoreMetrics.NEW_OVERALL_COVERAGE_KEY;
+    String lineCoverageKey = CoreMetrics.NEW_OVERALL_LINE_COVERAGE_KEY;
+    String branchCoverageKey = CoreMetrics.NEW_OVERALL_BRANCH_COVERAGE_KEY;
+
+    verify_aggregates_variations(metricKeys, codeCoverageKey, lineCoverageKey, branchCoverageKey);
+  }
+
+  private void verify_aggregates_variations(LinesAndConditionsWithUncoveredMetricKeys metricKeys, String codeCoverageKey, String lineCoverageKey, String branchCoverageKey) {
+    treeRootHolder.setRoot(VIEWS_TREE);
+    measureRepository
+      .addRawMeasure(PROJECT_VIEW_1_REF, metricKeys.getLines(), createMeasure(3000d, 2000d))
+      .addRawMeasure(PROJECT_VIEW_1_REF, metricKeys.getConditions(), createMeasure(300d, 400d))
+      .addRawMeasure(PROJECT_VIEW_1_REF, metricKeys.getUncoveredLines(), createMeasure(30d, 200d))
+      .addRawMeasure(PROJECT_VIEW_1_REF, metricKeys.getUncoveredConditions(), createMeasure(9d, 16d))
+      // PROJECT_VIEW_2_REF
+      .addRawMeasure(PROJECT_VIEW_2_REF, metricKeys.getLines(), createMeasure(2000d, 3000d))
+      .addRawMeasure(PROJECT_VIEW_2_REF, metricKeys.getConditions(), createMeasure(400d, 300d))
+      .addRawMeasure(PROJECT_VIEW_2_REF, metricKeys.getUncoveredLines(), createMeasure(200d, 30d))
+      .addRawMeasure(PROJECT_VIEW_2_REF, metricKeys.getUncoveredConditions(), createMeasure(16d, 9d))
+      // PROJECT_VIEW_3_REF has no measure
+      // PROJECT_VIEW_4_REF
+      .addRawMeasure(PROJECT_VIEW_4_REF, metricKeys.getLines(), createMeasure(1000d, 2000d))
+      .addRawMeasure(PROJECT_VIEW_4_REF, metricKeys.getConditions(), createMeasure(300d, 200d))
+      .addRawMeasure(PROJECT_VIEW_4_REF, metricKeys.getUncoveredLines(), createMeasure(100d, 20d))
+      .addRawMeasure(PROJECT_VIEW_4_REF, metricKeys.getUncoveredConditions(), createMeasure(6d, 9d));
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(SUB_SUBVIEW_1_REF))).contains(
+      entryOf(codeCoverageKey, createMeasure(98.8d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+      entryOf(lineCoverageKey, createMeasure(99d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+      entryOf(branchCoverageKey, createMeasure(97d, NO_PERIOD_4_OR_5_IN_VIEWS)));
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(SUB_SUBVIEW_2_REF))).contains(
+      entryOf(codeCoverageKey, createMeasure(91d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+      entryOf(lineCoverageKey, createMeasure(90d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+      entryOf(branchCoverageKey, createMeasure(96d, NO_PERIOD_4_OR_5_IN_VIEWS)));
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(SUBVIEW_REF))).contains(
+        entryOf(codeCoverageKey, createMeasure(94.8d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+        entryOf(lineCoverageKey, createMeasure(94.5d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+        entryOf(branchCoverageKey, createMeasure(96.9d, NO_PERIOD_4_OR_5_IN_VIEWS)));
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(ROOT_REF))).contains(
+        entryOf(codeCoverageKey, createMeasure(94.8d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+        entryOf(lineCoverageKey, createMeasure(94.5d, NO_PERIOD_4_OR_5_IN_VIEWS)),
+        entryOf(branchCoverageKey, createMeasure(96.9d, NO_PERIOD_4_OR_5_IN_VIEWS)));
+  }
+
+  private static final class MetricKeys {
+    private final String newLinesToCover;
+    private final String newUncoveredLines;
+    private final String newConditionsToCover;
+    private final String newUncoveredConditions;
+
+    public MetricKeys(String newLinesToCover, String newUncoveredLines, String newConditionsToCover, String newUncoveredConditions) {
+      this.newLinesToCover = newLinesToCover;
+      this.newUncoveredLines = newUncoveredLines;
+      this.newConditionsToCover = newConditionsToCover;
+      this.newUncoveredConditions = newUncoveredConditions;
+    }
+  }
+
+  private static Measure createMeasure(@Nullable Double variationPeriod2, @Nullable Double variationPeriod5) {
+    MeasureVariations.Builder variationBuilder = newMeasureVariationsBuilder();
+    if (variationPeriod2 != null) {
+      variationBuilder.setVariation(new Period(2, "", null, 1L, 2L), variationPeriod2);
+    }
+    if (variationPeriod5 != null) {
+      variationBuilder.setVariation(new Period(5, "", null, 1L, 2L), variationPeriod5);
+    }
+    return newMeasureBuilder()
+      .setVariations(variationBuilder.build())
+      .createNoValue();
+  }
+
+  private void assertNoAddedRawMeasureOnProjectViews() {
+    assertNoAddedRawMeasures(PROJECT_VIEW_1_REF);
+    assertNoAddedRawMeasures(PROJECT_VIEW_2_REF);
+    assertNoAddedRawMeasures(PROJECT_VIEW_3_REF);
+  }
+
+  private void assertNoAddedRawMeasures(int componentRef) {
+    assertThat(measureRepository.getAddedRawMeasures(componentRef)).isEmpty();
+  }
+
+}

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/step/ViewsUnitTestMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/step/ViewsUnitTestMeasuresStepTest.java
@@ -1,0 +1,282 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.server.computation.step;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.server.computation.batch.TreeRootHolderRule;
+import org.sonar.server.computation.measure.MeasureRepositoryRule;
+import org.sonar.server.computation.metric.MetricRepositoryRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.guava.api.Assertions.assertThat;
+import static org.sonar.api.measures.CoreMetrics.SKIPPED_TESTS;
+import static org.sonar.api.measures.CoreMetrics.SKIPPED_TESTS_KEY;
+import static org.sonar.api.measures.CoreMetrics.TESTS;
+import static org.sonar.api.measures.CoreMetrics.TESTS_KEY;
+import static org.sonar.api.measures.CoreMetrics.TEST_ERRORS;
+import static org.sonar.api.measures.CoreMetrics.TEST_ERRORS_KEY;
+import static org.sonar.api.measures.CoreMetrics.TEST_EXECUTION_TIME;
+import static org.sonar.api.measures.CoreMetrics.TEST_EXECUTION_TIME_KEY;
+import static org.sonar.api.measures.CoreMetrics.TEST_FAILURES;
+import static org.sonar.api.measures.CoreMetrics.TEST_FAILURES_KEY;
+import static org.sonar.api.measures.CoreMetrics.TEST_SUCCESS_DENSITY;
+import static org.sonar.api.measures.CoreMetrics.TEST_SUCCESS_DENSITY_KEY;
+import static org.sonar.server.computation.component.Component.Type.PROJECT_VIEW;
+import static org.sonar.server.computation.component.Component.Type.SUBVIEW;
+import static org.sonar.server.computation.component.Component.Type.VIEW;
+import static org.sonar.server.computation.component.ViewsComponent.builder;
+import static org.sonar.server.computation.measure.Measure.newMeasureBuilder;
+import static org.sonar.server.computation.measure.MeasureRepoEntry.entryOf;
+import static org.sonar.server.computation.measure.MeasureRepoEntry.toEntries;
+
+public class ViewsUnitTestMeasuresStepTest {
+
+  private static final int ROOT_REF = 1;
+  private static final int SUBVIEW_REF = 12;
+  private static final int SUB_SUBVIEW_1_REF = 123;
+  private static final int PROJECT_VIEW_1_REF = 12341;
+  private static final int PROJECT_VIEW_2_REF = 12342;
+  private static final int SUB_SUBVIEW_2_REF = 124;
+
+  @Rule
+  public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule()
+    .setRoot(
+      builder(VIEW, ROOT_REF)
+        .addChildren(
+          builder(SUBVIEW, SUBVIEW_REF)
+            .addChildren(
+              builder(SUBVIEW, SUB_SUBVIEW_1_REF)
+                .addChildren(
+                  builder(PROJECT_VIEW, PROJECT_VIEW_1_REF).build(),
+                  builder(PROJECT_VIEW, PROJECT_VIEW_2_REF).build())
+                .build(),
+              builder(SUBVIEW, SUB_SUBVIEW_2_REF).build())
+            .build())
+        .build());
+  @Rule
+  public MetricRepositoryRule metricRepository = new MetricRepositoryRule()
+    .add(TESTS)
+    .add(TEST_ERRORS)
+    .add(TEST_FAILURES)
+    .add(TEST_EXECUTION_TIME)
+    .add(SKIPPED_TESTS)
+    .add(TEST_SUCCESS_DENSITY);
+  @Rule
+  public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
+
+  ComputationStep underTest = new UnitTestMeasuresStep(treeRootHolder, metricRepository, measureRepository);
+
+  @Test
+  public void aggregate_tests() {
+    checkMeasuresAggregation(TESTS_KEY, 100, 400, 500);
+  }
+
+  @Test
+  public void aggregate_tests_in_errors() {
+    checkMeasuresAggregation(TEST_ERRORS_KEY, 100, 400, 500);
+  }
+
+  @Test
+  public void aggregate_tests_in_failures() {
+    checkMeasuresAggregation(TEST_FAILURES_KEY, 100, 400, 500);
+  }
+
+  @Test
+  public void aggregate_tests_execution_time() {
+    checkMeasuresAggregation(TEST_EXECUTION_TIME_KEY, 100, 400, 500);
+  }
+
+  @Test
+  public void aggregate_skipped_tests_time() {
+    checkMeasuresAggregation(SKIPPED_TESTS_KEY, 100, 400, 500);
+  }
+
+  @Test
+  public void compute_test_success_density() {
+    addedRawMeasure(PROJECT_VIEW_1_REF, TESTS_KEY, 10);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TESTS_KEY, 20);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_ERRORS_KEY, 2);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_ERRORS_KEY, 5);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_FAILURES_KEY, 4);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_FAILURES_KEY, 1);
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertAddedRawMeasureValue(SUB_SUBVIEW_1_REF, TEST_SUCCESS_DENSITY_KEY, 60d);
+    assertAddedRawMeasureValue(SUBVIEW_REF, TEST_SUCCESS_DENSITY_KEY, 60d);
+    assertAddedRawMeasureValue(ROOT_REF, TEST_SUCCESS_DENSITY_KEY, 60d);
+  }
+
+  @Test
+  public void compute_test_success_density_when_zero_tests_in_errors() {
+    addedRawMeasure(PROJECT_VIEW_1_REF, TESTS_KEY, 10);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TESTS_KEY, 20);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_ERRORS_KEY, 0);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_ERRORS_KEY, 0);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_FAILURES_KEY, 4);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_FAILURES_KEY, 1);
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertAddedRawMeasureValue(SUB_SUBVIEW_1_REF, TEST_SUCCESS_DENSITY_KEY, 83.3d);
+    assertNoAddedRawMeasure(SUB_SUBVIEW_2_REF, TEST_SUCCESS_DENSITY_KEY);
+    assertAddedRawMeasureValue(SUBVIEW_REF, TEST_SUCCESS_DENSITY_KEY, 83.3d);
+    assertAddedRawMeasureValue(ROOT_REF, TEST_SUCCESS_DENSITY_KEY, 83.3d);
+  }
+
+  @Test
+  public void compute_test_success_density_when_zero_tests_in_failures() {
+    addedRawMeasure(PROJECT_VIEW_1_REF, TESTS_KEY, 10);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TESTS_KEY, 20);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_ERRORS_KEY, 2);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_ERRORS_KEY, 5);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_FAILURES_KEY, 0);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_FAILURES_KEY, 0);
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertAddedRawMeasureValue(SUB_SUBVIEW_1_REF, TEST_SUCCESS_DENSITY_KEY, 76.7d);
+    assertNoAddedRawMeasure(SUB_SUBVIEW_2_REF, TEST_SUCCESS_DENSITY_KEY);
+    assertAddedRawMeasureValue(SUBVIEW_REF, TEST_SUCCESS_DENSITY_KEY, 76.7d);
+    assertAddedRawMeasureValue(ROOT_REF, TEST_SUCCESS_DENSITY_KEY, 76.7d);
+  }
+
+  @Test
+  public void compute_100_percent_test_success_density_when_no_tests_in_errors_or_failures() {
+    addedRawMeasure(PROJECT_VIEW_1_REF, TESTS_KEY, 10);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TESTS_KEY, 20);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_ERRORS_KEY, 0);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_ERRORS_KEY, 0);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_FAILURES_KEY, 0);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_FAILURES_KEY, 0);
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertAddedRawMeasureValue(SUB_SUBVIEW_1_REF, TEST_SUCCESS_DENSITY_KEY, 100d);
+    assertNoAddedRawMeasure(SUB_SUBVIEW_2_REF, TEST_SUCCESS_DENSITY_KEY);
+    assertAddedRawMeasureValue(SUBVIEW_REF, TEST_SUCCESS_DENSITY_KEY, 100d);
+    assertAddedRawMeasureValue(ROOT_REF, TEST_SUCCESS_DENSITY_KEY, 100d);
+  }
+
+  @Test
+  public void compute_0_percent_test_success_density() {
+    int value = 10;
+    String metricKey = TESTS_KEY;
+    int componentRef = PROJECT_VIEW_1_REF;
+    addedRawMeasure(componentRef, metricKey, value);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TESTS_KEY, 20);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_ERRORS_KEY, 8);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_ERRORS_KEY, 15);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_FAILURES_KEY, 2);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_FAILURES_KEY, 5);
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertAddedRawMeasureValue(SUB_SUBVIEW_1_REF, TEST_SUCCESS_DENSITY_KEY, 0d);
+    assertNoAddedRawMeasure(SUB_SUBVIEW_2_REF, TEST_SUCCESS_DENSITY_KEY);
+    assertAddedRawMeasureValue(SUBVIEW_REF, TEST_SUCCESS_DENSITY_KEY, 0d);
+    assertAddedRawMeasureValue(ROOT_REF, TEST_SUCCESS_DENSITY_KEY, 0d);
+  }
+
+  @Test
+  public void do_not_compute_test_success_density_when_no_tests_in_errors() {
+    addedRawMeasure(PROJECT_VIEW_1_REF, TESTS_KEY, 10);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TESTS_KEY, 20);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_FAILURES_KEY, 4);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_FAILURES_KEY, 1);
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertNoAddedRawMeasure(SUB_SUBVIEW_1_REF, TEST_SUCCESS_DENSITY_KEY);
+    assertNoAddedRawMeasure(SUBVIEW_REF, TEST_SUCCESS_DENSITY_KEY);
+    assertNoAddedRawMeasure(ROOT_REF, TEST_SUCCESS_DENSITY_KEY);
+  }
+
+  @Test
+  public void do_not_compute_test_success_density_when_no_tests_in_failure() {
+    addedRawMeasure(PROJECT_VIEW_1_REF, TESTS_KEY, 10);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TESTS_KEY, 20);
+
+    addedRawMeasure(PROJECT_VIEW_1_REF, TEST_ERRORS_KEY, 0);
+    addedRawMeasure(PROJECT_VIEW_2_REF, TEST_ERRORS_KEY, 0);
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertNoAddedRawMeasure(SUB_SUBVIEW_1_REF, TEST_SUCCESS_DENSITY_KEY);
+    assertNoAddedRawMeasure(SUBVIEW_REF, TEST_SUCCESS_DENSITY_KEY);
+    assertNoAddedRawMeasure(ROOT_REF, TEST_SUCCESS_DENSITY_KEY);
+  }
+
+  private void checkMeasuresAggregation(String metricKey, int file1Value, int file2Value, int expectedValue) {
+    addedRawMeasure(PROJECT_VIEW_1_REF, metricKey, file1Value);
+    addedRawMeasure(PROJECT_VIEW_2_REF, metricKey, file2Value);
+
+    underTest.execute();
+
+    assertNoAddedRawMeasureOnProjectViews();
+    assertAddedRawMeasureValue(SUB_SUBVIEW_1_REF, metricKey, expectedValue);
+    assertNoAddedRawMeasure(SUB_SUBVIEW_2_REF, TEST_SUCCESS_DENSITY_KEY);
+    assertAddedRawMeasureValue(SUBVIEW_REF, metricKey, expectedValue);
+    assertAddedRawMeasureValue(ROOT_REF, metricKey, expectedValue);
+  }
+
+  private void addedRawMeasure(int componentRef, String metricKey, int value) {
+    measureRepository.addRawMeasure(componentRef, metricKey, newMeasureBuilder().create(value));
+  }
+
+  private void assertAddedRawMeasureValue(int componentRef, String metricKey, double value) {
+    assertThat(entryOf(metricKey, measureRepository.getAddedRawMeasure(componentRef, metricKey).get()))
+      .isEqualTo(entryOf(metricKey, newMeasureBuilder().create(value)));
+  }
+
+  private void assertNoAddedRawMeasure(int componentRef, String metricKey) {
+    assertThat(measureRepository.getAddedRawMeasure(componentRef, metricKey)).isAbsent();
+  }
+
+  private void assertAddedRawMeasureValue(int componentRef, String metricKey, int expectedValue) {
+    assertThat(toEntries(measureRepository.getAddedRawMeasures(componentRef))).containsOnly(entryOf(metricKey, newMeasureBuilder().create(expectedValue)));
+  }
+
+  private void assertNoAddedRawMeasureOnProjectViews() {
+    assertThat(measureRepository.getAddedRawMeasures(PROJECT_VIEW_1_REF)).isEmpty();
+    assertThat(measureRepository.getAddedRawMeasures(PROJECT_VIEW_2_REF)).isEmpty();
+  }
+
+}

--- a/sonar-core/src/main/java/org/sonar/core/platform/PluginClassLoaderDef.java
+++ b/sonar-core/src/main/java/org/sonar/core/platform/PluginClassLoaderDef.java
@@ -31,9 +31,9 @@ import javax.annotation.Nullable;
 import org.sonar.classloader.Mask;
 
 /**
- * Temporary information about the classloader to be created for a plugin (or a group of plugins).
+ * Temporary information about the classLoader to be created for a plugin (or a group of plugins).
  */
-class PluginClassloaderDef {
+class PluginClassLoaderDef {
 
   private final String basePluginKey;
   private final Map<String, String> mainClassesByPluginKey = new HashMap<>();
@@ -46,9 +46,9 @@ class PluginClassloaderDef {
    */
   private boolean compatibilityMode = false;
 
-  private boolean serverExtension = false;
+  private boolean privileged = false;
 
-  PluginClassloaderDef(String basePluginKey) {
+  PluginClassLoaderDef(String basePluginKey) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(basePluginKey));
     this.basePluginKey = basePluginKey;
   }
@@ -95,12 +95,12 @@ class PluginClassloaderDef {
     this.compatibilityMode = b;
   }
 
-  boolean isServerExtension() {
-    return serverExtension;
+  boolean isPrivileged() {
+    return privileged;
   }
 
-  void setServerExtension(boolean serverExtension) {
-    this.serverExtension = serverExtension;
+  void setPrivileged(boolean privileged) {
+    this.privileged = privileged;
   }
 
   @Override
@@ -111,7 +111,7 @@ class PluginClassloaderDef {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    PluginClassloaderDef that = (PluginClassloaderDef) o;
+    PluginClassLoaderDef that = (PluginClassLoaderDef) o;
     return basePluginKey.equals(that.basePluginKey);
   }
 

--- a/sonar-core/src/test/java/org/sonar/core/platform/PluginClassloaderFactoryTest.java
+++ b/sonar-core/src/test/java/org/sonar/core/platform/PluginClassloaderFactoryTest.java
@@ -44,8 +44,8 @@ public class PluginClassloaderFactoryTest {
 
   @Test
   public void create_isolated_classloader() {
-    PluginClassloaderDef def = basePluginDef();
-    Map<PluginClassloaderDef, ClassLoader> map = factory.create(asList(def));
+    PluginClassLoaderDef def = basePluginDef();
+    Map<PluginClassLoaderDef, ClassLoader> map = factory.create(asList(def));
 
     assertThat(map).containsOnlyKeys(def);
     ClassLoader classLoader = map.get(def);
@@ -62,7 +62,7 @@ public class PluginClassloaderFactoryTest {
 
   @Test
   public void create_classloader_compatible_with_with_old_api_dependencies() {
-    PluginClassloaderDef def = basePluginDef();
+    PluginClassLoaderDef def = basePluginDef();
     def.setCompatibilityMode(true);
     ClassLoader classLoader = factory.create(asList(def)).get(def);
 
@@ -76,9 +76,9 @@ public class PluginClassloaderFactoryTest {
 
   @Test
   public void classloader_exports_resources_to_other_classloaders() {
-    PluginClassloaderDef baseDef = basePluginDef();
-    PluginClassloaderDef dependentDef = dependentPluginDef();
-    Map<PluginClassloaderDef, ClassLoader> map = factory.create(asList(baseDef, dependentDef));
+    PluginClassLoaderDef baseDef = basePluginDef();
+    PluginClassLoaderDef dependentDef = dependentPluginDef();
+    Map<PluginClassLoaderDef, ClassLoader> map = factory.create(asList(baseDef, dependentDef));
     ClassLoader baseClassloader = map.get(baseDef);
     ClassLoader dependentClassloader = map.get(dependentDef);
 
@@ -92,16 +92,16 @@ public class PluginClassloaderFactoryTest {
     assertThat(canLoadClass(baseClassloader, BASE_PLUGIN_CLASSNAME)).isTrue();
   }
 
-  private static PluginClassloaderDef basePluginDef() {
-    PluginClassloaderDef def = new PluginClassloaderDef(BASE_PLUGIN_KEY);
+  private static PluginClassLoaderDef basePluginDef() {
+    PluginClassLoaderDef def = new PluginClassLoaderDef(BASE_PLUGIN_KEY);
     def.addMainClass(BASE_PLUGIN_KEY, BASE_PLUGIN_CLASSNAME);
     def.getExportMask().addInclusion("org/sonar/plugins/base/api/");
     def.addFiles(asList(fakePluginJar("base-plugin/target/base-plugin-0.1-SNAPSHOT.jar")));
     return def;
   }
 
-  private static PluginClassloaderDef dependentPluginDef() {
-    PluginClassloaderDef def = new PluginClassloaderDef(DEPENDENT_PLUGIN_KEY);
+  private static PluginClassLoaderDef dependentPluginDef() {
+    PluginClassLoaderDef def = new PluginClassLoaderDef(DEPENDENT_PLUGIN_KEY);
     def.addMainClass(DEPENDENT_PLUGIN_KEY, DEPENDENT_PLUGIN_CLASSNAME);
     def.getExportMask().addInclusion("org/sonar/plugins/dependent/api/");
     def.addFiles(asList(fakePluginJar("dependent-plugin/target/dependent-plugin-0.1-SNAPSHOT.jar")));

--- a/sonar-core/src/test/java/org/sonar/core/platform/PluginLoaderTest.java
+++ b/sonar-core/src/test/java/org/sonar/core/platform/PluginLoaderTest.java
@@ -49,7 +49,7 @@ public class PluginLoaderTest {
 
   @Test
   public void instantiate_plugin_entry_point() {
-    PluginClassloaderDef def = new PluginClassloaderDef("fake");
+    PluginClassLoaderDef def = new PluginClassLoaderDef("fake");
     def.addMainClass("fake", FakePlugin.class.getName());
 
     Map<String, Plugin> instances = loader.instantiatePluginClasses(ImmutableMap.of(def, getClass().getClassLoader()));
@@ -59,7 +59,7 @@ public class PluginLoaderTest {
 
   @Test
   public void plugin_entry_point_must_be_no_arg_public() {
-    PluginClassloaderDef def = new PluginClassloaderDef("fake");
+    PluginClassLoaderDef def = new PluginClassLoaderDef("fake");
     def.addMainClass("fake", IncorrectPlugin.class.getName());
 
     try {
@@ -78,10 +78,10 @@ public class PluginLoaderTest {
       .setMainClass("org.foo.FooPlugin")
       .setMinimalSqVersion(Version.create("5.2"));
 
-    Collection<PluginClassloaderDef> defs = loader.defineClassloaders(ImmutableMap.of("foo", info));
+    Collection<PluginClassLoaderDef> defs = loader.defineClassloaders(ImmutableMap.of("foo", info));
 
     assertThat(defs).hasSize(1);
-    PluginClassloaderDef def = defs.iterator().next();
+    PluginClassLoaderDef def = defs.iterator().next();
     assertThat(def.getBasePluginKey()).isEqualTo("foo");
     assertThat(def.isSelfFirstStrategy()).isFalse();
     assertThat(def.getFiles()).containsOnly(jarFile);
@@ -100,7 +100,7 @@ public class PluginLoaderTest {
       .setMainClass("org.foo.FooPlugin")
       .setMinimalSqVersion(Version.create("4.5.2"));
 
-    Collection<PluginClassloaderDef> defs = loader.defineClassloaders(ImmutableMap.of("foo", info));
+    Collection<PluginClassLoaderDef> defs = loader.defineClassloaders(ImmutableMap.of("foo", info));
     assertThat(defs.iterator().next().isCompatibilityMode()).isTrue();
   }
 
@@ -132,11 +132,11 @@ public class PluginLoaderTest {
       .setBasePlugin("foo")
       .setUseChildFirstClassLoader(true);
 
-    Collection<PluginClassloaderDef> defs = loader.defineClassloaders(ImmutableMap.of(
+    Collection<PluginClassLoaderDef> defs = loader.defineClassloaders(ImmutableMap.of(
       base.getKey(), base, extension1.getKey(), extension1, extension2.getKey(), extension2));
 
     assertThat(defs).hasSize(1);
-    PluginClassloaderDef def = defs.iterator().next();
+    PluginClassLoaderDef def = defs.iterator().next();
     assertThat(def.getBasePluginKey()).isEqualTo("foo");
     assertThat(def.isSelfFirstStrategy()).isFalse();
     assertThat(def.getFiles()).containsOnly(baseJarFile, extensionJar1, extensionJar2);
@@ -151,9 +151,9 @@ public class PluginLoaderTest {
   public void plugin_is_recognised_as_server_extension_if_key_is_views_and_extends_no_other_plugin_and_runs_in_compatibility_mode() throws IOException {
     PluginInfo views = create52PluginInfo("views");
 
-    Collection<PluginClassloaderDef> defs = loader.defineClassloaders(ImmutableMap.of("views", views));
+    Collection<PluginClassLoaderDef> defs = loader.defineClassloaders(ImmutableMap.of("views", views));
 
-    assertThat(defs.iterator().next().isServerExtension()).isTrue();
+    assertThat(defs.iterator().next().isPrivileged()).isTrue();
   }
 
   @Test
@@ -162,7 +162,7 @@ public class PluginLoaderTest {
     PluginInfo views = create52PluginInfo("views")
         .setBasePlugin("foo");
 
-    Collection<PluginClassloaderDef> defs = loader.defineClassloaders(ImmutableMap.of("foo", foo, "views", views));
+    Collection<PluginClassLoaderDef> defs = loader.defineClassloaders(ImmutableMap.of("foo", foo, "views", views));
 
     assertThat(defs).extracting("compatibilityMode").containsOnly(false, false);
   }

--- a/sonar-db/src/main/java/org/sonar/db/MyBatis.java
+++ b/sonar-db/src/main/java/org/sonar/db/MyBatis.java
@@ -45,6 +45,8 @@ import org.sonar.db.component.ResourceMapper;
 import org.sonar.db.component.SnapshotDto;
 import org.sonar.db.component.SnapshotMapper;
 import org.sonar.db.component.UuidWithProjectUuidDto;
+import org.sonar.db.component.ViewsComponentDto;
+import org.sonar.db.component.ViewsSnapshotDto;
 import org.sonar.db.compute.AnalysisReportDto;
 import org.sonar.db.compute.AnalysisReportMapper;
 import org.sonar.db.dashboard.ActiveDashboardDto;
@@ -210,6 +212,8 @@ public class MyBatis {
     confBuilder.loadAlias("UuidWithProjectUuid", UuidWithProjectUuidDto.class);
     confBuilder.loadAlias("Event", EventDto.class);
     confBuilder.loadAlias("CustomMeasure", CustomMeasureDto.class);
+    confBuilder.loadAlias("ViewsComponent", ViewsComponentDto.class);
+    confBuilder.loadAlias("ViewsSnapshot", ViewsSnapshotDto.class);
 
     // AuthorizationMapper has to be loaded before IssueMapper because this last one used it
     confBuilder.loadMapper("org.sonar.db.user.AuthorizationMapper");

--- a/sonar-db/src/main/java/org/sonar/db/component/ComponentDao.java
+++ b/sonar-db/src/main/java/org/sonar/db/component/ComponentDao.java
@@ -277,7 +277,15 @@ public class ComponentDao implements Dao {
     mapper(session).update(item);
   }
 
+  public List<ViewsComponentDto> selectRootViews(DbSession dbSession) {
+    return mapper(dbSession).selectRootViews();
+  }
+
+  public List<ViewsComponentDto> selectViewTree(DbSession dbSession, String rootViewUuid) {
+    return mapper(dbSession).selectViewTree(rootViewUuid);
+  }
   private ComponentMapper mapper(DbSession session) {
     return session.getMapper(ComponentMapper.class);
   }
+
 }

--- a/sonar-db/src/main/java/org/sonar/db/component/ComponentMapper.java
+++ b/sonar-db/src/main/java/org/sonar/db/component/ComponentMapper.java
@@ -125,4 +125,8 @@ public interface ComponentMapper {
   void insert(ComponentDto componentDto);
 
   void update(ComponentDto componentDto);
+
+  List<ViewsComponentDto> selectRootViews();
+
+  List<ViewsComponentDto> selectViewTree(@Param("rootViewUuid") String rootViewUuid);
 }

--- a/sonar-db/src/main/java/org/sonar/db/component/SnapshotDao.java
+++ b/sonar-db/src/main/java/org/sonar/db/component/SnapshotDao.java
@@ -31,6 +31,8 @@ import org.sonar.db.Dao;
 import org.sonar.db.DbSession;
 import org.sonar.db.RowNotFoundException;
 
+import static com.google.common.collect.FluentIterable.from;
+
 public class SnapshotDao implements Dao {
 
   @CheckForNull
@@ -100,6 +102,18 @@ public class SnapshotDao implements Dao {
 
   public void insert(DbSession session, SnapshotDto item, SnapshotDto... others) {
     insert(session, Lists.asList(item, others));
+  }
+
+  @CheckForNull
+  public ViewsSnapshotDto selectSnapshotBefore(long componentId, long date, DbSession dbSession) {
+    return from(mapper(dbSession).selectSnapshotBefore(componentId, date))
+        .first()
+        .orNull();
+  }
+
+  @CheckForNull
+  public ViewsSnapshotDto selectLatestSnapshot(long componentId, DbSession dbSession) {
+    return mapper(dbSession).selectLatestSnapshot(componentId);
   }
 
   private SnapshotMapper mapper(DbSession session) {

--- a/sonar-db/src/main/java/org/sonar/db/component/SnapshotMapper.java
+++ b/sonar-db/src/main/java/org/sonar/db/component/SnapshotMapper.java
@@ -45,4 +45,8 @@ public interface SnapshotMapper {
 
   int updateSnapshotAndChildrenLastFlag(@Param(value = "root") Long rootId, @Param(value = "pathRootId") Long pathRootId,
     @Param(value = "path") String path, @Param(value = "isLast") boolean isLast);
+  
+  List<ViewsSnapshotDto> selectSnapshotBefore(@Param("componentId") long componentId, @Param("date") long date);
+
+  ViewsSnapshotDto selectLatestSnapshot(@Param("componentId") long componentId);
 }

--- a/sonar-db/src/main/java/org/sonar/db/component/ViewsComponentDto.java
+++ b/sonar-db/src/main/java/org/sonar/db/component/ViewsComponentDto.java
@@ -1,0 +1,109 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.db.component;
+
+public class ViewsComponentDto {
+  private Long id;
+  private String name;
+  private String uuid;
+  private String kee;
+  private String scope;
+  private String qualifier;
+  private Long copyResourceId;
+  private String moduleUuid;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getUuid() {
+    return uuid;
+  }
+
+  public void setUuid(String uuid) {
+    this.uuid = uuid;
+  }
+
+  public String getKee() {
+    return kee;
+  }
+
+  public void setKee(String kee) {
+    this.kee = kee;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public void setScope(String scope) {
+    this.scope = scope;
+  }
+
+  public String getQualifier() {
+    return qualifier;
+  }
+
+  public void setQualifier(String qualifier) {
+    this.qualifier = qualifier;
+  }
+
+  public Long getCopyResourceId() {
+    return copyResourceId;
+  }
+
+  public void setCopyResourceId(Long copyResourceId) {
+    this.copyResourceId = copyResourceId;
+  }
+
+  public String getModuleUuid() {
+    return moduleUuid;
+  }
+
+  public void setModuleUuid(String moduleUuid) {
+    this.moduleUuid = moduleUuid;
+  }
+
+  @Override
+  public String toString() {
+    return "ViewsComponentDto{" +
+        "id=" + id +
+        ", name='" + name + '\'' +
+        ", uuid='" + uuid + '\'' +
+        ", kee='" + kee + '\'' +
+        ", scope='" + scope + '\'' +
+        ", qualifier='" + qualifier + '\'' +
+        ", copyResourceId='" + copyResourceId + '\'' +
+        ", moduleUuid='" + moduleUuid + '\'' +
+        '}';
+  }
+}

--- a/sonar-db/src/main/java/org/sonar/db/component/ViewsSnapshotDto.java
+++ b/sonar-db/src/main/java/org/sonar/db/component/ViewsSnapshotDto.java
@@ -1,0 +1,41 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.db.component;
+
+public class ViewsSnapshotDto {
+  private Long id;
+  private Long createdAt;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Long getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Long createdAt) {
+    this.createdAt = createdAt;
+  }
+}

--- a/sonar-db/src/main/resources/org/sonar/db/component/ComponentMapper.xml
+++ b/sonar-db/src/main/resources/org/sonar/db/component/ComponentMapper.xml
@@ -24,6 +24,17 @@
     p.created_at as createdAt
   </sql>
 
+  <sql id="viewsComponentColumns">
+    p.id,
+    p.name,
+    p.uuid as uuid,
+    p.kee as kee,
+    p.qualifier as qualifier,
+    p.scope as scope,
+    P.copy_resource_id as copyResourceId,
+    p.module_uuid as moduleUuid
+  </sql>
+
   <sql id="authorizedComponentColumns">
     p.id,
     p.uuid as uuid,
@@ -383,5 +394,29 @@
     authorization_updated_at=#{authorizationUpdatedAt,jdbcType=BIGINT}
     WHERE uuid=#{uuid}
   </insert>
+
+  <select id="selectRootViews" resultType="ViewsComponent">
+    SELECT
+    <include refid="viewsComponentColumns"/>
+    FROM projects p
+    <where>
+      p.scope = 'PRJ'
+      and p.qualifier = 'VW'
+    </where>
+  </select>
+
+  <select id="selectViewTree" resultType="ViewsComponent" parameterType="String">
+    select
+    <include refid="viewsComponentColumns"/>
+    from projects p
+    <where>
+      project_uuid = #{rootViewUuid}
+      and p.uuid != #{rootViewUuid}
+      and p.scope in ('PRJ', 'FIL')
+      and p.qualifier in ('VW', 'SVW', 'TRK')
+      and p.enabled = ${_true}
+    </where>
+    order by module_uuid_path;
+  </select>
 
 </mapper>

--- a/sonar-db/src/main/resources/org/sonar/db/component/SnapshotMapper.xml
+++ b/sonar-db/src/main/resources/org/sonar/db/component/SnapshotMapper.xml
@@ -35,6 +35,11 @@
     s.period5_date as period5Date
   </sql>
 
+  <sql id="viewsSnapshotColumns">
+    s.id,
+    s.created_at as createdAt
+  </sql>
+
   <select id="selectByKey" parameterType="Long" resultType="Snapshot">
     SELECT
     <include refid="snapshotColumns"/>
@@ -110,6 +115,29 @@
     from snapshots s
     where s.scope = #{scope}
     AND (s.id = #{snapshot} or s.root_snapshot_id = #{snapshot})
+  </select>
+
+  <select id="selectSnapshotBefore" resultType="ViewsSnapshot">
+    SELECT
+    <include refid="viewsSnapshotColumns"/>
+    FROM snapshots s
+    <where>
+      and s.project_id = #{componentId}
+      and s.status = 'P'
+      and s.created_at &lt; #{date}
+    </where>
+    order by created_at desc
+  </select>
+
+  <select id="selectLatestSnapshot" resultType="ViewsSnapshot">
+    SELECT
+    <include refid="viewsSnapshotColumns"/>
+    FROM snapshots s
+    <where>
+      and s.project_id = #{componentId}
+      and s.status = 'P'
+      and s.islast = ${_true}
+    </where>
   </select>
 
   <sql id="insertColumns">


### PR DESCRIPTION
This PR contains:
* mode of DAOs and Mapper from views to SQ
* addition of support for Views Component tree to a bunch of Measure Computation Steps
* fix of the loading of Views in SQ on Dory