### PR TITLE
SONAR-6652 explicit error when DB is disconnected in WS response

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/platform/ws/DbMigrationJsonWriter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/platform/ws/DbMigrationJsonWriter.java
@@ -37,6 +37,7 @@ public class DbMigrationJsonWriter {
   static final String STATUS_MIGRATION_SUCCEEDED = "MIGRATION_SUCCEEDED";
   static final String STATUS_MIGRATION_REQUIRED = "MIGRATION_REQUIRED";
 
+  static final String NO_CONNECTION_TO_DB = "Cannot connect to Database.";
   static final String UNSUPPORTED_DATABASE_MIGRATION_STATUS = "Unsupported DatabaseMigration status";
   static final String MESSAGE_NO_MIGRATION_ON_EMBEDDED_DATABASE = "Upgrade is not supported on embedded database.";
   static final String MESSAGE_MIGRATION_REQUIRED = "Database migration is required. DB migration can be started using WS /api/system/migrate_db.";

--- a/server/sonar-server/src/main/java/org/sonar/server/platform/ws/DbMigrationStatusAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/platform/ws/DbMigrationStatusAction.java
@@ -29,6 +29,8 @@ import org.sonar.db.Database;
 import org.sonar.db.version.DatabaseMigration;
 import org.sonar.db.version.DatabaseVersion;
 
+import static com.google.common.base.Preconditions.checkState;
+import static org.sonar.server.platform.ws.DbMigrationJsonWriter.NO_CONNECTION_TO_DB;
 import static org.sonar.server.platform.ws.DbMigrationJsonWriter.UNSUPPORTED_DATABASE_MIGRATION_STATUS;
 import static org.sonar.server.platform.ws.DbMigrationJsonWriter.statusDescription;
 import static org.sonar.server.platform.ws.DbMigrationJsonWriter.write;
@@ -64,6 +66,7 @@ public class DbMigrationStatusAction implements SystemWsAction {
   @Override
   public void handle(Request request, Response response) throws Exception {
     Integer currentVersion = databaseVersion.getVersion();
+    checkState(currentVersion != null, NO_CONNECTION_TO_DB);
 
     JsonWriter json = response.newJsonWriter();
     try {

--- a/server/sonar-server/src/main/java/org/sonar/server/platform/ws/MigrateDbAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/platform/ws/MigrateDbAction.java
@@ -28,6 +28,8 @@ import org.sonar.db.Database;
 import org.sonar.db.version.DatabaseMigration;
 import org.sonar.db.version.DatabaseVersion;
 
+import static com.google.common.base.Preconditions.checkState;
+import static org.sonar.server.platform.ws.DbMigrationJsonWriter.NO_CONNECTION_TO_DB;
 import static org.sonar.server.platform.ws.DbMigrationJsonWriter.UNSUPPORTED_DATABASE_MIGRATION_STATUS;
 import static org.sonar.server.platform.ws.DbMigrationJsonWriter.statusDescription;
 import static org.sonar.server.platform.ws.DbMigrationJsonWriter.write;
@@ -67,9 +69,7 @@ public class MigrateDbAction implements SystemWsAction {
   @Override
   public void handle(Request request, Response response) throws Exception {
     Integer currentVersion = databaseVersion.getVersion();
-    if (currentVersion == null) {
-      throw new IllegalStateException("Version can not be retrieved from Database. Database is either blank or corrupted");
-    }
+    checkState(currentVersion != null, NO_CONNECTION_TO_DB);
 
     JsonWriter json = response.newJsonWriter();
     try {

--- a/server/sonar-server/src/test/java/org/sonar/server/platform/ws/DbMigrationStatusActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/platform/ws/DbMigrationStatusActionTest.java
@@ -25,7 +25,9 @@ import java.util.Arrays;
 import java.util.Date;
 import javax.annotation.Nullable;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.sonar.api.server.ws.Request;
 import org.sonar.api.utils.DateUtils;
 import org.sonar.db.Database;
@@ -58,6 +60,8 @@ import static org.sonar.server.platform.ws.DbMigrationJsonWriter.STATUS_NO_MIGRA
 import static org.sonar.test.JsonAssert.assertJson;
 
 public class DbMigrationStatusActionTest {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   private static final Date SOME_DATE = new Date();
   private static final String SOME_THROWABLE_MSG = "blablabla pop !";
@@ -89,6 +93,16 @@ public class DbMigrationStatusActionTest {
     underTest.handle(request, response);
 
     assertJson(response.outputAsString()).isSimilarTo(getClass().getResource("example-migrate_db.json"));
+  }
+
+  @Test
+  public void throws_ISE_when_databaseVersion_can_not_be_determined() throws Exception {
+    when(databaseVersion.getVersion()).thenReturn(null);
+
+    expectedException.expect(IllegalStateException.class);
+    expectedException.expectMessage("Cannot connect to Database.");
+
+    underTest.handle(request, response);
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/platform/ws/MigrateDbActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/platform/ws/MigrateDbActionTest.java
@@ -24,7 +24,9 @@ import java.util.Arrays;
 import java.util.Date;
 import javax.annotation.Nullable;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.sonar.api.server.ws.Request;
 import org.sonar.api.utils.DateUtils;
 import org.sonar.db.Database;
@@ -47,6 +49,8 @@ import static org.sonar.db.version.DatabaseMigration.Status.SUCCEEDED;
 import static org.sonar.test.JsonAssert.assertJson;
 
 public class MigrateDbActionTest {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   private static final Date SOME_DATE = new Date();
   private static final String SOME_THROWABLE_MSG = "blablabla pop !";
@@ -80,9 +84,12 @@ public class MigrateDbActionTest {
     when(database.getDialect()).thenReturn(dialect);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void ISE_is_thrown_when_version_can_not_be_retrieved_from_database() throws Exception {
     when(databaseVersion.getVersion()).thenReturn(null);
+
+    expectedException.expect(IllegalStateException.class);
+    expectedException.expectMessage("Cannot connect to Database.");
 
     underTest.handle(request, response);
   }


### PR DESCRIPTION
fix for 5.2 of WS response of DB migration related WebService when the DB can not be reached
not error message is related to the problem and explicit
