### PR TITLE
SONAR-7429 defaults of HTTPS proxy are values of HTTP proxy

### DIFF
--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -188,8 +188,7 @@
 # HTTP proxy (default none)
 #http.proxyHost=
 #http.proxyPort=
-
-# HTTPS proxy (default none)
+# HTTPS proxy (defaults are values of http.proxyHost and http.proxyPort)
 #https.proxyHost=
 #https.proxyPort=
 

--- a/sonar-core/src/main/java/org/sonar/core/util/DefaultHttpDownloader.java
+++ b/sonar-core/src/main/java/org/sonar/core/util/DefaultHttpDownloader.java
@@ -177,10 +177,14 @@ public class DefaultHttpDownloader extends HttpDownloader {
     private static final String GET = "GET";
     private static final String HTTP_PROXY_USER = "http.proxyUser";
     private static final String HTTP_PROXY_PASSWORD = "http.proxyPassword";
+    private static final String HTTP_PROXY_HOST = "http.proxyHost";
+    private static final String HTTPS_PROXY_HOST = "https.proxyHost";
+    private static final String HTTP_PROXY_PORT = "http.proxyPort";
+    private static final String HTTPS_PROXY_PORT = "https.proxyPort";
 
     private static final List<String> PROXY_SETTINGS = ImmutableList.of(
-      "http.proxyHost", "http.proxyPort", "http.nonProxyHosts",
-      "https.proxyHost", "https.proxyPort",
+      HTTP_PROXY_HOST, HTTP_PROXY_PORT, "http.nonProxyHosts",
+      HTTPS_PROXY_HOST, HTTPS_PROXY_PORT,
       "http.auth.ntlm.domain", "socksProxyHost", "socksProxyPort");
 
     private String userAgent;
@@ -196,6 +200,13 @@ public class DefaultHttpDownloader extends HttpDownloader {
         if (settings.hasKey(key)) {
           system.setProperty(key, settings.getString(key));
         }
+      }
+      // defaults of HTTPS properties are the values of HTTP properties
+      if (!settings.hasKey(HTTPS_PROXY_HOST) && settings.hasKey(HTTP_PROXY_HOST)) {
+        system.setProperty(HTTPS_PROXY_HOST, settings.getString(HTTP_PROXY_HOST));
+      }
+      if (!settings.hasKey(HTTPS_PROXY_PORT) && settings.hasKey(HTTP_PROXY_PORT)) {
+        system.setProperty(HTTPS_PROXY_PORT, settings.getString(HTTP_PROXY_PORT));
       }
       // register credentials
       String login = settings.getString(HTTP_PROXY_USER);

--- a/sonar-core/src/test/java/org/sonar/core/util/DefaultHttpDownloaderTest.java
+++ b/sonar-core/src/test/java/org/sonar/core/util/DefaultHttpDownloaderTest.java
@@ -57,7 +57,9 @@ import org.sonar.api.utils.SonarException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -273,6 +275,21 @@ public class DefaultHttpDownloaderTest {
   }
 
   @Test
+  public void https_defaults_are_http_properties() {
+    DefaultHttpDownloader.SystemFacade system = mock(DefaultHttpDownloader.SystemFacade.class);
+    Settings settings = new Settings();
+    settings.setProperty("http.proxyHost", "1.2.3.4");
+    settings.setProperty("http.proxyPort", "80");
+
+    new DefaultHttpDownloader.BaseHttpDownloader(system, settings, null);
+
+    verify(system).setProperty("http.proxyHost", "1.2.3.4");
+    verify(system).setProperty("http.proxyPort", "80");
+    verify(system).setProperty("https.proxyHost", "1.2.3.4");
+    verify(system).setProperty("https.proxyPort", "80");
+  }
+
+  @Test
   public void configure_http_proxy_credentials() {
     DefaultHttpDownloader.SystemFacade system = mock(DefaultHttpDownloader.SystemFacade.class);
     Settings settings = new Settings();
@@ -295,6 +312,19 @@ public class DefaultHttpDownloaderTest {
       public void describeTo(Description description) {
       }
     }));
+  }
+
+  @Test
+  public void no_http_proxy_settings_by_default() {
+    DefaultHttpDownloader.SystemFacade system = mock(DefaultHttpDownloader.SystemFacade.class);
+    Settings settings = new Settings();
+    new DefaultHttpDownloader.BaseHttpDownloader(system, settings, null);
+
+    verify(system, never()).setProperty(eq("http.proxyHost"), anyString());
+    verify(system, never()).setProperty(eq("https.proxyHost"), anyString());
+    verify(system, never()).setProperty(eq("http.proxyPort"), anyString());
+    verify(system, never()).setProperty(eq("https.proxyPort"), anyString());
+    verify(system, never()).setDefaultAuthenticator(any(Authenticator.class));
   }
 
 }


### PR DESCRIPTION
Change the default values of HTTPS proxy according to comment from Nicolas Bontoux: https://jira.sonarsource.com/browse/SONAR-7429?focusedCommentId=84727&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-84727