### PR TITLE
Disable Travis build of PR branches

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -13,6 +13,11 @@ function strongEcho {
   echo "================ $1 ================="
 }
 
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "${TRAVIS_BRANCH}" != "master" ]; then
+  strongEcho 'Build of branch disabled for this PR'
+  exit 0
+fi
+
 case "$TARGET" in
 
 CI)

--- a/travis.sh
+++ b/travis.sh
@@ -13,8 +13,8 @@ function strongEcho {
   echo "================ $1 ================="
 }
 
-if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] && [[ "${TRAVIS_BRANCH}" = feature* ]]; then
-  strongEcho 'Build of branch disabled for this PR'
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] then
+  strongEcho 'Build of pull request disabled'
   exit 0
 fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -13,7 +13,7 @@ function strongEcho {
   echo "================ $1 ================="
 }
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "${TRAVIS_BRANCH}" != "master" ]; then
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] && [[ "${TRAVIS_BRANCH}" = feature* ]]; then
   strongEcho 'Build of branch disabled for this PR'
   exit 0
 fi
@@ -21,7 +21,7 @@ fi
 case "$TARGET" in
 
 CI)
-  if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "${TRAVIS_BRANCH}" == "master" ] && [ -n "$GITHUB_TOKEN" ]; then
+  if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] && [[ "${TRAVIS_BRANCH}" = "master" ]] && [[ -n "$GITHUB_TOKEN" ]]; then
     # For security reasons environment variables are not available on the pull requests
     # coming from outside repositories
     # http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests


### PR DESCRIPTION
Disable Travis build of PR branches

Keep only build of PR, not of the underlying branch. That allows
to divide by 2 the nb of reserved slaves -> respect other
teams.