### PR TITLE
Update com.github.eirslett:frontend-maven-plugin to fix proxy issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-          <version>0.0.26</version>
+          <version>0.0.29</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Behind a proxy, it was not possible to build Sonarqube because it
failed to download node-v4.2.4-linux-x64.tar.gz, for example.
Updating com.github.eirslett:frontend-maven-plugin fixes this issue.

Signed-off-by: Marc-Andre Laperle <malaperle@gmail.com>