### PR TITLE
remove dependency on sonar-channel and switch to sslr

### DIFF
--- a/sonar-markdown/pom.xml
+++ b/sonar-markdown/pom.xml
@@ -14,10 +14,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.codehaus.sonar</groupId>
-      <artifactId>sonar-channel</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
@@ -35,6 +31,11 @@
       <artifactId>sonar-testing-harness</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+		<groupId>org.sonarsource.sslr</groupId>
+		<artifactId>sslr-core</artifactId>
+		<version>1.21</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -48,4 +49,13 @@
       </plugin>
     </plugins>
   </build>
+  <dependencyManagement>
+	<dependencies>
+		<dependency>
+		<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>10.0.1</version>
+		</dependency>
+	</dependencies>
+	</dependencyManagement>
 </project>

--- a/sonar-markdown/src/main/java/org/sonar/markdown/BlackholeChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/BlackholeChannel.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.markdown;
 
-import org.sonar.channel.Channel;
-import org.sonar.channel.CodeReader;
+import org.sonar.sslr.channel.Channel;
+import org.sonar.sslr.channel.CodeReader;
 
 class BlackholeChannel extends Channel<MarkdownOutput> {
 

--- a/sonar-markdown/src/main/java/org/sonar/markdown/HtmlBlockquoteChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/HtmlBlockquoteChannel.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.markdown;
 
-import org.sonar.channel.Channel;
-import org.sonar.channel.CodeReader;
-import org.sonar.channel.RegexChannel;
+import org.sonar.sslr.channel.Channel;
+import org.sonar.sslr.channel.CodeReader;
+import org.sonar.sslr.channel.RegexChannel;
 
 /**
  * Markdown treats lines starting with a greater than sign (&gt;) as a block of quoted text.

--- a/sonar-markdown/src/main/java/org/sonar/markdown/HtmlCodeChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/HtmlCodeChannel.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.markdown;
 
-import org.sonar.channel.RegexChannel;
+import org.sonar.sslr.channel.RegexChannel;
 
 /**
  * Markdown treats double backtick quote (``) as indicators of code. Text wrapped with two `` will be wrapped with an HTML {@literal <code>} tag.

--- a/sonar-markdown/src/main/java/org/sonar/markdown/HtmlEmphasisChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/HtmlEmphasisChannel.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.markdown;
 
-import org.sonar.channel.RegexChannel;
+import org.sonar.sslr.channel.RegexChannel;
 
 /**
  * Markdown treats asterisks (*) as indicators of emphasis. Text wrapped with one * will be wrapped with an HTML {@literal <em>} tag.

--- a/sonar-markdown/src/main/java/org/sonar/markdown/HtmlEndOfLineChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/HtmlEndOfLineChannel.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.markdown;
 
-import org.sonar.channel.RegexChannel;
+import org.sonar.sslr.channel.RegexChannel;
 
 /**
  * Markdown replace any line return by an HTML {@literal <br/>}

--- a/sonar-markdown/src/main/java/org/sonar/markdown/HtmlHeadingChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/HtmlHeadingChannel.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.markdown;
 
-import org.sonar.channel.RegexChannel;
+import org.sonar.sslr.channel.RegexChannel;
 
 /**
  * Headings are triggered by equal signs at the beginning of a line. The depth of the heading is determined by the number

--- a/sonar-markdown/src/main/java/org/sonar/markdown/HtmlLinkChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/HtmlLinkChannel.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.markdown;
 
-import org.sonar.channel.RegexChannel;
+import org.sonar.sslr.channel.RegexChannel;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/sonar-markdown/src/main/java/org/sonar/markdown/HtmlListChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/HtmlListChannel.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.markdown;
 
-import org.sonar.channel.Channel;
-import org.sonar.channel.CodeReader;
-import org.sonar.channel.RegexChannel;
+import org.sonar.sslr.channel.Channel;
+import org.sonar.sslr.channel.CodeReader;
+import org.sonar.sslr.channel.RegexChannel;
 
 /**
  * Lists come in two flavors:

--- a/sonar-markdown/src/main/java/org/sonar/markdown/HtmlMultilineCodeChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/HtmlMultilineCodeChannel.java
@@ -22,7 +22,7 @@ package org.sonar.markdown;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.sonar.channel.RegexChannel;
+import org.sonar.sslr.channel.RegexChannel;
 
 /**
  * Markdown treats double backtick quote (``) as indicators of code. Text wrapped with two `` and that spans on multiple lines will be wrapped with 

--- a/sonar-markdown/src/main/java/org/sonar/markdown/HtmlUrlChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/HtmlUrlChannel.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.markdown;
 
-import org.sonar.channel.RegexChannel;
+import org.sonar.sslr.channel.RegexChannel;
 
 /**
  * Markdown will wrap any URL with an HTML {@literal <a href="URL">} tag.

--- a/sonar-markdown/src/main/java/org/sonar/markdown/IdentifierAndNumberChannel.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/IdentifierAndNumberChannel.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.markdown;
 
-import org.sonar.channel.RegexChannel;
+import org.sonar.sslr.channel.RegexChannel;
 
 /**
  * Channel used only to improve performances of the Markdown engine by consuming any sequence of letter or digit.

--- a/sonar-markdown/src/main/java/org/sonar/markdown/Markdown.java
+++ b/sonar-markdown/src/main/java/org/sonar/markdown/Markdown.java
@@ -20,8 +20,8 @@
 package org.sonar.markdown;
 
 import org.apache.commons.lang.StringEscapeUtils;
-import org.sonar.channel.ChannelDispatcher;
-import org.sonar.channel.CodeReader;
+import org.sonar.sslr.channel.ChannelDispatcher;
+import org.sonar.sslr.channel.CodeReader;
 
 /**
  * Entry point of the Markdown library
@@ -54,6 +54,6 @@ public final class Markdown {
   }
 
   public static String convertToHtml(String input) {
-    return new Markdown().convert(StringEscapeUtils.escapeHtml(input));
+  	return new Markdown().convert(StringEscapeUtils.escapeHtml(input));
   }
 }


### PR DESCRIPTION
I noticed sonar-markdown makes use of sonar-channel whereas most other pieces of the project have switched to sslr. It also seems that a difference in guava version stands in the way. This is a possible way to move to sslr.