### PR TITLE
SONAR-7055 Ability to display key as a column of measure filters

### DIFF
--- a/server/sonar-web/src/main/webapp/WEB-INF/app/views/measures/_display_list.html.erb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/views/measures/_display_list.html.erb
@@ -130,6 +130,7 @@
                               :allow_empty => true,
                               :key_prefix => 'metric:',
                               :extra_values => [
+                                  [message('measure_filter.col.key'), 'key'],
                                   [message('measure_filter.col.name'), 'name'],
                                   [message('measure_filter.col.short_name'), 'short_name'],
                                   [message('measure_filter.col.description'), 'description'],


### PR DESCRIPTION
SONAR-7055 Ability to display key as a column of measure filters