### PR TITLE
Remove Useless parentheses

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/charts/deprecated/SparkLinesChart.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/charts/deprecated/SparkLinesChart.java
@@ -130,8 +130,8 @@ public class SparkLinesChart extends BaseChartWeb implements DeprecatedChart {
         }
         series1.add(vX, vY);
 
-        min = (vY < min ? vY : min);
-        max = (vY > max ? vY : max);
+        min = vY < min ? vY : min;
+        max = vY > max ? vY : max;
       }
       dataset.addSeries(series1);
       y.setRange(min-1, max+1);

--- a/server/sonar-server/src/main/java/org/sonar/server/platform/DefaultServerUpgradeStatus.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/platform/DefaultServerUpgradeStatus.java
@@ -42,7 +42,7 @@ public final class DefaultServerUpgradeStatus implements ServerUpgradeStatus, St
   @Override
   public void start() {
     Integer v = dbVersion.getVersion();
-    this.initialDbVersion = (v != null ? v : -1);
+    this.initialDbVersion = v != null ? v : -1;
   }
 
   @Override

--- a/server/sonar-server/src/main/java/org/sonar/server/rule/RuleUpdate.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/rule/RuleUpdate.java
@@ -90,7 +90,7 @@ public class RuleUpdate {
    * Set to <code>null</code> or blank to remove existing note.
    */
   public RuleUpdate setMarkdownNote(@Nullable String s) {
-    this.markdownNote = (s == null ? null : StringUtils.defaultIfBlank(s, null));
+    this.markdownNote = s == null ? null : StringUtils.defaultIfBlank(s, null);
     this.changeMarkdownNote = true;
     return this;
   }
@@ -105,7 +105,7 @@ public class RuleUpdate {
    * to reset to default characteristic.
    */
   public RuleUpdate setDebtSubCharacteristic(@Nullable String c) {
-    this.debtSubCharacteristicKey = (c == null ? null : StringUtils.defaultIfBlank(c, null));
+    this.debtSubCharacteristicKey = c == null ? null : StringUtils.defaultIfBlank(c, null);
     this.changeDebtSubCharacteristic = true;
     return this;
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/ui/ViewProxy.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/ui/ViewProxy.java
@@ -86,7 +86,7 @@ public class ViewProxy<V extends View> implements Comparable<ViewProxy> {
     initWidgetGlobal(view);
     initRequiredMeasures(view);
 
-    isWidget = (view instanceof Widget);
+    isWidget = view instanceof Widget;
   }
 
   private void initRequiredMeasures(V view) {

--- a/sonar-db/src/main/java/org/sonar/db/component/ResourceIndexDao.java
+++ b/sonar-db/src/main/java/org/sonar/db/component/ResourceIndexDao.java
@@ -192,7 +192,7 @@ public class ResourceIndexDao extends AbstractDao {
       .setRootProjectId(rootId)
       .setNameSize(nameLength);
 
-    int maxPosition = (key.length() == SINGLE_INDEX_SIZE ? 0 : key.length() - MINIMUM_KEY_SIZE);
+    int maxPosition = key.length() == SINGLE_INDEX_SIZE ? 0 : key.length() - MINIMUM_KEY_SIZE;
     for (int position = 0; position <= maxPosition; position++) {
       dto.setPosition(position);
       dto.setKey(StringUtils.substring(key, position));

--- a/sonar-duplications/src/main/java/net/sourceforge/pmd/cpd/SourceCode.java
+++ b/sonar-duplications/src/main/java/net/sourceforge/pmd/cpd/SourceCode.java
@@ -144,7 +144,7 @@ public class SourceCode {
   public String getSlice(int startLine, int endLine) {
     StringBuffer sb = new StringBuffer();
     List lines = cl.getCode();
-    for (int i = (startLine == 0 ? startLine : (startLine - 1)); i < endLine && i < lines.size(); i++) {
+    for (int i = (startLine == 0 ? startLine : startLine - 1); i < endLine && i < lines.size(); i++) {
       if (sb.length() != 0) {
         sb.append(EOL);
       }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/ws/WebService.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/ws/WebService.java
@@ -633,7 +633,7 @@ public interface WebService extends Definable<WebService.Context> {
      * @since 4.4
      */
     public NewParam setExampleValue(@Nullable Object s) {
-      this.exampleValue = ((s != null) ? s.toString() : null);
+      this.exampleValue = (s != null) ? s.toString() : null;
       return this;
     }
 
@@ -676,7 +676,7 @@ public interface WebService extends Definable<WebService.Context> {
      * @since 4.4
      */
     public NewParam setDefaultValue(@Nullable Object o) {
-      this.defaultValue = ((o != null) ? o.toString() : null);
+      this.defaultValue = (o != null) ? o.toString() : null;
       return this;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck Useless parentheses around expression should be removed to prevent any misunderstanging

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck


Please let me know if you have any questions.

Zeeshan
