### PR TITLE
SONAR-7430 Wrong remote IP in access.log when server is behind a reverse proxy

### DIFF
--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -287,10 +287,13 @@
 # sonar.log (see sonar.log.rollingPolicy and sonar.log.maxFiles).
 #sonar.web.accessLogs.enable=true
 
-# Format of access log. It is ignored if sonar.web.accessLogs.enable=false. Value is:
-#    - "common" is the Common Log Format (shortcut for: %h %l %u %user %date "%r" %s %b)
-#    - "combined" is another format widely recognized (shortcut for: %h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}")
-#    - else a custom pattern. See http://logback.qos.ch/manual/layouts.html#AccessPatternLayout
+# Format of access log. It is ignored if sonar.web.accessLogs.enable=false. Possible values are:
+#    - "common" is the Common Log Format, shortcut to: %h %l %u %user %date "%r" %s %b
+#    - "combined" is another format widely recognized, shortcut to: %h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}"
+#    - else a custom pattern. See http://logback.qos.ch/manual/layouts.html#AccessPatternLayout.
+# If SonarQube is behind a reverse proxy, then the following value allows to display the correct remote IP address:
+#sonar.web.accessLogs.pattern=%i{X-Forwarded-For} %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}"
+# Default value is:
 #sonar.web.accessLogs.pattern=combined
 
 

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -292,7 +292,7 @@
 #    - "combined" is another format widely recognized, shortcut to: %h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}"
 #    - else a custom pattern. See http://logback.qos.ch/manual/layouts.html#AccessPatternLayout.
 # If SonarQube is behind a reverse proxy, then the following value allows to display the correct remote IP address:
-#sonar.web.accessLogs.pattern=%i{X-Forwarded-For} %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}"
+#sonar.web.accessLogs.pattern=%i{X-Forwarded-For} %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}"
 # Default value is:
 #sonar.web.accessLogs.pattern=combined
 


### PR DESCRIPTION
SONAR-7430 Wrong remote IP in access.log when server is behind a reverse proxy