### PR TITLE
Add missing Javadoc

### DIFF
--- a/sonar-plugin-api/src/main/java/org/sonar/api/source/Symbolizable.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/source/Symbolizable.java
@@ -48,6 +48,8 @@ public interface Symbolizable extends Perspective {
     /**
      * Creates a new reference for a symbol.
      * The offsets are global in the file.
+     *
+     * @since 5.3
      */
     void newReference(Symbol symbol, int fromOffset, int toOffset);
 


### PR DESCRIPTION
Method was added in SQ 5.3 as part of SONAR-5894.