### PR TITLE
Members of an interface decleration or class should appear in a pre-defined order

### DIFF
--- a/sonar-batch/src/main/java/org/sonar/batch/analysis/AnalysisTempFolderProvider.java
+++ b/sonar-batch/src/main/java/org/sonar/batch/analysis/AnalysisTempFolderProvider.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 public class AnalysisTempFolderProvider extends ProviderAdapter implements ComponentLifecycle<TempFolder> {
   static final String TMP_NAME = ".sonartmp";
   private DefaultTempFolder projectTempFolder;
+  private boolean started = false;
 
   public TempFolder provide(ProjectReactor projectReactor) {
     if (projectTempFolder == null) {
@@ -54,8 +55,6 @@ public class AnalysisTempFolderProvider extends ProviderAdapter implements Compo
   public void start(PicoContainer container) {
     started = true;
   }
-
-  private boolean started = false;
 
   @Override
   public void stop(PicoContainer container) {

--- a/sonar-batch/src/main/java/org/sonar/batch/bootstrap/GlobalTempFolderProvider.java
+++ b/sonar-batch/src/main/java/org/sonar/batch/bootstrap/GlobalTempFolderProvider.java
@@ -44,7 +44,8 @@ public class GlobalTempFolderProvider extends ProviderAdapter implements Compone
   private static final Logger LOG = Loggers.get(GlobalTempFolderProvider.class);
   private static final long CLEAN_MAX_AGE = TimeUnit.DAYS.toMillis(21);
   static final String TMP_NAME_PREFIX = ".sonartmp_";
-
+  private boolean started = false;
+  
   private System2 system;
   private DefaultTempFolder tempFolder;
 
@@ -150,8 +151,6 @@ public class GlobalTempFolderProvider extends ProviderAdapter implements Compone
   public void start(PicoContainer container) {
     started = true;
   }
-
-  private boolean started = false;
 
   @Override
   public void stop(PicoContainer container) {

--- a/sonar-batch/src/main/java/org/sonar/batch/issue/tracking/RollingFileHashes.java
+++ b/sonar-batch/src/main/java/org/sonar/batch/issue/tracking/RollingFileHashes.java
@@ -25,6 +25,10 @@ package org.sonar.batch.issue.tracking;
 public class RollingFileHashes {
 
   final int[] rollingHashes;
+  
+  private RollingFileHashes(int[] hashes) {
+    this.rollingHashes = hashes;
+  }
 
   public static RollingFileHashes create(FileHashes hashes, int halfBlockSize) {
     int size = hashes.length();
@@ -51,10 +55,6 @@ public class RollingFileHashes {
 
   public int getHash(int line) {
     return rollingHashes[line - 1];
-  }
-
-  private RollingFileHashes(int[] hashes) {
-    this.rollingHashes = hashes;
   }
 
   private static class RollingHashCalculator {

--- a/sonar-batch/src/main/java/org/sonar/batch/profiling/PhasesSumUpTimeProfiler.java
+++ b/sonar-batch/src/main/java/org/sonar/batch/profiling/PhasesSumUpTimeProfiler.java
@@ -71,6 +71,15 @@ public class PhasesSumUpTimeProfiler implements ProjectAnalysisHandler, SensorEx
 
   private final System2 system;
   private final File out;
+  
+  public PhasesSumUpTimeProfiler(System2 system, GlobalProperties bootstrapProps) {
+    String workingDirPath = StringUtils.defaultIfBlank(bootstrapProps.property(CoreProperties.WORKING_DIRECTORY), CoreProperties.WORKING_DIRECTORY_DEFAULT_VALUE);
+    File workingDir = new File(workingDirPath).getAbsoluteFile();
+    this.out = new File(workingDir, "profiling");
+    this.out.mkdirs();
+    this.totalProfiling = new ModuleProfiling(null, system);
+    this.system = system;
+  }
 
   static void println(String msg) {
     LOG.info(msg);
@@ -83,15 +92,6 @@ public class PhasesSumUpTimeProfiler implements ProjectAnalysisHandler, SensorEx
       sb.append(" (").append((int) (phaseProfiling.totalTime() / percent)).append("%)");
     }
     println(sb.toString());
-  }
-
-  public PhasesSumUpTimeProfiler(System2 system, GlobalProperties bootstrapProps) {
-    String workingDirPath = StringUtils.defaultIfBlank(bootstrapProps.property(CoreProperties.WORKING_DIRECTORY), CoreProperties.WORKING_DIRECTORY_DEFAULT_VALUE);
-    File workingDir = new File(workingDirPath).getAbsoluteFile();
-    this.out = new File(workingDir, "profiling");
-    this.out.mkdirs();
-    this.totalProfiling = new ModuleProfiling(null, system);
-    this.system = system;
   }
 
   @Override

--- a/sonar-batch/src/main/java/org/sonar/batch/rule/RuleFinderCompatibility.java
+++ b/sonar-batch/src/main/java/org/sonar/batch/rule/RuleFinderCompatibility.java
@@ -46,6 +46,12 @@ import java.util.Collections;
 public class RuleFinderCompatibility implements RuleFinder {
 
   private final Rules rules;
+  private static Function<org.sonar.api.batch.rule.Rule, Rule> ruleTransformer = new Function<org.sonar.api.batch.rule.Rule, Rule>() {
+    @Override
+    public Rule apply(@Nonnull org.sonar.api.batch.rule.Rule input) {
+      return toRule(input);
+    }
+  };
 
   public RuleFinderCompatibility(Rules rules) {
     this.rules = rules;
@@ -98,12 +104,7 @@ public class RuleFinderCompatibility implements RuleFinder {
     return Collections2.transform(rules.findByRepository(query.getRepositoryKey()), ruleTransformer);
   }
 
-  private static Function<org.sonar.api.batch.rule.Rule, Rule> ruleTransformer = new Function<org.sonar.api.batch.rule.Rule, Rule>() {
-    @Override
-    public Rule apply(@Nonnull org.sonar.api.batch.rule.Rule input) {
-      return toRule(input);
-    }
-  };
+  
 
   private Collection<Rule> byKey(RuleQuery query) {
     Rule rule = toRule(rules.find(RuleKey.of(query.getRepositoryKey(), query.getKey())));

--- a/sonar-batch/src/main/java/org/sonar/batch/sensor/coverage/CoverageConstants.java
+++ b/sonar-batch/src/main/java/org/sonar/batch/sensor/coverage/CoverageConstants.java
@@ -27,9 +27,6 @@ import java.util.Collection;
 
 public class CoverageConstants {
 
-  private CoverageConstants() {
-  }
-
   public static final Collection<Metric> COVERAGE_METRICS = ImmutableList.<Metric>of(CoreMetrics.LINES_TO_COVER, CoreMetrics.UNCOVERED_LINES, CoreMetrics.NEW_LINES_TO_COVER,
     CoreMetrics.NEW_UNCOVERED_LINES, CoreMetrics.CONDITIONS_TO_COVER, CoreMetrics.UNCOVERED_CONDITIONS,
     CoreMetrics.NEW_CONDITIONS_TO_COVER, CoreMetrics.NEW_UNCOVERED_CONDITIONS);
@@ -39,4 +36,7 @@ public class CoverageConstants {
 
   public static final Collection<Metric> BRANCH_COVERAGE_METRICS = ImmutableList.<Metric>of(CoreMetrics.UNCOVERED_CONDITIONS, CoreMetrics.CONDITIONS_TO_COVER,
     CoreMetrics.NEW_UNCOVERED_CONDITIONS, CoreMetrics.NEW_CONDITIONS_TO_COVER);
+  
+  private CoverageConstants() {
+  }
 }

--- a/sonar-colorizer/src/main/java/org/sonar/colorizer/InlineDocTokenizer.java
+++ b/sonar-colorizer/src/main/java/org/sonar/colorizer/InlineDocTokenizer.java
@@ -34,6 +34,12 @@ public abstract class InlineDocTokenizer extends Tokenizer {
   private final String tagAfter;
 
   private final char[] startToken;
+  private static final EndMatcher LINE_END_MATCHER = new EndMatcher() {
+    @Override
+    public boolean match(int endFlag) {
+      return endFlag == '\r' || endFlag == '\n';
+    }
+  };
 
   public InlineDocTokenizer(String startToken, String tagBefore, String tagAfter) {
     this.tagBefore = tagBefore;
@@ -52,12 +58,5 @@ public abstract class InlineDocTokenizer extends Tokenizer {
       return false;
     }
   }
-
-  private static final EndMatcher LINE_END_MATCHER = new EndMatcher() {
-    @Override
-    public boolean match(int endFlag) {
-      return endFlag == '\r' || endFlag == '\n';
-    }
-  };
 
 }

--- a/sonar-colorizer/src/main/java/org/sonar/colorizer/JavaAnnotationTokenizer.java
+++ b/sonar-colorizer/src/main/java/org/sonar/colorizer/JavaAnnotationTokenizer.java
@@ -30,18 +30,17 @@ public class JavaAnnotationTokenizer extends Tokenizer {
 
   private final String tagBefore;
   private final String tagAfter;
-
-  public JavaAnnotationTokenizer(String tagBefore, String tagAfter) {
-    this.tagBefore = tagBefore;
-    this.tagAfter = tagAfter;
-  }
-
   private static final EndMatcher END_TOKEN_MATCHER = new EndMatcher() {
     @Override
     public boolean match(int endFlag) {
       return !Character.isJavaIdentifierPart(endFlag);
     }
   };
+
+  public JavaAnnotationTokenizer(String tagBefore, String tagAfter) {
+    this.tagBefore = tagBefore;
+    this.tagAfter = tagAfter;
+  }
 
   @Override
   public boolean consume(CodeReader code, HtmlCodeBuilder codeBuilder) {

--- a/sonar-colorizer/src/main/java/org/sonar/colorizer/JavaConstantTokenizer.java
+++ b/sonar-colorizer/src/main/java/org/sonar/colorizer/JavaConstantTokenizer.java
@@ -31,6 +31,13 @@ public class JavaConstantTokenizer extends Tokenizer {
   private final String tagBefore;
   private final String tagAfter;
   private static final int DOT = '.';
+  private EndMatcher endTokenMatcher = new EndMatcher() {
+
+    @Override
+    public boolean match(int endFlag) {
+      return !isJavaConstantPart(endFlag);
+    }
+  };
 
   public JavaConstantTokenizer(String tagBefore, String tagAfter) {
     this.tagBefore = tagBefore;
@@ -70,13 +77,5 @@ public class JavaConstantTokenizer extends Tokenizer {
   private boolean isJavaConstantPart(int character) {
     return Character.isUpperCase(character) || character == '_' || character == '-' || Character.isDigit(character);
   }
-
-  private EndMatcher endTokenMatcher = new EndMatcher() {
-
-    @Override
-    public boolean match(int endFlag) {
-      return !isJavaConstantPart(endFlag);
-    }
-  };
 
 }

--- a/sonar-core/src/main/java/org/sonar/core/util/CloseableIterator.java
+++ b/sonar-core/src/main/java/org/sonar/core/util/CloseableIterator.java
@@ -31,6 +31,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public abstract class CloseableIterator<O> implements Iterator<O>, AutoCloseable {
+  private O nextObject = null;
+  boolean isClosed = false;
   private static final CloseableIterator<?> EMPTY_CLOSEABLE_ITERATOR = new CloseableIterator<Object>() {
     @Override
     public boolean hasNext() {
@@ -75,9 +77,6 @@ public abstract class CloseableIterator<O> implements Iterator<O>, AutoCloseable
   public static <T> CloseableIterator<T> wrap(CloseableIterator<T> iterator, AutoCloseable... otherCloseables) {
     return new CloseablesIteratorWrapper<>(iterator, otherCloseables);
   }
-
-  private O nextObject = null;
-  boolean isClosed = false;
 
   @Override
   public boolean hasNext() {

--- a/sonar-db/src/main/java/org/sonar/db/ce/CeTaskTypes.java
+++ b/sonar-db/src/main/java/org/sonar/db/ce/CeTaskTypes.java
@@ -20,11 +20,11 @@
 package org.sonar.db.ce;
 
 public final class CeTaskTypes {
+  
+  public static final String REPORT = "REPORT";
 
   private CeTaskTypes() {
     // only statics
   }
-
-  public static final String REPORT = "REPORT";
 
 }

--- a/sonar-db/src/main/java/org/sonar/db/dialect/DialectUtils.java
+++ b/sonar-db/src/main/java/org/sonar/db/dialect/DialectUtils.java
@@ -29,12 +29,12 @@ import org.sonar.api.utils.MessageException;
 
 public final class DialectUtils {
 
+  private static final Dialect[] DIALECTS = new Dialect[] {new H2(), new MySql(), new Oracle(), new PostgreSql(), new MsSql()};
+
   private DialectUtils() {
     // only static stuff
   }
-
-  private static final Dialect[] DIALECTS = new Dialect[] {new H2(), new MySql(), new Oracle(), new PostgreSql(), new MsSql()};
-
+  
   public static Dialect find(final String dialectId, final String jdbcConnectionUrl) {
     Dialect match = StringUtils.isNotBlank(dialectId) ? findById(dialectId) : findByJdbcUrl(jdbcConnectionUrl);
     if (match == null) {

--- a/sonar-db/src/main/java/org/sonar/db/qualityprofile/ActiveRuleDto.java
+++ b/sonar-db/src/main/java/org/sonar/db/qualityprofile/ActiveRuleDto.java
@@ -45,6 +45,8 @@ public class ActiveRuleDto extends Dto<ActiveRuleKey> {
   private Integer ruleId;
   private Integer severity;
   private String inheritance;
+  //This field do not exists in db, it's only retrieve by joins
+  private Integer parentId;
 
   /**
    * @deprecated for internal use, should be private
@@ -61,9 +63,6 @@ public class ActiveRuleDto extends Dto<ActiveRuleKey> {
   public ActiveRuleKey getKey() {
     return ActiveRuleKey.of(profileKey, RuleKey.of(repository, ruleField));
   }
-
-  // This field do not exists in db, it's only retrieve by joins
-  private Integer parentId;
 
   public Integer getId() {
     return id;

--- a/sonar-db/src/main/java/org/sonar/db/version/v50/FeedFileSources.java
+++ b/sonar-db/src/main/java/org/sonar/db/version/v50/FeedFileSources.java
@@ -39,6 +39,7 @@ import org.sonar.db.version.SqlStatement;
  */
 public class FeedFileSources extends BaseDataChange {
 
+  private final System2 system;
   private static final String SELECT_FILES_AND_MEASURES_SQL = "SELECT " +
     "p.uuid, " +
     "f.uuid, " +
@@ -138,6 +139,11 @@ public class FeedFileSources extends BaseDataChange {
     "AND p.scope = 'PRJ' AND p.qualifier = 'TRK' " +
     "AND fs.file_uuid IS NULL";
 
+  public FeedFileSources(Database db, System2 system) {
+    super(db);
+    this.system = system;
+  }
+  
   private static final class FileSourceBuilder implements MassUpdate.Handler {
     private final long now;
 
@@ -218,13 +224,6 @@ public class FeedFileSources extends BaseDataChange {
       result = shortBytes;
     }
     return new String(result, StandardCharsets.UTF_8);
-  }
-
-  private final System2 system;
-
-  public FeedFileSources(Database db, System2 system) {
-    super(db);
-    this.system = system;
   }
 
   @Override

--- a/sonar-duplications/src/main/java/org/sonar/duplications/detector/suffixtree/Search.java
+++ b/sonar-duplications/src/main/java/org/sonar/duplications/detector/suffixtree/Search.java
@@ -35,15 +35,22 @@ public final class Search {
 
   private final List<Integer> list = new ArrayList<>();
   private final List<Node> innerNodes = new ArrayList<>();
-
-  public static void perform(TextSet text, Collector reporter) {
-    new Search(SuffixTree.create(text), text, reporter).compute();
-  }
+  
+  private static final Comparator<Node> DEPTH_COMPARATOR = new Comparator<Node>() {
+    @Override
+    public int compare(Node o1, Node o2) {
+      return o2.depth - o1.depth;
+    }
+  };
 
   private Search(SuffixTree tree, TextSet text, Collector reporter) {
     this.tree = tree;
     this.text = text;
     this.reporter = reporter;
+  }
+  
+  public static void perform(TextSet text, Collector reporter) {
+    new Search(SuffixTree.create(text), text, reporter).compute();
   }
 
   private void compute() {
@@ -56,13 +63,6 @@ public final class Search {
     // O(N)
     visitInnerNodes();
   }
-
-  private static final Comparator<Node> DEPTH_COMPARATOR = new Comparator<Node>() {
-    @Override
-    public int compare(Node o1, Node o2) {
-      return o2.depth - o1.depth;
-    }
-  };
 
   /**
    * Depth-first search (DFS).

--- a/sonar-duplications/src/main/java/org/sonar/duplications/detector/suffixtree/SuffixTree.java
+++ b/sonar-duplications/src/main/java/org/sonar/duplications/detector/suffixtree/SuffixTree.java
@@ -46,7 +46,12 @@ public final class SuffixTree {
   final Text text;
 
   private final Node root;
-
+  
+  private SuffixTree(Text text) {
+    this.text = text;
+    root = new Node(this, null);
+  }
+  
   public static SuffixTree create(Text text) {
     SuffixTree tree = new SuffixTree(text);
     Suffix active = new Suffix(tree.root, 0, -1);
@@ -54,11 +59,6 @@ public final class SuffixTree {
       tree.addPrefix(active, i);
     }
     return tree;
-  }
-
-  private SuffixTree(Text text) {
-    this.text = text;
-    root = new Node(this, null);
   }
 
   private void addPrefix(Suffix active, int endIndex) {

--- a/sonar-duplications/src/main/java/org/sonar/duplications/detector/suffixtree/SuffixTreeCloneDetectionAlgorithm.java
+++ b/sonar-duplications/src/main/java/org/sonar/duplications/detector/suffixtree/SuffixTreeCloneDetectionAlgorithm.java
@@ -34,7 +34,17 @@ import org.sonar.duplications.index.CloneGroup;
 import org.sonar.duplications.index.CloneIndex;
 
 public final class SuffixTreeCloneDetectionAlgorithm {
-
+  
+  private SuffixTreeCloneDetectionAlgorithm() {
+  }
+  
+  private static final Comparator<Block> BLOCK_COMPARATOR = new Comparator<Block>() {
+    @Override
+    public int compare(Block o1, Block o2) {
+      return o1.getIndexInFile() - o2.getIndexInFile();
+    }
+  };
+  
   public static List<CloneGroup> detect(CloneIndex cloneIndex, Collection<Block> fileBlocks) {
     if (fileBlocks.isEmpty()) {
       return Collections.emptyList();
@@ -46,9 +56,6 @@ public final class SuffixTreeCloneDetectionAlgorithm {
     DuplicationsCollector reporter = new DuplicationsCollector(text);
     Search.perform(text, reporter);
     return reporter.getResult();
-  }
-
-  private SuffixTreeCloneDetectionAlgorithm() {
   }
 
   private static TextSet createTextSet(CloneIndex index, Collection<Block> fileBlocks) {
@@ -111,12 +118,5 @@ public final class SuffixTreeCloneDetectionAlgorithm {
     }
     return collection;
   }
-
-  private static final Comparator<Block> BLOCK_COMPARATOR = new Comparator<Block>() {
-    @Override
-    public int compare(Block o1, Block o2) {
-      return o1.getIndexInFile() - o2.getIndexInFile();
-    }
-  };
 
 }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/web/ServletFilter.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/web/ServletFilter.java
@@ -45,10 +45,6 @@ public abstract class ServletFilter implements Filter {
     private String url;
     private String urlToMatch;
 
-    public static UrlPattern create(String pattern) {
-      return new UrlPattern(pattern);
-    }
-
     private UrlPattern(String url) {
       Preconditions.checkArgument(!Strings.isNullOrEmpty(url), "Empty url");
       this.url = url;
@@ -62,6 +58,10 @@ public abstract class ServletFilter implements Filter {
       } else {
         code = 4;
       }
+    }
+    
+    public static UrlPattern create(String pattern) {
+      return new UrlPattern(pattern);
     }
 
     public boolean matches(String path) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 members of an interface decleration or class should appear in a pre-defined order

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

Zeeshan