### PR TITLE
SONAR-7226 L10n plugins can't be up-to-date with SonarQube 5.2+

### DIFF
--- a/server/sonar-dev-cockpit-bridge/pom.xml
+++ b/server/sonar-dev-cockpit-bridge/pom.xml
@@ -38,21 +38,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
-
 </project>

--- a/server/sonar-process-monitor/pom.xml
+++ b/server/sonar-process-monitor/pom.xml
@@ -79,21 +79,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
 </project>

--- a/server/sonar-process/pom.xml
+++ b/server/sonar-process/pom.xml
@@ -96,21 +96,4 @@
 
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
 </project>

--- a/server/sonar-search/pom.xml
+++ b/server/sonar-search/pom.xml
@@ -68,20 +68,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
 </project>

--- a/server/sonar-server-benchmarks/pom.xml
+++ b/server/sonar-server-benchmarks/pom.xml
@@ -14,6 +14,8 @@
     <sonar.skip>true</sonar.skip>
     <skipBenchmarks>true</skipBenchmarks>
     <enableBenchmarkAssertions>false</enableBenchmarkAssertions>
+    <maven.install.skip>true</maven.install.skip>
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
   <dependencies>
@@ -97,19 +99,6 @@
         <enableBenchmarkAssertions>true</enableBenchmarkAssertions>
         <skipBenchmarks>false</skipBenchmarks>
       </properties>
-    </profile>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>

--- a/server/sonar-server/pom.xml
+++ b/server/sonar-server/pom.xml
@@ -338,20 +338,6 @@
         </dependency>
       </dependencies>
     </profile>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
   </profiles>
 
 

--- a/server/sonar-views-bridge/pom.xml
+++ b/server/sonar-views-bridge/pom.xml
@@ -38,21 +38,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
-
 </project>

--- a/server/sonar-web/pom.xml
+++ b/server/sonar-web/pom.xml
@@ -221,12 +221,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
         </plugins>
       </build>
       <dependencies>

--- a/sonar-application/pom.xml
+++ b/sonar-application/pom.xml
@@ -243,16 +243,9 @@
   <profiles>
     <profile>
       <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
+      <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+      </properties>
     </profile>
     <profile>
       <id>dev</id>

--- a/sonar-batch-protocol/pom.xml
+++ b/sonar-batch-protocol/pom.xml
@@ -108,20 +108,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/sonar-batch-shaded/pom.xml
+++ b/sonar-batch-shaded/pom.xml
@@ -62,20 +62,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>  
 </project>

--- a/sonar-batch/pom.xml
+++ b/sonar-batch/pom.xml
@@ -186,18 +186,5 @@
         <enableBenchmarkAssertions>true</enableBenchmarkAssertions>
       </properties>
     </profile>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/sonar-core/pom.xml
+++ b/sonar-core/pom.xml
@@ -124,20 +124,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/sonar-db/pom.xml
+++ b/sonar-db/pom.xml
@@ -175,18 +175,5 @@
         </dependency>
       </dependencies>
     </profile>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/sonar-plugin-api-deps/pom.xml
+++ b/sonar-plugin-api-deps/pom.xml
@@ -164,20 +164,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
All artifacts should be deployed to central, except SQ zip