### PR TITLE
SONAR-7539 WS api/properties should return licenses if user is authenticated

### DIFF
--- a/server/sonar-web/src/main/webapp/WEB-INF/app/controllers/api/properties_controller.rb
+++ b/server/sonar-web/src/main/webapp/WEB-INF/app/controllers/api/properties_controller.rb
@@ -156,7 +156,7 @@ class Api::PropertiesController < Api::ApiController
   end
 
   def allowed?(property_key)
-    !property_key.end_with?('.secured') || is_admin?
+    !property_key.end_with?('.secured') || is_admin? || (property_key.include?(".license") && logged_in?)
   end
 
   def get_default_property(key)


### PR DESCRIPTION
SONAR-7539 WS api/properties should return licenses if user is authenticated