### PR TITLE
SONAR-7154 main process must create property file in SQ's temp dir

### DIFF
--- a/server/sonar-process-monitor/src/main/java/org/sonar/process/monitor/JavaProcessLauncher.java
+++ b/server/sonar-process-monitor/src/main/java/org/sonar/process/monitor/JavaProcessLauncher.java
@@ -105,8 +105,7 @@ class JavaProcessLauncher {
 
   private String buildJavaPath() {
     String separator = System.getProperty("file.separator");
-    return new File(new File(System.getProperty("java.home")),
-      "bin" + separator + "java").getAbsolutePath();
+    return new File(new File(System.getProperty("java.home")), "bin" + separator + "java").getAbsolutePath();
   }
 
   private List<String> buildClasspath(JavaCommand javaCommand) {
@@ -116,7 +115,7 @@ class JavaProcessLauncher {
   private File buildPropertiesFile(JavaCommand javaCommand) {
     File propertiesFile = null;
     try {
-      propertiesFile = File.createTempFile("sq-process", "properties");
+      propertiesFile = File.createTempFile("sq-process", "properties", tempDir);
       Properties props = new Properties();
       props.putAll(javaCommand.getArguments());
       props.setProperty(PROPERTY_PROCESS_KEY, javaCommand.getProcessId().getKey());

--- a/server/sonar-process-monitor/src/test/java/org/sonar/process/monitor/JavaProcessLauncherTest.java
+++ b/server/sonar-process-monitor/src/test/java/org/sonar/process/monitor/JavaProcessLauncherTest.java
@@ -22,29 +22,28 @@ package org.sonar.process.monitor;
 import java.io.File;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.sonar.process.ProcessId;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 public class JavaProcessLauncherTest {
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void fail_to_launch() throws Exception {
     File tempDir = temp.newFolder();
     JavaCommand command = new JavaCommand(ProcessId.ELASTICSEARCH);
     JavaProcessLauncher launcher = new JavaProcessLauncher(new Timeouts(), tempDir);
-    try {
-      // command is not correct (missing options), java.lang.ProcessBuilder#start()
-      // throws an exception
-      launcher.launch(command);
-      fail();
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Fail to launch [es]");
-    }
+
+    expectedException.expect(IllegalStateException.class);
+    expectedException.expectMessage("Fail to launch [es]");
+
+    // command is not correct (missing options), java.lang.ProcessBuilder#start()
+    // throws an exception
+    launcher.launch(command);
   }
 }


### PR DESCRIPTION
because the JVM's temp dir might just be read only (eg. temp dir of windows services launched with Local System Account on recent windows versions is actuallt read only)