### PR TITLE
Static members should be accessed statically

### DIFF
--- a/sonar-core/src/main/java/org/sonar/core/util/DefaultHttpDownloader.java
+++ b/sonar-core/src/main/java/org/sonar/core/util/DefaultHttpDownloader.java
@@ -133,7 +133,7 @@ public class DefaultHttpDownloader extends HttpDownloader {
   }
 
   public String getProxySynthesis(URI uri) {
-    return downloader.getProxySynthesis(uri);
+    return BaseHttpDownloader.getProxySynthesis(uri);
   }
 
   @Override

--- a/sonar-db/src/main/java/org/sonar/db/component/ResourceDao.java
+++ b/sonar-db/src/main/java/org/sonar/db/component/ResourceDao.java
@@ -51,7 +51,7 @@ public class ResourceDao extends AbstractDao {
     try {
       return selectResource(query, session);
     } finally {
-      myBatis().closeQuietly(session);
+      MyBatis.closeQuietly(session);
     }
   }
 
@@ -74,7 +74,7 @@ public class ResourceDao extends AbstractDao {
     try {
       return session.getMapper(ResourceMapper.class).selectResourceByUuid(componentUuid);
     } finally {
-      myBatis().closeQuietly(session);
+      MyBatis.closeQuietly(session);
     }
   }
 
@@ -139,7 +139,7 @@ public class ResourceDao extends AbstractDao {
     try {
       return getRootProjectByComponentKey(session, componentKey);
     } finally {
-      myBatis().closeQuietly(session);
+      MyBatis.closeQuietly(session);
     }
   }
 
@@ -165,7 +165,7 @@ public class ResourceDao extends AbstractDao {
     try {
       return toComponents(session.getMapper(ResourceMapper.class).selectProjectsByQualifiers(qualifiers));
     } finally {
-      myBatis().closeQuietly(session);
+      MyBatis.closeQuietly(session);
     }
   }
 
@@ -180,7 +180,7 @@ public class ResourceDao extends AbstractDao {
     try {
       return toComponents(session.getMapper(ResourceMapper.class).selectProjectsIncludingNotCompletedOnesByQualifiers(qualifiers));
     } finally {
-      myBatis().closeQuietly(session);
+      MyBatis.closeQuietly(session);
     }
   }
 
@@ -198,7 +198,7 @@ public class ResourceDao extends AbstractDao {
     try {
       return toComponents(session.getMapper(ResourceMapper.class).selectGhostsProjects(qualifiers));
     } finally {
-      myBatis().closeQuietly(session);
+      MyBatis.closeQuietly(session);
     }
   }
 
@@ -213,7 +213,7 @@ public class ResourceDao extends AbstractDao {
     try {
       return session.getMapper(ResourceMapper.class).selectProvisionedProjects(qualifiers);
     } finally {
-      myBatis().closeQuietly(session);
+      MyBatis.closeQuietly(session);
     }
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2209 static members should be accessed statically

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2209


Please let me know if you have any questions.

Zeeshan