### PR TITLE
Compute Engine logs of execution duration of each component visitor

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/computation/component/PathAwareVisitorWrapper.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/component/PathAwareVisitorWrapper.java
@@ -33,6 +33,11 @@ public class PathAwareVisitorWrapper<T> implements VisitorWrapper {
   }
 
   @Override
+  public ComponentVisitor getWrappedVisitor() {
+    return this.delegate;
+  }
+
+  @Override
   public void beforeComponent(Component component){
     stack.add(new PathElementImpl<>(component, createForComponent(component)));
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/component/TypeAwareVisitorWrapper.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/component/TypeAwareVisitorWrapper.java
@@ -29,6 +29,11 @@ public class TypeAwareVisitorWrapper implements VisitorWrapper {
   }
 
   @Override
+  public ComponentVisitor getWrappedVisitor() {
+    return this.delegate;
+  }
+
+  @Override
   public void beforeComponent(Component component){
     // Nothing to do
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/component/VisitorWrapper.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/component/VisitorWrapper.java
@@ -22,6 +22,8 @@ package org.sonar.server.computation.component;
 
 public interface VisitorWrapper extends TypeAwareVisitor {
 
+  ComponentVisitor getWrappedVisitor();
+
   void beforeComponent(Component component);
 
   void afterComponent(Component component);

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/component/ReportComponent.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/component/ReportComponent.java
@@ -22,6 +22,7 @@ package org.sonar.server.computation.component;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
@@ -142,7 +143,7 @@ public class ReportComponent implements Component {
   }
 
   public static Builder builder(Type type, int ref) {
-    return new Builder(type, ref);
+    return new Builder(type, ref).setKey("key_" + ref).setUuid("uuid_" + ref);
   }
 
   public static final class Builder {
@@ -163,8 +164,8 @@ public class ReportComponent implements Component {
       this.ref = ref;
     }
 
-    public Builder setUuid(@Nullable String s) {
-      this.uuid = s;
+    public Builder setUuid(String s) {
+      this.uuid = Objects.requireNonNull(s);
       return this;
     }
 
@@ -173,8 +174,8 @@ public class ReportComponent implements Component {
       return this;
     }
 
-    public Builder setKey(@Nullable String s) {
-      this.key = s;
+    public Builder setKey(String s) {
+      this.key = Objects.requireNonNull(s);
       return this;
     }
 

--- a/sonar-core/src/main/java/org/sonar/core/util/logs/NullProfiler.java
+++ b/sonar-core/src/main/java/org/sonar/core/util/logs/NullProfiler.java
@@ -49,12 +49,27 @@ class NullProfiler extends Profiler {
   }
 
   @Override
+  public Profiler startTrace(String message, Object... args) {
+    return this;
+  }
+
+  @Override
   public Profiler startDebug(String message) {
     return this;
   }
 
   @Override
+  public Profiler startDebug(String message, Object... args) {
+    return this;
+  }
+
+  @Override
   public Profiler startInfo(String message) {
+    return this;
+  }
+
+  @Override
+  public Profiler startInfo(String message, Object... args) {
     return this;
   }
 
@@ -79,12 +94,27 @@ class NullProfiler extends Profiler {
   }
 
   @Override
+  public long stopTrace(String message, Object... args) {
+    return 0;
+  }
+
+  @Override
   public long stopDebug(String message) {
     return 0;
   }
 
   @Override
+  public long stopDebug(String message, Object... args) {
+    return 0;
+  }
+
+  @Override
   public long stopInfo(String message) {
+    return 0;
+  }
+
+  @Override
+  public long stopInfo(String message, Object... args) {
     return 0;
   }
 

--- a/sonar-core/src/main/java/org/sonar/core/util/logs/Profiler.java
+++ b/sonar-core/src/main/java/org/sonar/core/util/logs/Profiler.java
@@ -54,9 +54,15 @@ public abstract class Profiler {
 
   public abstract Profiler startTrace(String message);
 
+  public abstract Profiler startTrace(String message, Object... args);
+
   public abstract Profiler startDebug(String message);
 
+  public abstract Profiler startDebug(String message, Object... args);
+
   public abstract Profiler startInfo(String message);
+
+  public abstract Profiler startInfo(String message, Object... args);
 
   /**
    * Works only if a message have been set in startXXX() methods.
@@ -69,9 +75,15 @@ public abstract class Profiler {
 
   public abstract long stopTrace(String message);
 
+  public abstract long stopTrace(String message, Object... args);
+
   public abstract long stopDebug(String message);
 
+  public abstract long stopDebug(String message, Object... args);
+
   public abstract long stopInfo(String message);
+
+  public abstract long stopInfo(String message, Object... args);
 
   /**
    * Context information is removed if value is <code>null</code>.

--- a/sonar-core/src/test/java/org/sonar/core/util/logs/DefaultProfilerTest.java
+++ b/sonar-core/src/test/java/org/sonar/core/util/logs/DefaultProfilerTest.java
@@ -55,13 +55,13 @@ public class DefaultProfilerTest {
     tester.setLevel(LoggerLevel.TRACE);
 
     // trace
-    underTest.startTrace("Register rules");
+    underTest.startTrace("Register rules {}", 1);
     Thread.sleep(2);
-    assertThat(tester.logs()).containsOnly("Register rules");
+    assertThat(tester.logs()).containsOnly("Register rules 1");
     long timing = underTest.stopTrace();
     assertThat(timing).isGreaterThan(0);
     assertThat(tester.logs()).hasSize(2);
-    assertThat(tester.logs().get(1)).startsWith("Register rules (done) | time=" + timing);
+    assertThat(tester.logs().get(1)).startsWith("Register rules 1 (done) | time=" + timing);
     tester.clear();
 
     // debug
@@ -97,10 +97,10 @@ public class DefaultProfilerTest {
     tester.clear();
 
     // start DEBUG and stop INFO
-    underTest.startDebug("Register rules");
+    underTest.startDebug("Register rules {}", 10);
     underTest.stopInfo("Rules registered");
     assertThat(tester.logs()).hasSize(2);
-    assertThat(tester.logs().get(0)).contains("Register rules");
+    assertThat(tester.logs().get(0)).contains("Register rules 10");
     assertThat(tester.logs().get(1)).startsWith("Rules registered | time=");
     tester.clear();
 
@@ -125,9 +125,9 @@ public class DefaultProfilerTest {
 
     // debug
     underTest.start();
-    underTest.stopDebug("Rules registered");
+    underTest.stopDebug("Rules registered {} on {}", 6, 10);
     assertThat(tester.logs()).hasSize(1);
-    assertThat(tester.logs().get(0)).startsWith("Rules registered | time=");
+    assertThat(tester.logs().get(0)).startsWith("Rules registered 6 on 10 | time=");
     tester.clear();
 
     // info


### PR DESCRIPTION
this PR contains:
* improvements on the sonar.util Profiler implementation (less String creation when actual log level is lower than the configured one)
* ReportComponent now create Component implementations for tests which always have a key
** this can be changed now because Component implementation of production code is now immutable (see @julienlancelot 's PR)
* the cumulative execution time of each visitor is now displayed in logs at INFO level
* bonus: at TRACE level, the Component Visitor execution time for each component will be displayed