### PR TITLE
SONAR-7267 Do not accept multiple rules with the same key in a repository

### DIFF
--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinition.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinition.java
@@ -20,6 +20,7 @@
 package org.sonar.api.server.rule;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -46,7 +47,6 @@ import org.sonar.api.server.ServerSide;
 import org.sonar.api.server.debt.DebtRemediationFunction;
 import org.sonar.api.utils.log.Loggers;
 
-import static com.google.common.base.Objects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
@@ -488,14 +488,13 @@ public interface RulesDefinition {
       return this;
     }
 
+    /**
+     * The specified rule key must be unique among the repository. Since version 5.5 it raises
+     * a {@link IllegalArgumentException}, whereas it logs a warning in previous versions.
+     */
     @Override
     public NewRule createRule(String ruleKey) {
-      if (newRules.containsKey(ruleKey)) {
-        // Should fail in a perfect world, but at the time being the Findbugs plugin
-        // defines several times the rule EC_INCOMPATIBLE_ARRAY_COMPARE
-        // See http://jira.sonarsource.com/browse/SONARJAVA-428
-        Loggers.get(getClass()).warn(format("The rule '%s' of repository '%s' is declared several times", ruleKey, key));
-      }
+      Preconditions.checkArgument(!newRules.containsKey(ruleKey), "The rule '%s' of repository '%s' is declared several times", ruleKey, key);
       NewRule newRule = new NewRule(key, ruleKey);
       newRules.put(ruleKey, newRule);
       return newRule;

--- a/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/RulesDefinitionTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/server/rule/RulesDefinitionTest.java
@@ -22,11 +22,11 @@ package org.sonar.api.server.rule;
 import java.net.URL;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.sonar.api.rule.RuleStatus;
 import org.sonar.api.rule.Severity;
 import org.sonar.api.server.debt.DebtRemediationFunction;
 import org.sonar.api.utils.log.LogTester;
-import org.sonar.api.utils.log.LoggerLevel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -37,6 +37,9 @@ public class RulesDefinitionTest {
 
   @Rule
   public LogTester logTester = new LogTester();
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void define_repositories() {
@@ -257,13 +260,12 @@ public class RulesDefinitionTest {
   }
 
   @Test
-  public void warning_if_duplicated_rule_keys() {
+  public void fail_if_duplicated_rule_keys_in_the_same_repository() {
+    expectedException.expect(IllegalArgumentException.class);
+
     RulesDefinition.NewRepository findbugs = context.createRepository("findbugs", "java");
     findbugs.createRule("NPE");
     findbugs.createRule("NPE");
-    // do not fail as long as http://jira.sonarsource.com/browse/SONARJAVA-428 is not fixed
-    // and as common-rules are packaged within plugins (common-rules were integrated to core in v5.2)
-    assertThat(logTester.logs(LoggerLevel.WARN)).hasSize(1);
   }
 
   @Test


### PR DESCRIPTION
SONAR-7267 Do not accept multiple rules with the same key in a repository