### PR TITLE
feature/4.5-vulnerability-fixes

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/platform/SecurityServletFilter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/platform/SecurityServletFilter.java
@@ -1,0 +1,78 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.platform;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Set;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This servlet filter sets response headers that enable browser protection against several classes if Web attacks.
+ * The list of headers is mirrored in environment.rb as a workaround to Rack swallowing the headers..
+ */
+public class SecurityServletFilter implements Filter {
+
+  private static final Set<String> ALLOWED_HTTP_METHODS = ImmutableSet.of("DELETE", "GET", "HEAD", "POST", "PUT");
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    // nothing
+  }
+
+  @Override
+  public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException, ServletException {
+    doHttpFilter((HttpServletRequest) req, (HttpServletResponse) resp, chain);
+  }
+
+  private static void doHttpFilter(HttpServletRequest httpRequest, HttpServletResponse httpResponse, FilterChain chain) throws IOException, ServletException {
+    // SONAR-6881 Disable OPTIONS and TRACE methods
+    if (!ALLOWED_HTTP_METHODS.contains(httpRequest.getMethod())) {
+      httpResponse.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+      return;
+    }
+
+    chain.doFilter(httpRequest, httpResponse);
+
+    // Clickjacking protection
+    // See https://www.owasp.org/index.php/Clickjacking_Protection_for_Java_EE
+    httpResponse.addHeader("X-Frame-Options", "SAMEORIGIN");
+
+    // Cross-site scripting
+    // See https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+    httpResponse.addHeader("X-XSS-Protection", "1; mode=block");
+
+    // MIME-sniffing
+    // See https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+    httpResponse.addHeader("X-Content-Type-Options", "nosniff");
+  }
+
+  @Override
+  public void destroy() {
+    // nothing
+  }
+}

--- a/server/sonar-server/src/test/java/org/sonar/server/platform/SecurityServletFilterTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/platform/SecurityServletFilterTest.java
@@ -1,0 +1,103 @@
+/*
+ * SonarQube, open source software quality management tool.
+ * Copyright (C) 2008-2014 SonarSource
+ * mailto:contact AT sonarsource DOT com
+ *
+ * SonarQube is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * SonarQube is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.platform;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SecurityServletFilterTest {
+
+  SecurityServletFilter underTest = new SecurityServletFilter();
+  HttpServletResponse response = mock(HttpServletResponse.class);
+  FilterChain chain = mock(FilterChain.class);
+
+  @Test
+  public void allow_GET_method() throws IOException, ServletException {
+    assertThatMethodIsAllowed("GET");
+  }
+
+  @Test
+  public void allow_HEAD_method() throws IOException, ServletException {
+    assertThatMethodIsAllowed("HEAD");
+  }
+
+  @Test
+  public void allow_PUT_method() throws IOException, ServletException {
+    assertThatMethodIsAllowed("PUT");
+  }
+
+  @Test
+  public void allow_POST_method() throws IOException, ServletException {
+    assertThatMethodIsAllowed("POST");
+  }
+
+  private void assertThatMethodIsAllowed(String httpMethod) throws IOException, ServletException {
+    HttpServletRequest request = newRequest(httpMethod);
+    underTest.doFilter(request, response, chain);
+    verify(response, never()).setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  public void deny_OPTIONS_method() throws IOException, ServletException {
+    assertThatMethodIsDenied("OPTIONS");
+  }
+
+  @Test
+  public void deny_TRACE_method() throws IOException, ServletException {
+    assertThatMethodIsDenied("TRACE");
+  }
+
+  private void assertThatMethodIsDenied(String httpMethod) throws IOException, ServletException {
+    underTest.doFilter(newRequest(httpMethod), response, chain);
+    verify(response).setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+  }
+
+  @Test
+  public void set_secured_headers() throws ServletException, IOException {
+    underTest.init(mock(FilterConfig.class));
+    HttpServletRequest request = newRequest("GET");
+
+    underTest.doFilter(request, response, chain);
+
+    verify(response, times(3)).addHeader(startsWith("X-"), anyString());
+
+    underTest.destroy();
+  }
+
+  private HttpServletRequest newRequest(String httpMethod) {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getMethod()).thenReturn(httpMethod);
+    return req;
+  }
+}

--- a/server/sonar-web/src/main/webapp/WEB-INF/web.xml
+++ b/server/sonar-web/src/main/webapp/WEB-INF/web.xml
@@ -48,6 +48,10 @@
     <filter-class>org.jruby.rack.RackFilter</filter-class>
   </filter>
   <filter>
+    <filter-name>SecurityFilter</filter-name>
+    <filter-class>org.sonar.server.platform.SecurityServletFilter</filter-class>
+  </filter>
+  <filter>
     <filter-name>ProfilingFilter</filter-name>
     <filter-class>org.sonar.server.platform.ProfilingFilter</filter-class>
     <init-param>
@@ -71,6 +75,10 @@
   </filter-mapping>
   <filter-mapping>
     <filter-name>ServletFilters</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>SecurityFilter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
   <filter-mapping>


### PR DESCRIPTION
SONAR-6881 backporting SecurityServletFilter to 4.5 allows 
to fix two other vulnerabilities that were already fixed in 5.1 and 5.2.
See https://github.com/SonarSource/sonarqube/commits/master/server/sonar-server/src/main/java/org/sonar/server/platform/SecurityServletFilter.java