### PR TITLE
Upgrade Elasticsearch from 1.7.2 to 1.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <logback.version>1.1.3</logback.version>
     <slf4j.version>1.7.12</slf4j.version>
     <tomcat.version>8.0.30</tomcat.version>
-    <elasticsearch.version>1.7.2</elasticsearch.version>
+    <elasticsearch.version>1.7.5</elasticsearch.version>
     <orchestrator.version>3.11-build315</orchestrator.version>
     <okhttp.version>2.6.0</okhttp.version>
 


### PR DESCRIPTION
Release notes
- https://www.elastic.co/downloads/past-releases/elasticsearch-1-7-3
- https://www.elastic.co/downloads/past-releases/elasticsearch-1-7-4
- https://www.elastic.co/downloads/past-releases/elasticsearch-1-7-5