### PR TITLE
SONAR-6863 Support Integrated Authentication for SQL Server with Sona…

### DIFF
--- a/server/sonar-process/src/main/java/org/sonar/process/ProcessProperties.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/ProcessProperties.java
@@ -115,8 +115,6 @@ public class ProcessProperties {
     defaults.put(ProcessProperties.WEB_JAVA_OPTS, "-Xmx768m -XX:MaxPermSize=160m -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true");
     defaults.put(ProcessProperties.WEB_JAVA_ADDITIONAL_OPTS, "");
     defaults.put(ProcessProperties.JDBC_URL, "jdbc:h2:tcp://localhost:9092/sonar");
-    defaults.put(ProcessProperties.JDBC_LOGIN, "sonar");
-    defaults.put(ProcessProperties.JDBC_PASSWORD, "sonar");
     defaults.put(ProcessProperties.JDBC_MAX_ACTIVE, "50");
     defaults.put(ProcessProperties.JDBC_MAX_IDLE, "5");
     defaults.put(ProcessProperties.JDBC_MIN_IDLE, "2");

--- a/server/sonar-process/src/test/java/org/sonar/process/ProcessPropertiesTest.java
+++ b/server/sonar-process/src/test/java/org/sonar/process/ProcessPropertiesTest.java
@@ -34,7 +34,6 @@ public class ProcessPropertiesTest {
     ProcessProperties.completeDefaults(props);
 
     assertThat(props.value("sonar.search.javaOpts")).contains("-Xmx");
-    assertThat(props.value("sonar.jdbc.username")).isEqualTo("sonar");
     assertThat(props.valueAsInt("sonar.jdbc.maxActive")).isEqualTo(50);
   }
 

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -44,6 +44,13 @@
 
 #----- Microsoft SQLServer 2008/2012
 # Collation must be case-sensitive (CS) and accent-sensitive (AS).
+#Use the following connection string if you want to use integrated security with MS Sql Server.
+#Do not set sonar.jdbc.username or sonar.jdbc.password property if you are using Integrated Auth
+#For Integrated Security to work, you have to download the MS SQL JDBC driver package from http://www.microsoft.com/en-us/download/details.aspx?displaylang=en&id=11774
+#and copy sqljdbc_auth.dll to your path. If you have to copy the 32 bit or 64 bit version of the dll depending upon the architecture of your server machine
+#sonar.jdbc.url=jdbc:sqlserver://localhost;databaseName=sonar;integratedSecurity=true
+
+#Use the following connection string if you want to use SQL Auth while connecting to MS Sql Server. Set the sonar.jdbc.username and sonar.jdbc.password appropriately
 #sonar.jdbc.url=jdbc:sqlserver://localhost;databaseName=sonar
 
 

--- a/sonar-db/src/main/java/org/sonar/db/DefaultDatabase.java
+++ b/sonar-db/src/main/java/org/sonar/db/DefaultDatabase.java
@@ -162,8 +162,9 @@ public class DefaultDatabase implements Database {
 
   private static void completeDefaultProperties(Properties props) {
     completeDefaultProperty(props, DatabaseProperties.PROP_URL, DEFAULT_URL);
-    completeDefaultProperty(props, DatabaseProperties.PROP_USER, props.getProperty(DatabaseProperties.PROP_USER_DEPRECATED, DatabaseProperties.PROP_USER_DEFAULT_VALUE));
-    completeDefaultProperty(props, DatabaseProperties.PROP_PASSWORD, DatabaseProperties.PROP_PASSWORD_DEFAULT_VALUE);
+
+    if (props.getProperty(DatabaseProperties.PROP_USER_DEPRECATED) != null)
+      completeDefaultProperty(props, DatabaseProperties.PROP_USER, props.getProperty(DatabaseProperties.PROP_USER_DEPRECATED));
   }
 
   private static void completeDefaultProperty(Properties props, String key, String defaultValue) {

--- a/sonar-db/src/test/java/org/sonar/db/DefaultDatabaseTest.java
+++ b/sonar-db/src/test/java/org/sonar/db/DefaultDatabaseTest.java
@@ -35,8 +35,6 @@ public class DefaultDatabaseTest {
     db.initSettings();
 
     Properties props = db.getProperties();
-    assertThat(props.getProperty("sonar.jdbc.username")).isEqualTo("sonar");
-    assertThat(props.getProperty("sonar.jdbc.password")).isEqualTo("sonar");
     assertThat(props.getProperty("sonar.jdbc.url")).isEqualTo("jdbc:h2:tcp://localhost/sonar");
     assertThat(props.getProperty("sonar.jdbc.driverClassName")).isEqualTo("org.h2.Driver");
     assertThat(db.toString()).isEqualTo("Database[jdbc:h2:tcp://localhost/sonar]");

--- a/sonar-plugin-api/src/main/java/org/sonar/api/database/DatabaseProperties.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/database/DatabaseProperties.java
@@ -27,9 +27,9 @@ public interface DatabaseProperties {
   String PROP_DRIVER = "sonar.jdbc.driverClassName";
   String PROP_USER = "sonar.jdbc.username";
   String PROP_USER_DEPRECATED = "sonar.jdbc.user";
-  String PROP_USER_DEFAULT_VALUE = "sonar";
+  String PROP_USER_DEFAULT_VALUE = "";
   String PROP_PASSWORD = "sonar.jdbc.password";
-  String PROP_PASSWORD_DEFAULT_VALUE = "sonar";
+  String PROP_PASSWORD_DEFAULT_VALUE = "";
   String PROP_DIALECT = "sonar.jdbc.dialect";
 
   /**


### PR DESCRIPTION
…rQube installed in Windows

Enabling Integrated Authentication for connecting to MS Sql Server. Default value for sonar.jdbc.username and sonar.jdbc.password have been removed.