### PR TITLE
SONAR-7498 OkHttpClient doesn't use ssl socket factory by default

### DIFF
--- a/sonar-ws/src/test/java/org/sonarqube/ws/client/HttpConnectorTest.java
+++ b/sonar-ws/src/test/java/org/sonarqube/ws/client/HttpConnectorTest.java
@@ -25,6 +25,7 @@ import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 import java.io.File;
 import java.util.List;
+import javax.net.ssl.SSLSocketFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -281,8 +282,7 @@ public class HttpConnectorTest {
     HttpConnector underTest = new HttpConnector.Builder().url(serverUrl).build(javaVersion);
 
     assertTlsAndClearTextSpecifications(underTest);
-    // do not override the default TLS context provided by java 8
-    assertThat(underTest.okHttpClient().getSslSocketFactory()).isNull();
+    assertThat(underTest.okHttpClient().getSslSocketFactory()).isInstanceOf(SSLSocketFactory.getDefault().getClass());
   }
 
   private void assertTlsAndClearTextSpecifications(HttpConnector underTest) {


### PR DESCRIPTION
since we didn't set it for Java 8, SSL connections opened with OkHttpClient under Java 8 didn't have any of the SSL parameters