### PR TITLE
SONAR-6353 do not compute the metric days_since_last_commit

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/computation/source/LastCommitVisitor.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/source/LastCommitVisitor.java
@@ -41,7 +41,6 @@ public class LastCommitVisitor extends PathAwareVisitorAdapter<LastCommitVisitor
   private final BatchReportReader reportReader;
   private final MeasureRepository measureRepository;
   private final Metric lastCommitDateMetric;
-  private final Metric daysSinceLastCommitDateMetric;
   private final System2 system2;
 
   public LastCommitVisitor(BatchReportReader reportReader, MetricRepository metricRepository,
@@ -62,7 +61,6 @@ public class LastCommitVisitor extends PathAwareVisitorAdapter<LastCommitVisitor
     this.measureRepository = measureRepository;
     this.system2 = system2;
     this.lastCommitDateMetric = metricRepository.getByKey(CoreMetrics.LAST_COMMIT_DATE_KEY);
-    this.daysSinceLastCommitDateMetric = metricRepository.getByKey(CoreMetrics.DAYS_SINCE_LAST_COMMIT_KEY);
   }
 
   @Override
@@ -124,17 +122,11 @@ public class LastCommitVisitor extends PathAwareVisitorAdapter<LastCommitVisitor
     long maxDate = path.current().getDate();
     if (maxDate > 0L) {
       measureRepository.add(component, lastCommitDateMetric, Measure.newMeasureBuilder().create(maxDate));
-      measureRepository.add(component, daysSinceLastCommitDateMetric, Measure.newMeasureBuilder().create(daysBetween(system2.now(), maxDate)));
 
       if (!path.isRoot()) {
         path.parent().addDate(maxDate);
       }
     }
-  }
-
-  private static int daysBetween(long d1, long d2) {
-    // limitation of metric type: long is not supported yet, so casting to int
-    return (int) (Math.abs(d1 - d2) / MILLISECONDS_PER_DAY);
   }
 
   public static final class LastCommit {

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/source/LastCommitVisitor.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/source/LastCommitVisitor.java
@@ -21,7 +21,6 @@ package org.sonar.server.computation.source;
 
 import com.google.common.base.Optional;
 import org.sonar.api.measures.CoreMetrics;
-import org.sonar.api.utils.System2;
 import org.sonar.batch.protocol.output.BatchReport;
 import org.sonar.server.computation.batch.BatchReportReader;
 import org.sonar.server.computation.component.Component;
@@ -36,15 +35,12 @@ import static org.sonar.server.computation.component.ComponentVisitor.Order.POST
 
 public class LastCommitVisitor extends PathAwareVisitorAdapter<LastCommitVisitor.LastCommit> {
 
-  private static final long MILLISECONDS_PER_DAY = 1000L * 60 * 60 * 24;
-
   private final BatchReportReader reportReader;
   private final MeasureRepository measureRepository;
   private final Metric lastCommitDateMetric;
-  private final System2 system2;
 
   public LastCommitVisitor(BatchReportReader reportReader, MetricRepository metricRepository,
-    MeasureRepository measureRepository, System2 system2) {
+    MeasureRepository measureRepository) {
     super(CrawlerDepthLimit.LEAVES, POST_ORDER, new SimpleStackElementFactory<LastCommit>() {
       @Override
       public LastCommit createForAny(Component component) {
@@ -59,7 +55,6 @@ public class LastCommitVisitor extends PathAwareVisitorAdapter<LastCommitVisitor
     });
     this.reportReader = reportReader;
     this.measureRepository = measureRepository;
-    this.system2 = system2;
     this.lastCommitDateMetric = metricRepository.getByKey(CoreMetrics.LAST_COMMIT_DATE_KEY);
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/source/LastCommitVisitorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/source/LastCommitVisitorTest.java
@@ -42,7 +42,6 @@ import org.sonar.server.computation.metric.MetricRepositoryRule;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.sonar.api.measures.CoreMetrics.DAYS_SINCE_LAST_COMMIT_KEY;
 import static org.sonar.api.measures.CoreMetrics.LAST_COMMIT_DATE_KEY;
 import static org.sonar.server.computation.component.Component.Type.DIRECTORY;
 import static org.sonar.server.computation.component.Component.Type.FILE;
@@ -73,8 +72,7 @@ public class LastCommitVisitorTest {
 
   @Rule
   public MetricRepositoryRule metricRepository = new MetricRepositoryRule()
-    .add(CoreMetrics.LAST_COMMIT_DATE)
-    .add(CoreMetrics.DAYS_SINCE_LAST_COMMIT);
+    .add(CoreMetrics.LAST_COMMIT_DATE);
 
   @Rule
   public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
@@ -138,17 +136,13 @@ public class LastCommitVisitorTest {
     underTest.visit(project);
 
     assertDate(DIR_1_REF, FILE_2_DATE);
-    assertDaysSinceLastCommit(DIR_1_REF, 6944 /* number of days between FILE_2_DATE and now */);
     assertDate(DIR_2_REF, FILE_3_DATE);
-    assertDaysSinceLastCommit(DIR_2_REF, 5787 /* number of days between FILE_3_DATE and now */);
 
     // module = most recent commit date of directories
     assertDate(MODULE_REF, FILE_3_DATE);
-    assertDaysSinceLastCommit(MODULE_REF, 5787 /* number of days between FILE_3_DATE and now */);
 
     // project
     assertDate(PROJECT_REF, FILE_3_DATE);
-    assertDaysSinceLastCommit(PROJECT_REF, 5787 /* number of days between FILE_3_DATE and now */);
   }
 
   @Test
@@ -191,17 +185,13 @@ public class LastCommitVisitorTest {
 
     // second level of sub-views
     assertDate(SUBVIEW_2_REF, PROJECT_2_DATE);
-    assertDaysSinceLastCommit(SUBVIEW_2_REF, 1157 /* nb of days between PROJECT_2_DATE and NOW */);
     assertDate(SUBVIEW_3_REF, PROJECT_3_DATE);
-    assertDaysSinceLastCommit(SUBVIEW_3_REF, 2314 /* nb of days between PROJECT_3_DATE and NOW */);
 
     // first level of sub-views
     assertDate(SUBVIEW_1_REF, PROJECT_2_DATE);
-    assertDaysSinceLastCommit(SUBVIEW_1_REF, 1157 /* nb of days between PROJECT_2_DATE and NOW */);
 
     // view
     assertDate(VIEW_REF, PROJECT_2_DATE);
-    assertDaysSinceLastCommit(VIEW_REF, 1157 /* nb of days between PROJECT_2_DATE and NOW */);
   }
 
   @Test
@@ -235,19 +225,12 @@ public class LastCommitVisitorTest {
     underTest.visit(file);
 
     assertDate(FILE_1_REF, 1_600_000_000_000L);
-    assertDaysSinceLastCommit(FILE_1_REF, 2314);
   }
 
   private void assertDate(int componentRef, long expectedDate) {
     Optional<Measure> measure = measureRepository.getAddedRawMeasure(componentRef, LAST_COMMIT_DATE_KEY);
     assertThat(measure.isPresent()).isTrue();
     assertThat(measure.get().getLongValue()).isEqualTo(expectedDate);
-  }
-
-  private void assertDaysSinceLastCommit(int componentRef, int numberOfDays) {
-    Optional<Measure> measure = measureRepository.getAddedRawMeasure(componentRef, DAYS_SINCE_LAST_COMMIT_KEY);
-    assertThat(measure.isPresent()).isTrue();
-    assertThat(measure.get().getIntValue()).isEqualTo(numberOfDays);
   }
 
   /**

--- a/sonar-plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java
@@ -366,21 +366,21 @@ public final class CoreMetrics {
   @Deprecated
   public static final Metric<String> CLASS_COMPLEXITY_DISTRIBUTION = new Metric.Builder(CLASS_COMPLEXITY_DISTRIBUTION_KEY, "Classes distribution /complexity",
     Metric.ValueType.DISTRIB)
-    .setDescription("Classes distribution /complexity")
-    .setDirection(Metric.DIRECTION_NONE)
-    .setQualitative(true)
-    .setDomain(DOMAIN_COMPLEXITY)
-    .setHidden(true)
-    .create();
+      .setDescription("Classes distribution /complexity")
+      .setDirection(Metric.DIRECTION_NONE)
+      .setQualitative(true)
+      .setDomain(DOMAIN_COMPLEXITY)
+      .setHidden(true)
+      .create();
 
   public static final String FUNCTION_COMPLEXITY_DISTRIBUTION_KEY = "function_complexity_distribution";
   public static final Metric<String> FUNCTION_COMPLEXITY_DISTRIBUTION = new Metric.Builder(FUNCTION_COMPLEXITY_DISTRIBUTION_KEY, "Functions distribution /complexity",
     Metric.ValueType.DISTRIB)
-    .setDescription("Functions distribution /complexity")
-    .setDirection(Metric.DIRECTION_NONE)
-    .setQualitative(true)
-    .setDomain(DOMAIN_COMPLEXITY)
-    .create();
+      .setDescription("Functions distribution /complexity")
+      .setDirection(Metric.DIRECTION_NONE)
+      .setQualitative(true)
+      .setDomain(DOMAIN_COMPLEXITY)
+      .create();
 
   public static final String FILE_COMPLEXITY_DISTRIBUTION_KEY = "file_complexity_distribution";
   public static final Metric<String> FILE_COMPLEXITY_DISTRIBUTION = new Metric.Builder(FILE_COMPLEXITY_DISTRIBUTION_KEY, "Files distribution /complexity", Metric.ValueType.DISTRIB)
@@ -887,12 +887,12 @@ public final class CoreMetrics {
    */
   public static final Metric<Integer> NEW_IT_UNCOVERED_CONDITIONS = new Metric.Builder(NEW_IT_UNCOVERED_CONDITIONS_KEY, "Uncovered branches by IT on new code",
     Metric.ValueType.INT)
-    .setDescription("Uncovered branches by Integration Tests on new code")
-    .setDirection(Metric.DIRECTION_WORST)
-    .setDomain(DOMAIN_INTEGRATION_TESTS)
-    .setBestValue(0.0)
-    .setDeleteHistoricalData(true)
-    .create();
+      .setDescription("Uncovered branches by Integration Tests on new code")
+      .setDirection(Metric.DIRECTION_WORST)
+      .setDomain(DOMAIN_INTEGRATION_TESTS)
+      .setBestValue(0.0)
+      .setDeleteHistoricalData(true)
+      .create();
 
   /**
    * @since 2.12
@@ -1114,12 +1114,12 @@ public final class CoreMetrics {
   @Deprecated
   public static final Metric<String> OVERALL_COVERAGE_LINE_HITS_DATA = new Metric.Builder(OVERALL_COVERAGE_LINE_HITS_DATA_KEY, "Overall coverage hits by line",
     Metric.ValueType.DATA)
-    .setDescription("Coverage hits by all tests and by line")
-    .setDirection(Metric.DIRECTION_NONE)
-    .setQualitative(false)
-    .setDomain(DOMAIN_OVERALL_TESTS)
-    .setDeleteHistoricalData(true)
-    .create();
+      .setDescription("Coverage hits by all tests and by line")
+      .setDirection(Metric.DIRECTION_NONE)
+      .setQualitative(false)
+      .setDomain(DOMAIN_OVERALL_TESTS)
+      .setDeleteHistoricalData(true)
+      .create();
 
   /**
    * @since 3.3
@@ -1147,11 +1147,11 @@ public final class CoreMetrics {
    */
   public static final Metric<Integer> NEW_OVERALL_CONDITIONS_TO_COVER = new Metric.Builder(NEW_OVERALL_CONDITIONS_TO_COVER_KEY, "Overall branches to cover on new code",
     Metric.ValueType.INT)
-    .setDescription("New branches to cover by all tests")
-    .setDomain(DOMAIN_OVERALL_TESTS)
-    .setDeleteHistoricalData(true)
-    .setHidden(true)
-    .create();
+      .setDescription("New branches to cover by all tests")
+      .setDomain(DOMAIN_OVERALL_TESTS)
+      .setDeleteHistoricalData(true)
+      .setHidden(true)
+      .create();
 
   /**
    * @since 3.3
@@ -1177,12 +1177,12 @@ public final class CoreMetrics {
    */
   public static final Metric<Integer> NEW_OVERALL_UNCOVERED_CONDITIONS = new Metric.Builder(NEW_OVERALL_UNCOVERED_CONDITIONS_KEY, "Overall uncovered branches on new code",
     Metric.ValueType.INT)
-    .setDescription("New branches that are not covered by any test")
-    .setDirection(Metric.DIRECTION_WORST)
-    .setDomain(DOMAIN_OVERALL_TESTS)
-    .setBestValue(0.0)
-    .setDeleteHistoricalData(true)
-    .create();
+      .setDescription("New branches that are not covered by any test")
+      .setDirection(Metric.DIRECTION_WORST)
+      .setDomain(DOMAIN_OVERALL_TESTS)
+      .setBestValue(0.0)
+      .setDeleteHistoricalData(true)
+      .create();
 
   /**
    * @since 3.3
@@ -1211,14 +1211,14 @@ public final class CoreMetrics {
    */
   public static final Metric<Double> NEW_OVERALL_BRANCH_COVERAGE = new Metric.Builder(NEW_OVERALL_BRANCH_COVERAGE_KEY, "Overall condition coverage on new code",
     Metric.ValueType.PERCENT)
-    .setDescription("Condition coverage of new/changed code by all tests")
-    .setDirection(Metric.DIRECTION_BETTER)
-    .setQualitative(true)
-    .setDomain(DOMAIN_OVERALL_TESTS)
-    .setWorstValue(0.0)
-    .setBestValue(100.0)
-    .setDeleteHistoricalData(true)
-    .create();
+      .setDescription("Condition coverage of new/changed code by all tests")
+      .setDirection(Metric.DIRECTION_BETTER)
+      .setQualitative(true)
+      .setDomain(DOMAIN_OVERALL_TESTS)
+      .setWorstValue(0.0)
+      .setBestValue(100.0)
+      .setDeleteHistoricalData(true)
+      .create();
 
   /**
    * @since 3.3
@@ -1252,10 +1252,10 @@ public final class CoreMetrics {
   @Deprecated
   public static final Metric<String> OVERALL_COVERED_CONDITIONS_BY_LINE = new Metric.Builder(OVERALL_COVERED_CONDITIONS_BY_LINE_KEY, "Overall covered branches by line",
     Metric.ValueType.DATA)
-    .setDescription("Overall covered branches by all tests and by line")
-    .setDomain(DOMAIN_OVERALL_TESTS)
-    .setDeleteHistoricalData(true)
-    .create();
+      .setDescription("Overall covered branches by all tests and by line")
+      .setDomain(DOMAIN_OVERALL_TESTS)
+      .setDeleteHistoricalData(true)
+      .create();
 
   // --------------------------------------------------------------------------------------------------------------------
   //
@@ -2004,8 +2004,8 @@ public final class CoreMetrics {
   @Deprecated
   public static final transient Metric<String> SCM_LAST_COMMIT_DATETIMES_BY_LINE = new Metric.Builder(SCM_LAST_COMMIT_DATETIMES_BY_LINE_KEY, "Last commit dates by line",
     Metric.ValueType.DATA)
-    .setDomain(DOMAIN_SCM)
-    .create();
+      .setDomain(DOMAIN_SCM)
+      .create();
 
   // --------------------------------------------------------------------------------------------------------------------
   //
@@ -2106,13 +2106,13 @@ public final class CoreMetrics {
    * @since 5.2
    */
   public static final Metric<Double> NEW_SQALE_DEBT_RATIO = new Metric.Builder(NEW_SQALE_DEBT_RATIO_KEY, "Technical Debt Ratio on new code", Metric.ValueType.PERCENT)
-      .setDescription("Technical Debt Ratio of new/changed code.")
-      .setDomain(DOMAIN_TECHNICAL_DEBT)
-      .setDirection(Metric.DIRECTION_WORST)
-      .setOptimizedBestValue(true)
-      .setBestValue(0.0)
-      .setQualitative(true)
-      .create();
+    .setDescription("Technical Debt Ratio of new/changed code.")
+    .setDomain(DOMAIN_TECHNICAL_DEBT)
+    .setDirection(Metric.DIRECTION_WORST)
+    .setOptimizedBestValue(true)
+    .setBestValue(0.0)
+    .setQualitative(true)
+    .create();
 
   // --------------------------------------------------------------------------------------------------------------------
   //
@@ -2231,18 +2231,6 @@ public final class CoreMetrics {
     .setQualitative(false)
     .setDomain(DOMAIN_GENERAL)
     .setHidden(true)
-    .create();
-
-  /**
-   * @since 5.2 – was computed in the dev cockpit plugin previously
-   */
-  public static final String DAYS_SINCE_LAST_COMMIT_KEY = "days_since_last_commit";
-
-  /**
-   * @since 5.2 – was computed in the dev cockpit plugin previously
-   */
-  public static final Metric<Integer> DAYS_SINCE_LAST_COMMIT = new Metric.Builder(DAYS_SINCE_LAST_COMMIT_KEY, "Days since last commit", Metric.ValueType.INT)
-    .setDomain(CoreMetrics.DOMAIN_SCM)
     .create();
 
   /**


### PR DESCRIPTION
The metric days_since_last_commit was introduced during the 
sprint 5.2 but then was replaced by last_commit_date