### PR TITLE
SONAR-7108 Delete Issues from index when purging old issues

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/component/ComponentCleanerService.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/component/ComponentCleanerService.java
@@ -20,10 +20,10 @@
 package org.sonar.server.component;
 
 import java.util.List;
+import org.sonar.api.ce.ComputeEngineSide;
 import org.sonar.api.resources.ResourceType;
 import org.sonar.api.resources.ResourceTypes;
 import org.sonar.api.resources.Scopes;
-import org.sonar.api.ce.ComputeEngineSide;
 import org.sonar.api.server.ServerSide;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
@@ -83,7 +83,7 @@ public class ComponentCleanerService {
   private void deleteFromIndices(String projectUuid) {
     // optimization : index "issues" is refreshed once at the end
     issueAuthorizationIndexer.deleteProject(projectUuid, false);
-    issueIndexer.deleteProject(projectUuid, true);
+    issueIndexer.deleteProject(projectUuid);
     testIndexer.deleteByProject(projectUuid);
   }
 

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/dbcleaner/IndexPurgeListener.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/dbcleaner/IndexPurgeListener.java
@@ -19,20 +19,30 @@
  */
 package org.sonar.server.computation.dbcleaner;
 
+import java.util.List;
 import org.sonar.api.server.ServerSide;
 import org.sonar.db.purge.PurgeListener;
+import org.sonar.server.issue.index.IssueIndexer;
 import org.sonar.server.test.index.TestIndexer;
 
 @ServerSide
 public class IndexPurgeListener implements PurgeListener {
   private final TestIndexer testIndexer;
+  private final IssueIndexer issueIndexer;
 
-  public IndexPurgeListener(TestIndexer testIndexer) {
+  public IndexPurgeListener(TestIndexer testIndexer, IssueIndexer issueIndexer) {
     this.testIndexer = testIndexer;
+    this.issueIndexer = issueIndexer;
   }
 
   @Override
   public void onComponentDisabling(String uuid) {
     testIndexer.deleteByFile(uuid);
   }
+
+  @Override
+  public void onIssuesRemoval(List<String> issueKeys) {
+    issueIndexer.deleteByKeys(issueKeys);
+  }
+
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/index/IssueIndex.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/index/IssueIndex.java
@@ -684,16 +684,6 @@ public class IssueIndex extends BaseIndex {
     return searchResponse.getAggregations().get("_ref");
   }
 
-  public void deleteClosedIssuesOfProjectBefore(String projectUuid, Date beforeDate) {
-    FilterBuilder projectFilter = FilterBuilders.boolFilter().must(FilterBuilders.termsFilter(IssueIndexDefinition.FIELD_ISSUE_PROJECT_UUID, projectUuid));
-    FilterBuilder dateFilter = FilterBuilders.rangeFilter(IssueIndexDefinition.FIELD_ISSUE_FUNC_CLOSED_AT).lt(beforeDate.getTime());
-    QueryBuilder queryBuilder = QueryBuilders.filteredQuery(
-      QueryBuilders.matchAllQuery(),
-      FilterBuilders.andFilter(projectFilter, dateFilter));
-
-    getClient().prepareDeleteByQuery(IssueIndexDefinition.INDEX).setQuery(queryBuilder).get();
-  }
-
   private BoolFilterBuilder createBoolFilter(IssueQuery query) {
     BoolFilterBuilder boolFilter = FilterBuilders.boolFilter();
     for (FilterBuilder filter : createFilters(query).values()) {

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/index/IssueIndexer.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/index/IssueIndexer.java
@@ -101,9 +101,9 @@ public class IssueIndexer extends BaseIndexer {
     return maxDate;
   }
 
-  public void deleteProject(String uuid, boolean refresh) {
+  public void deleteProject(String uuid) {
     BulkIndexer bulk = new BulkIndexer(esClient, INDEX);
-    bulk.setDisableRefresh(!refresh);
+    bulk.setDisableRefresh(false);
     bulk.start();
     SearchRequestBuilder search = esClient.prepareSearch(INDEX)
       .setRouting(uuid)

--- a/server/sonar-server/src/main/java/org/sonar/server/qualityprofile/ws/BulkRuleActivationActions.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/qualityprofile/ws/BulkRuleActivationActions.java
@@ -30,6 +30,7 @@ import org.sonar.api.server.ws.Response;
 import org.sonar.api.server.ws.WebService;
 import org.sonar.api.server.ws.WebService.Param;
 import org.sonar.api.utils.text.JsonWriter;
+import org.sonar.db.DbClient;
 import org.sonar.server.qualityprofile.BulkChangeResult;
 import org.sonar.server.qualityprofile.QProfileService;
 import org.sonar.server.rule.RuleService;
@@ -61,12 +62,14 @@ public class BulkRuleActivationActions {
   public static final String BULK_ACTIVATE_ACTION = "activate_rules";
   public static final String BULK_DEACTIVATE_ACTION = "deactivate_rules";
 
+  private final DbClient dbClient;
   private final QProfileService profileService;
   private final RuleService ruleService;
   private final I18n i18n;
   private final UserSession userSession;
 
-  public BulkRuleActivationActions(QProfileService profileService, RuleService ruleService, I18n i18n, UserSession userSession) {
+  public BulkRuleActivationActions(DbClient dbClient, QProfileService profileService, RuleService ruleService, I18n i18n, UserSession userSession) {
+    this.dbClient = dbClient;
     this.profileService = profileService;
     this.ruleService = ruleService;
     this.i18n = i18n;
@@ -132,6 +135,7 @@ public class BulkRuleActivationActions {
   }
 
   private void bulkDeactivate(Request request, Response response) {
+    // TODO filter on rule language
     BulkChangeResult result = profileService.bulkDeactivate(
       createRuleQuery(ruleService.newRuleQuery(), request),
       request.mandatoryParam(PROFILE_KEY));

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/dbcleaner/IndexPurgeListenerTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/dbcleaner/IndexPurgeListenerTest.java
@@ -20,21 +20,32 @@
 package org.sonar.server.computation.dbcleaner;
 
 import org.junit.Test;
+import org.sonar.server.issue.index.IssueIndexer;
 import org.sonar.server.test.index.TestIndexer;
 
+import static java.util.Arrays.asList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class IndexPurgeListenerTest {
 
-  @Test
-  public void call_test_indexer() {
-    TestIndexer testIndexer = mock(TestIndexer.class);
-    IndexPurgeListener underTest = new IndexPurgeListener(testIndexer);
+  TestIndexer testIndexer = mock(TestIndexer.class);
+  IssueIndexer issueIndexer = mock(IssueIndexer.class);
 
+  IndexPurgeListener underTest = new IndexPurgeListener(testIndexer, issueIndexer);
+
+  @Test
+  public void test_onComponentDisabling() {
     underTest.onComponentDisabling("123456");
 
     verify(testIndexer).deleteByFile("123456");
+  }
+
+  @Test
+  public void test_onIssuesRemoval() {
+    underTest.onIssuesRemoval(asList("ISSUE1", "ISSUE2"));
+
+    verify(issueIndexer).deleteByKeys(asList("ISSUE1", "ISSUE2"));
   }
 
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/dbcleaner/ProjectCleanerTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/dbcleaner/ProjectCleanerTest.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.server.computation.dbcleaner;
 
-import java.util.Date;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.CoreProperties;
@@ -33,7 +32,6 @@ import org.sonar.db.purge.PurgeDao;
 import org.sonar.db.purge.PurgeListener;
 import org.sonar.db.purge.PurgeProfiler;
 import org.sonar.db.purge.period.DefaultPeriodCleaner;
-import org.sonar.server.issue.index.IssueIndex;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
@@ -41,7 +39,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class ProjectCleanerTest {
 
@@ -50,12 +47,11 @@ public class ProjectCleanerTest {
   private PurgeProfiler profiler = mock(PurgeProfiler.class);
   private DefaultPeriodCleaner periodCleaner = mock(DefaultPeriodCleaner.class);
   private PurgeListener purgeListener = mock(PurgeListener.class);
-  private IssueIndex issueIndex = mock(IssueIndex.class);
   private Settings settings = new Settings();
 
   @Before
   public void before() {
-    this.underTest = new ProjectCleaner(dao, periodCleaner, profiler, purgeListener, issueIndex);
+    this.underTest = new ProjectCleaner(dao, periodCleaner, profiler, purgeListener);
   }
 
   @Test
@@ -65,13 +61,6 @@ public class ProjectCleanerTest {
     underTest.purge(mock(DbSession.class), mock(IdUuidPair.class), settings);
 
     verify(profiler, never()).dump(anyLong(), any(Logger.class));
-  }
-
-  @Test
-  public void no_indexing_when_no_issue_to_delete() {
-    underTest.purge(mock(DbSession.class), mock(IdUuidPair.class), settings);
-
-    verifyZeroInteractions(issueIndex);
   }
 
   @Test
@@ -91,7 +80,6 @@ public class ProjectCleanerTest {
 
     verify(periodCleaner).clean(any(DbSession.class), any(Long.class), any(Settings.class));
     verify(dao).purge(any(DbSession.class), any(PurgeConfiguration.class), any(PurgeListener.class), any(PurgeProfiler.class));
-    verify(issueIndex).deleteClosedIssuesOfProjectBefore(any(String.class), any(Date.class));
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/index/IssueIndexTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/index/IssueIndexTest.java
@@ -202,20 +202,20 @@ public class IssueIndexTest {
 
     assertThat(
       index.search(IssueQuery.builder(userSessionRule).projectUuids(newArrayList(project.uuid())).moduleUuids(newArrayList(file.uuid())).build(), new SearchOptions()).getDocs())
-      .isEmpty();
+        .isEmpty();
     assertThat(
       index.search(IssueQuery.builder(userSessionRule).projectUuids(newArrayList(project.uuid())).moduleUuids(newArrayList(module.uuid())).build(), new SearchOptions()).getDocs())
-      .hasSize(1);
+        .hasSize(1);
     assertThat(
       index.search(IssueQuery.builder(userSessionRule).projectUuids(newArrayList(project.uuid())).moduleUuids(newArrayList(subModule.uuid())).build(), new SearchOptions())
         .getDocs())
-      .hasSize(2);
+          .hasSize(2);
     assertThat(
       index.search(IssueQuery.builder(userSessionRule).projectUuids(newArrayList(project.uuid())).moduleUuids(newArrayList(project.uuid())).build(), new SearchOptions()).getDocs())
-      .isEmpty();
+        .isEmpty();
     assertThat(
       index.search(IssueQuery.builder(userSessionRule).projectUuids(newArrayList(project.uuid())).moduleUuids(newArrayList("unknown")).build(), new SearchOptions()).getDocs())
-      .isEmpty();
+        .isEmpty();
   }
 
   @Test
@@ -429,7 +429,7 @@ public class IssueIndexTest {
 
     assertThat(
       index.search(IssueQuery.builder(userSessionRule).resolutions(newArrayList(Issue.RESOLUTION_FALSE_POSITIVE, Issue.RESOLUTION_FIXED)).build(), new SearchOptions()).getDocs())
-      .hasSize(2);
+        .hasSize(2);
     assertThat(index.search(IssueQuery.builder(userSessionRule).resolutions(newArrayList(Issue.RESOLUTION_FALSE_POSITIVE)).build(), new SearchOptions()).getDocs()).hasSize(1);
     assertThat(index.search(IssueQuery.builder(userSessionRule).resolutions(newArrayList(Issue.RESOLUTION_REMOVED)).build(), new SearchOptions()).getDocs()).isEmpty();
   }
@@ -1139,35 +1139,6 @@ public class IssueIndexTest {
 
     userSessionRule.login("john").setUserGroups("sonar-users");
     assertThat(index.search(IssueQuery.builder(userSessionRule).build(), new SearchOptions()).getDocs()).hasSize(1);
-  }
-
-  @Test
-  public void delete_closed_issues_from_one_project_older_than_specific_date() {
-    // ARRANGE
-    Date today = new Date();
-    Date yesterday = org.apache.commons.lang.time.DateUtils.addDays(today, -1);
-    Date beforeYesterday = org.apache.commons.lang.time.DateUtils.addDays(yesterday, -1);
-
-    ComponentDto project = ComponentTesting.newProjectDto();
-    ComponentDto file = ComponentTesting.newFileDto(project);
-
-    indexIssues(
-      IssueTesting.newDoc("ISSUE1", file).setFuncCloseDate(today),
-      IssueTesting.newDoc("ISSUE2", file).setFuncCloseDate(beforeYesterday),
-      IssueTesting.newDoc("ISSUE3", file).setFuncCloseDate(null));
-
-    // ACT
-    index.deleteClosedIssuesOfProjectBefore(project.uuid(), yesterday);
-
-    // ASSERT
-    List<IssueDoc> issues = index.search(IssueQuery.builder(userSessionRule).projectUuids(newArrayList(project.uuid())).build(), new SearchOptions()).getDocs();
-    List<Date> dates = newArrayList();
-    for (IssueDoc issue : issues) {
-      dates.add(issue.closeDate());
-    }
-
-    assertThat(index.countAll()).isEqualTo(2);
-    assertThat(dates).containsOnly(null, today);
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/index/IssueIndexerTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/index/IssueIndexerTest.java
@@ -106,7 +106,7 @@ public class IssueIndexerTest {
 
     assertThat(esTester.countDocuments("issues", "issue")).isEqualTo(1);
 
-    indexer.deleteProject("THE_PROJECT", true);
+    indexer.deleteProject("THE_PROJECT");
 
     assertThat(esTester.countDocuments("issues", "issue")).isZero();
   }

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/QProfilesWsTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/QProfilesWsTest.java
@@ -61,7 +61,7 @@ public class QProfilesWsTest {
 
     controller = new WsTester(new QProfilesWs(
       new RuleActivationActions(profileService),
-      new BulkRuleActivationActions(profileService, ruleService, i18n, userSessionRule),
+      new BulkRuleActivationActions(null, profileService, ruleService, i18n, userSessionRule),
       new ProjectAssociationActions(null, null, null, languages, userSessionRule),
       new CreateAction(null, null, null, languages, importers, userSessionRule),
       new ImportersAction(importers),

--- a/sonar-db/src/main/java/org/sonar/db/purge/PurgeListener.java
+++ b/sonar-db/src/main/java/org/sonar/db/purge/PurgeListener.java
@@ -19,6 +19,8 @@
  */
 package org.sonar.db.purge;
 
+import java.util.List;
+
 public interface PurgeListener {
 
   PurgeListener EMPTY = new PurgeListener() {
@@ -26,7 +28,14 @@ public interface PurgeListener {
     public void onComponentDisabling(String uuid) {
       // do nothing
     }
+
+    @Override
+    public void onIssuesRemoval(List<String> issueKeys) {
+      // do nothing
+    }
   };
 
   void onComponentDisabling(String uuid);
+
+  void onIssuesRemoval(List<String> issueKeys);
 }

--- a/sonar-db/src/main/java/org/sonar/db/purge/PurgeMapper.java
+++ b/sonar-db/src/main/java/org/sonar/db/purge/PurgeMapper.java
@@ -82,9 +82,11 @@ public interface PurgeMapper {
 
   void deleteComponentIssues(@Param("componentUuids") List<String> componentUuids);
 
-  void deleteOldClosedIssueChanges(@Param("projectUuid") String projectUuid, @Nullable @Param("toDate") Long toDate);
+  List<String> selectOldClosedIssueKeys(@Param("projectUuid") String projectUuid, @Nullable @Param("toDate") Long toDate);
 
-  void deleteOldClosedIssues(@Param("projectUuid") String projectUuid, @Nullable @Param("toDate") Long toDate);
+  void deleteIssuesFromKeys(@Param("keys") List<String> keys);
+
+  void deleteIssueChangesFromIssueKeys(@Param("issueKeys") List<String> issueKeys);
 
   void deleteFileSourcesByProjectUuid(String rootProjectUuid);
 

--- a/sonar-db/src/main/resources/org/sonar/db/purge/PurgeMapper.xml
+++ b/sonar-db/src/main/resources/org/sonar/db/purge/PurgeMapper.xml
@@ -260,69 +260,38 @@
     delete from file_sources where file_uuid=#{fileUuid}
   </delete>
 
-  <delete id="deleteOldClosedIssueChanges" parameterType="map">
-    delete from issue_changes ic
-    where exists (
-    select * from issues i
-    where i.project_uuid=#{projectUuid} and i.kee=ic.issue_key
+  <select id="selectOldClosedIssueKeys" parameterType="map" resultType="String">
+    SELECT kee FROM issues
+    WHERE project_uuid=#{projectUuid}
     <choose>
       <when test="toDate == null">
-        and i.issue_close_date is not null
+        AND issue_close_date IS NOT NULL
       </when>
       <otherwise>
-        and i.issue_close_date &lt; #{toDate}
+        AND issue_close_date &lt; #{toDate}
       </otherwise>
     </choose>
-    )
+  </select>
+
+  <delete id="deleteIssuesFromKeys" parameterType="map">
+    DELETE FROM issues
+    WHERE kee IN
+    <foreach collection="keys" open="(" close=")" item="key" separator=",">
+      #{key}
+    </foreach>
   </delete>
 
-  <!-- Mssql -->
-  <delete id="deleteOldClosedIssueChanges" databaseId="mssql" parameterType="map">
-    delete issue_changes from issue_changes
-    inner join issues on issue_changes.issue_key=issues.kee
-    where issues.project_uuid=#{projectUuid}
-    <choose>
-      <when test="toDate == null">
-        and issues.issue_close_date is not null
-      </when>
-      <otherwise>
-        and issues.issue_close_date &lt; #{toDate}
-      </otherwise>
-    </choose>
+  <delete id="deleteIssueChangesFromIssueKeys" parameterType="map">
+    DELETE FROM issue_changes
+    WHERE issue_key IN
+    <foreach collection="issueKeys" open="(" close=")" item="issueKey" separator=",">
+      #{issueKey}
+    </foreach>
   </delete>
 
-  <!-- Mysql -->
-  <delete id="deleteOldClosedIssueChanges" databaseId="mysql" parameterType="map">
-    delete ic
-    from issue_changes as ic, issues as i
-    where i.project_uuid=#{projectUuid}
-    and ic.issue_key=i.kee
-    <choose>
-      <when test="toDate == null">
-        and i.issue_close_date is not null
-      </when>
-      <otherwise>
-        and i.issue_close_date &lt; #{toDate}
-      </otherwise>
-    </choose>
+  <delete id="deleteCeActivityByProjectUuid">
+      delete from ce_activity where component_uuid=#{rootProjectUuid}
   </delete>
-
-  <delete id="deleteOldClosedIssues" parameterType="map">
-    delete from issues
-    where project_uuid=#{projectUuid}
-    <choose>
-      <when test="toDate == null">
-        and issue_close_date is not null
-      </when>
-      <otherwise>
-        and issue_close_date &lt; #{toDate}
-      </otherwise>
-    </choose>
-  </delete>
-
-    <delete id="deleteCeActivityByProjectUuid">
-        delete from ce_activity where component_uuid=#{rootProjectUuid}
-    </delete>
 
 </mapper>
 

--- a/sonar-db/src/test/java/org/sonar/db/purge/PurgeDaoTest.java
+++ b/sonar-db/src/test/java/org/sonar/db/purge/PurgeDaoTest.java
@@ -33,8 +33,10 @@ import org.sonar.db.ce.CeQueueDto;
 import org.sonar.db.component.ComponentDto;
 import org.sonar.db.component.ComponentTesting;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sonar.db.ce.CeTaskTypes.REPORT;
 
@@ -171,9 +173,13 @@ public class PurgeDaoTest {
 
   @Test
   public void should_delete_old_closed_issues() {
+    PurgeListener purgeListener = mock(PurgeListener.class);
     dbTester.prepareDbUnit(getClass(), "should_delete_old_closed_issues.xml");
-    underTest.purge(newConfigurationWith30Days(), PurgeListener.EMPTY, new PurgeProfiler());
+
+    underTest.purge(newConfigurationWith30Days(), purgeListener, new PurgeProfiler());
+
     dbTester.assertDbUnit(getClass(), "should_delete_old_closed_issues-result.xml", "issues", "issue_changes");
+    verify(purgeListener).onIssuesRemoval(asList("ISSUE-1", "ISSUE-2"));
   }
 
   @Test


### PR DESCRIPTION
SONAR-7108 Delete Issues from index when purging old issues

Purge from index was already working when property 'sonar.dbcleaner.daysBeforeDeletingClosedIssues' was not equal to 0. Now it's working whatever the value is.