### PR TITLE
SONAR-6867: Add a new APIs UserDetails.getUserId()/setUserId(userId)

### DIFF
--- a/server/sonar-web/src/main/webapp/WEB-INF/lib/need_authentication.rb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/lib/need_authentication.rb
@@ -115,7 +115,12 @@ class PluginRealm
   # Return the user.
   #
   def synchronize(username, password, details)
-    username=details.getName() if username.blank? && details
+    user_id = nil
+    user_id = details.getUserId() if details
+
+    username = user_id if !user_id.blank?
+    username = details.getName() if username.blank? && details
+
     user = User.find_by_login(username)
 
     now = java.lang.System.currentTimeMillis

--- a/sonar-plugin-api/src/main/java/org/sonar/api/security/UserDetails.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/security/UserDetails.java
@@ -24,38 +24,54 @@ import com.google.common.base.Objects;
 /**
  * This class is not intended to be subclassed by clients.
  *
- * @since 2.14
  * @see ExternalUsersProvider
+ * @since 2.14
  */
 public final class UserDetails {
 
-  private String name = "";
-  private String email = "";
+    private String name = "";
+    private String email = "";
+    private String userId = "";
 
-  public UserDetails() {
-  }
+    public UserDetails() {
+    }
 
-  public void setEmail(String email) {
-    this.email = email;
-  }
+    public void setEmail(String email) {
+        this.email = email;
+    }
 
-  public String getEmail() {
-    return email;
-  }
+    public String getEmail() {
+        return email;
+    }
 
-  public void setName(String name) {
-    this.name = name;
-  }
+    public void setName(String name) {
+        this.name = name;
+    }
 
-  public String getName() {
-    return name;
-  }
+    public String getName() {
+        return name;
+    }
 
-  @Override
-  public String toString() {
-    return Objects.toStringHelper(this)
-        .add("name", name)
-        .add("email", email)
-        .toString();
-  }
+    /**
+     * @since 5.2
+     */
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    /**
+     * @since 5.2
+     */
+    public String getUserId() {
+        return userId;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("name", name)
+                .add("email", email)
+                .add("userId", userId)
+                .toString();
+    }
 }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/security/UserDetails.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/security/UserDetails.java
@@ -29,49 +29,49 @@ import com.google.common.base.Objects;
  */
 public final class UserDetails {
 
-    private String name = "";
-    private String email = "";
-    private String userId = "";
+  private String name = "";
+  private String email = "";
+  private String userId = "";
 
-    public UserDetails() {
-    }
+  public UserDetails() {
+  }
 
-    public void setEmail(String email) {
-        this.email = email;
-    }
+  public void setEmail(String email) {
+    this.email = email;
+  }
 
-    public String getEmail() {
-        return email;
-    }
+  public String getEmail() {
+    return email;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    /**
-     * @since 5.2
-     */
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
+  /**
+   * @since 5.2
+   */
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
 
-    /**
-     * @since 5.2
-     */
-    public String getUserId() {
-        return userId;
-    }
+  /**
+   * @since 5.2
+   */
+  public String getUserId() {
+    return userId;
+  }
 
-    @Override
-    public String toString() {
-        return Objects.toStringHelper(this)
-                .add("name", name)
-                .add("email", email)
-                .add("userId", userId)
-                .toString();
-    }
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("name", name)
+      .add("email", email)
+      .add("userId", userId)
+      .toString();
+  }
 }

--- a/sonar-plugin-api/src/test/java/org/sonar/api/security/UserDetailsTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/security/UserDetailsTest.java
@@ -1,0 +1,79 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.security;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserDetailsTest {
+    private UserDetails userDetails;
+
+    @Before
+    public void init() {
+        userDetails = new UserDetails();
+    }
+
+    @Test
+    public void getNameTest() {
+        userDetails.setName(null);
+        assertThat(userDetails.getName()).isNull();
+
+        userDetails.setName("");
+        assertThat(userDetails.getName()).isEqualTo("");
+
+        userDetails.setName("foo");
+        assertThat(userDetails.getName()).isEqualTo("foo");
+    }
+
+    @Test
+    public void getEmailTest() {
+        userDetails.setEmail(null);
+        assertThat(userDetails.getEmail()).isNull();
+
+        userDetails.setEmail("");
+        assertThat(userDetails.getEmail()).isEqualTo("");
+
+        userDetails.setEmail("foo@example.com");
+        assertThat(userDetails.getEmail()).isEqualTo("foo@example.com");
+    }
+
+    @Test
+    public void getUserIdTest() {
+        userDetails.setUserId(null);
+        assertThat(userDetails.getUserId()).isNull();
+
+        userDetails.setUserId("");
+        assertThat(userDetails.getUserId()).isEqualTo("");
+
+        userDetails.setUserId("foo@example");
+        assertThat(userDetails.getUserId()).isEqualTo("foo@example");
+    }
+
+    @Test
+    public void toStringTest() {
+        userDetails.setName("foo");
+        userDetails.setEmail("foo@example.com");
+        userDetails.setUserId("foo@example");
+
+        assertThat(userDetails.toString()).isEqualTo("UserDetails{name=foo, email=foo@example.com, userId=foo@example}");
+    }
+}

--- a/sonar-plugin-api/src/test/java/org/sonar/api/security/UserDetailsTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/security/UserDetailsTest.java
@@ -25,55 +25,55 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class UserDetailsTest {
-    private UserDetails userDetails;
+  private UserDetails userDetails;
 
-    @Before
-    public void init() {
-        userDetails = new UserDetails();
-    }
+  @Before
+  public void init() {
+    userDetails = new UserDetails();
+  }
 
-    @Test
-    public void getNameTest() {
-        userDetails.setName(null);
-        assertThat(userDetails.getName()).isNull();
+  @Test
+  public void getNameTest() {
+    userDetails.setName(null);
+    assertThat(userDetails.getName()).isNull();
 
-        userDetails.setName("");
-        assertThat(userDetails.getName()).isEqualTo("");
+    userDetails.setName("");
+    assertThat(userDetails.getName()).isEqualTo("");
 
-        userDetails.setName("foo");
-        assertThat(userDetails.getName()).isEqualTo("foo");
-    }
+    userDetails.setName("foo");
+    assertThat(userDetails.getName()).isEqualTo("foo");
+  }
 
-    @Test
-    public void getEmailTest() {
-        userDetails.setEmail(null);
-        assertThat(userDetails.getEmail()).isNull();
+  @Test
+  public void getEmailTest() {
+    userDetails.setEmail(null);
+    assertThat(userDetails.getEmail()).isNull();
 
-        userDetails.setEmail("");
-        assertThat(userDetails.getEmail()).isEqualTo("");
+    userDetails.setEmail("");
+    assertThat(userDetails.getEmail()).isEqualTo("");
 
-        userDetails.setEmail("foo@example.com");
-        assertThat(userDetails.getEmail()).isEqualTo("foo@example.com");
-    }
+    userDetails.setEmail("foo@example.com");
+    assertThat(userDetails.getEmail()).isEqualTo("foo@example.com");
+  }
 
-    @Test
-    public void getUserIdTest() {
-        userDetails.setUserId(null);
-        assertThat(userDetails.getUserId()).isNull();
+  @Test
+  public void getUserIdTest() {
+    userDetails.setUserId(null);
+    assertThat(userDetails.getUserId()).isNull();
 
-        userDetails.setUserId("");
-        assertThat(userDetails.getUserId()).isEqualTo("");
+    userDetails.setUserId("");
+    assertThat(userDetails.getUserId()).isEqualTo("");
 
-        userDetails.setUserId("foo@example");
-        assertThat(userDetails.getUserId()).isEqualTo("foo@example");
-    }
+    userDetails.setUserId("foo@example");
+    assertThat(userDetails.getUserId()).isEqualTo("foo@example");
+  }
 
-    @Test
-    public void toStringTest() {
-        userDetails.setName("foo");
-        userDetails.setEmail("foo@example.com");
-        userDetails.setUserId("foo@example");
+  @Test
+  public void toStringTest() {
+    userDetails.setName("foo");
+    userDetails.setEmail("foo@example.com");
+    userDetails.setUserId("foo@example");
 
-        assertThat(userDetails.toString()).isEqualTo("UserDetails{name=foo, email=foo@example.com, userId=foo@example}");
-    }
+    assertThat(userDetails.toString()).isEqualTo("UserDetails{name=foo, email=foo@example.com, userId=foo@example}");
+  }
 }


### PR DESCRIPTION
 SONAR-6867: Add a new APIs UserDetails.getUserId()/setUserId(String userId)
 to allow plugins to pass userId information to SonarQube
setUserId(String userId) and getUserId () are added to UserDetails.

Testing
 1. Unit test for UserDetails
 2. Verification of following scenarios :
    a. Plugin (e.g. LDAP) is dependent on older sonarqube plugins apis
       ( < 5.2) and the plugin is being used in SonarQube 5.2 server
    b. Plugin is dependent on SonarQube 5.2 plugin apis and userId is not
       being populated in UserDetails along with userName and Email .
    c. Plugin is dependent on SonarQube 5.2 plugin apis and userId is
       also being populated by the plugin in UserDetails along with
       userName and Email.