### PR TITLE
Simplify deletion of a project in PurgeDao

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/component/ComponentCleanerService.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/component/ComponentCleanerService.java
@@ -29,8 +29,6 @@ import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.MyBatis;
 import org.sonar.db.component.ComponentDto;
-import org.sonar.db.purge.IdUuidPair;
-import org.sonar.db.purge.PurgeProfiler;
 import org.sonar.server.issue.index.IssueAuthorizationIndexer;
 import org.sonar.server.issue.index.IssueIndexer;
 import org.sonar.server.test.index.TestIndexer;
@@ -75,7 +73,7 @@ public class ComponentCleanerService {
     if (hasNotProjectScope(project) || isNotDeletable(project)) {
       throw new IllegalArgumentException("Only projects can be deleted");
     }
-    dbClient.purgeDao().deleteResourceTree(dbSession, new IdUuidPair(project.getId(), project.uuid()), new PurgeProfiler());
+    dbClient.purgeDao().deleteProject(dbSession, project.uuid());
     dbSession.commit();
 
     deleteFromIndices(project.uuid());

--- a/sonar-db/src/main/java/org/sonar/db/MyBatis.java
+++ b/sonar-db/src/main/java/org/sonar/db/MyBatis.java
@@ -96,7 +96,6 @@ import org.sonar.db.permission.PermissionTemplateUserDto;
 import org.sonar.db.permission.UserWithPermissionDto;
 import org.sonar.db.property.PropertiesMapper;
 import org.sonar.db.property.PropertyDto;
-import org.sonar.db.purge.IdUuidPair;
 import org.sonar.db.purge.PurgeMapper;
 import org.sonar.db.purge.PurgeableSnapshotDto;
 import org.sonar.db.qualitygate.ProjectQgateAssociationDto;
@@ -207,7 +206,6 @@ public class MyBatis {
     confBuilder.loadAlias("RequirementMigration", RequirementMigrationDto.class);
     confBuilder.loadAlias("Activity", ActivityDto.class);
     confBuilder.loadAlias("AnalysisReport", AnalysisReportDto.class);
-    confBuilder.loadAlias("IdUuidPair", IdUuidPair.class);
     confBuilder.loadAlias("FilePathWithHash", FilePathWithHashDto.class);
     confBuilder.loadAlias("UuidWithProjectUuid", UuidWithProjectUuidDto.class);
     confBuilder.loadAlias("Event", EventDto.class);

--- a/sonar-db/src/main/java/org/sonar/db/purge/PurgeMapper.java
+++ b/sonar-db/src/main/java/org/sonar/db/purge/PurgeMapper.java
@@ -29,9 +29,10 @@ public interface PurgeMapper {
 
   List<Long> selectSnapshotIdsByResource(@Param("resourceIds") List<Long> resourceIds);
 
-  List<IdUuidPair> selectProjectIdUuidsByRootId(long rootResourceId);
-
-  List<IdUuidPair> selectComponentIdUuidsByRootId(long rootProjectId);
+  /**
+   * Returns the list of components of a project from a project_uuid. The project itself is also returned.
+   */
+  List<IdUuidPair> selectComponentsByProjectUuid(String projectUuid);
 
   void deleteSnapshot(@Param("snapshotIds") List<Long> snapshotIds);
 

--- a/sonar-db/src/main/resources/org/sonar/db/purge/PurgeMapper.xml
+++ b/sonar-db/src/main/resources/org/sonar/db/purge/PurgeMapper.xml
@@ -72,7 +72,7 @@
     not exists(select e.id from events e where e.snapshot_id=s.id)
   </select>
 
-  <select id="selectComponentIdUuidsToDisable" resultType="IdUuidPair" parameterType="long">
+  <select id="selectComponentIdUuidsToDisable" resultType="org.sonar.db.purge.IdUuidPair" parameterType="long">
     select p.id, p.uuid from projects p
     where (p.id=#{id} or p.root_id=#{id}) and p.enabled=${_true}
     and not exists(select s.project_id from snapshots s where s.islast=${_true} and s.project_id=p.id)
@@ -82,12 +82,8 @@
     select id from metrics where delete_historical_data=${_true}
   </select>
 
-  <select id="selectProjectIdUuidsByRootId" resultType="IdUuidPair" parameterType="long">
-    select id, uuid from projects where root_id=#{id} and scope='PRJ'
-  </select>
-
-  <select id="selectComponentIdUuidsByRootId" resultType="IdUuidPair" parameterType="long">
-    select id, uuid from projects where root_id=#{id} or id=#{id}
+  <select id="selectComponentsByProjectUuid" resultType="org.sonar.db.purge.IdUuidPair" parameterType="String">
+    select id, uuid from projects where project_uuid=#{uuid}
   </select>
 
   <delete id="deleteSnapshotMeasures" parameterType="map">

--- a/sonar-db/src/test/java/org/sonar/db/purge/PurgeDaoTest.java
+++ b/sonar-db/src/test/java/org/sonar/db/purge/PurgeDaoTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.sonar.api.resources.Scopes;
 import org.sonar.api.utils.System2;
+import org.sonar.db.DbSession;
 import org.sonar.db.DbTester;
 import org.sonar.test.DbTests;
 
@@ -39,6 +40,8 @@ public class PurgeDaoTest {
 
   @Rule
   public DbTester dbTester = DbTester.create(system2);
+
+  DbSession dbSession = dbTester.getSession();
 
   PurgeDao underTest = dbTester.getDbClient().purgeDao();
 
@@ -101,9 +104,10 @@ public class PurgeDaoTest {
   }
 
   @Test
-  public void should_delete_project_and_associated_data() {
+  public void delete_project_and_associated_data() {
     dbTester.prepareDbUnit(getClass(), "shouldDeleteProject.xml");
-    underTest.deleteResourceTree(new IdUuidPair(1L, "A"), new PurgeProfiler());
+    underTest.deleteProject(dbSession, "A");
+    dbSession.commit();
     assertThat(dbTester.countRowsOfTable("projects")).isZero();
     assertThat(dbTester.countRowsOfTable("snapshots")).isZero();
     assertThat(dbTester.countRowsOfTable("action_plans")).isZero();


### PR DESCRIPTION
Simplify deletion of a project in PurgeDao

- Rename deleteResourceTree to deleteProject
- deleteProject only takes a uuid as paramter (instead of a IdUUidPair)