### PR TITLE
SONAR-7183 faster ce submit

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/computation/monitoring/CEQueueStatus.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/monitoring/CEQueueStatus.java
@@ -35,6 +35,10 @@ public interface CEQueueStatus {
 
   /**
    * Adds 1 to the count of received batch reports and 1 to the count of batch reports waiting for processing.
+   * <p>
+   * Calling this method is equivalent to calling {@link #addReceived(long)} with {@code 1} as argument but will
+   * trigger no parameter check. So, it can be faster.
+   * </p>
    *
    * @return the new count of received batch reports
    *
@@ -44,6 +48,20 @@ public interface CEQueueStatus {
    * @throws IllegalStateException if {@link #initPendingCount(long)} has not been called yet
    */
   long addReceived();
+
+  /**
+   * Adds {@code numberOfReceived} to the count of received batch reports and {@code numberOfReceived} to the count of
+   * batch reports waiting for processing.
+   *
+   * @return the new count of received batch reports
+   *
+   * @see #getReceivedCount()
+   * @see #getPendingCount()
+   *
+   * @throws IllegalStateException if {@link #initPendingCount(long)} has not been called yet
+   * @throws IllegalArgumentException if {@code numberOfReceived} is less or equal to 0
+   */
+  long addReceived(long numberOfReceived);
 
   /**
    * Adds 1 to the count of batch reports under processing and removes 1 from the count of batch reports waiting for

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/monitoring/CEQueueStatusImpl.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/monitoring/CEQueueStatusImpl.java
@@ -52,6 +52,15 @@ public class CEQueueStatusImpl implements CEQueueStatus {
   }
 
   @Override
+  public long addReceived(long numberOfReceived) {
+    ensurePendingInitialized("addReceived");
+    checkArgument(numberOfReceived > 0, "numberOfReceived must be > 0");
+
+    pending.addAndGet(numberOfReceived);
+    return received.addAndGet(numberOfReceived);
+  }
+
+  @Override
   public long addInProgress() {
     ensurePendingInitialized("addInProgress");
 

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/queue/CeQueue.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/queue/CeQueue.java
@@ -20,6 +20,8 @@
 package org.sonar.server.computation.queue;
 
 import com.google.common.base.Optional;
+import java.util.Collection;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.sonar.db.ce.CeActivityDto;
 
@@ -40,10 +42,23 @@ public interface CeQueue {
 
   /**
    * Submits a task to the queue. The task is processed asynchronously.
-   * If submits are paused (see {@link #isSubmitPaused()}, then an
-   * unchecked exception is thrown.
+   * <p>
+   * This method is equivalent to calling {@code massSubmit(Collections.singletonList(submission))}.
+   * </p>
+   *
+   * @throws IllegalStateException If submits are paused (see {@link #isSubmitPaused()})
    */
   CeTask submit(CeTaskSubmit submission);
+
+  /**
+   * Submits multiple tasks to the queue at once. All tasks are processed asynchronously.
+   * <p>
+   * This method will perform significantly better that calling {@link #submit(CeTaskSubmit)} in a loop.
+   * </p>
+   *
+   * @throws IllegalStateException If submits are paused (see {@link #isSubmitPaused()})
+   */
+  List<CeTask> massSubmit(Collection<CeTaskSubmit> submissions);
 
   /**
    * Peek the oldest task in status {@link org.sonar.db.ce.CeQueueDto.Status#PENDING}.

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/monitoring/CEQueueStatusImplTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/monitoring/CEQueueStatusImplTest.java
@@ -71,7 +71,7 @@ public class CEQueueStatusImplTest {
   }
 
   @Test
-  public void addReceived_sets_received_and_pending_counts_to_1_when_initPendingCount_has_not_been_called() {
+  public void addReceived_sets_received_to_1_and_pending_counts_to_initial_value_plus_1() {
     underTest.initPendingCount(INITIAL_PENDING_COUNT);
 
     underTest.addReceived();
@@ -91,6 +91,55 @@ public class CEQueueStatusImplTest {
 
     assertThat(underTest.getReceivedCount()).isEqualTo(calls);
     assertThat(underTest.getPendingCount()).isEqualTo(INITIAL_PENDING_COUNT + calls);
+  }
+
+  @Test
+  public void addReceived_with_argument_throws_IAE_if_parameter_is_0() {
+    underTest.initPendingCount(INITIAL_PENDING_COUNT);
+
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("numberOfReceived must be > 0");
+
+    underTest.addReceived(0);
+  }
+
+  @Test
+  public void addReceived_with_argument_throws_IAE_if_parameter_less_than_0() {
+    underTest.initPendingCount(INITIAL_PENDING_COUNT);
+
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("numberOfReceived must be > 0");
+
+    underTest.addReceived(-1 * (new Random().nextInt(SOME_RANDOM_MAX)));
+  }
+
+  @Test
+  public void addReceived_with_argument_sets_received_to_value_and_pending_counts_to_initial_value_plus_value() {
+    long value = 123;
+    underTest.initPendingCount(INITIAL_PENDING_COUNT);
+
+    underTest.addReceived(value);
+
+    assertThat(underTest.getReceivedCount()).isEqualTo(value);
+    assertThat(underTest.getPendingCount()).isEqualTo(INITIAL_PENDING_COUNT + value);
+  }
+
+  @Test
+  public void addReceived_with_argument_any_number_of_call_adds_some_number_per_call() {
+    underTest.initPendingCount(INITIAL_PENDING_COUNT);
+
+    Random random = new Random();
+    int calls = random.nextInt(SOME_RANDOM_MAX);
+    long added = 0;
+    for (int i = 0; i < calls; i++) {
+      // adding 1 to random number because value can not be 0
+      long numberOfReceived = random.nextInt(SOME_RANDOM_MAX) + 1;
+      underTest.addReceived(numberOfReceived);
+      added += numberOfReceived;
+    }
+
+    assertThat(underTest.getReceivedCount()).isEqualTo(added);
+    assertThat(underTest.getPendingCount()).isEqualTo(INITIAL_PENDING_COUNT + added);
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/monitoring/ComputeEngineQueueMonitorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/monitoring/ComputeEngineQueueMonitorTest.java
@@ -73,8 +73,9 @@ public class ComputeEngineQueueMonitorTest {
       return methodNotImplemented();
     }
 
-    private long methodNotImplemented() {
-      throw new UnsupportedOperationException("Not Implemented");
+    @Override
+    public long addReceived(long numberOfReceived) {
+      return methodNotImplemented();
     }
 
     @Override
@@ -125,6 +126,10 @@ public class ComputeEngineQueueMonitorTest {
     @Override
     public long getProcessingTime() {
       return PROCESSING_TIME;
+    }
+
+    private long methodNotImplemented() {
+      throw new UnsupportedOperationException("Not Implemented");
     }
   }
 }


### PR DESCRIPTION
allow possibility to batch insert tasks into the CeQueue:
* using a single transaction for inserting all tasks
* using a single request to retrieve all components referenced by the inserted tasks rather than one per task