### PR TITLE
SONAR-6749 add ignoreZeroValue flag to VariationSumFormula

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/computation/step/NewCoverageMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/step/NewCoverageMeasuresStep.java
@@ -278,10 +278,10 @@ public class NewCoverageMeasuresStep implements ComputationStep {
    */
   private static Iterable<Formula<?>> variationSumFormulas(NewCoverageOutputMetricKeys outputMetricKeys) {
     return ImmutableList.<Formula<?>>of(
-      new VariationSumFormula(outputMetricKeys.getNewLinesToCover(), viewsRestrictedPeriods()),
-      new VariationSumFormula(outputMetricKeys.getNewUncoveredLines(), viewsRestrictedPeriods()),
-      new VariationSumFormula(outputMetricKeys.getNewConditionsToCover(), viewsRestrictedPeriods()),
-      new VariationSumFormula(outputMetricKeys.getNewUncoveredConditions(), viewsRestrictedPeriods()));
+      new VariationSumFormula(outputMetricKeys.getNewLinesToCover(), viewsRestrictedPeriods(), true),
+      new VariationSumFormula(outputMetricKeys.getNewUncoveredLines(), viewsRestrictedPeriods(), true),
+      new VariationSumFormula(outputMetricKeys.getNewConditionsToCover(), viewsRestrictedPeriods(), true),
+      new VariationSumFormula(outputMetricKeys.getNewUncoveredConditions(), viewsRestrictedPeriods(), true));
   }
 
   public static class NewLinesAndConditionsFormula implements Formula<NewCoverageCounter> {


### PR DESCRIPTION
hardcoded behavior to ignore zero value in variations to aggregate is suitable for new_coverage metrics but not for other new_* metrics aggregated by views