### PR TITLE
SONAR-6912 prevent admin lockout -- partial fix

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/usergroups/ws/DeleteAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/usergroups/ws/DeleteAction.java
@@ -105,8 +105,10 @@ public class DeleteAction implements UserGroupsWsAction {
     boolean isOneRemainingSystemAdminGroup =
       dbClient.roleDao().countGroupsWithSystemAdminRole(dbSession) == 1;
 
+    boolean existsOtherSystemAdminUser = false;  // TODO see SONAR-6912
+
     boolean willLockoutSystemAdmin =
-      hasSystemAdminRole && isOneRemainingSystemAdminGroup;
+      hasSystemAdminRole && isOneRemainingSystemAdminGroup && !existsOtherSystemAdminUser;
 
     checkArgument(!willLockoutSystemAdmin,
       format("The last system admin group '%s' cannot be deleted", groupName));

--- a/server/sonar-server/src/main/java/org/sonar/server/usergroups/ws/DeleteAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/usergroups/ws/DeleteAction.java
@@ -102,10 +102,14 @@ public class DeleteAction implements UserGroupsWsAction {
       .selectGroupPermissions(dbSession, groupName, null)
       .contains(GlobalPermissions.SYSTEM_ADMIN);
 
-    boolean isLastSystemAdminGroup =
-      hasSystemAdminRole && dbClient.roleDao().countGroupsWithSystemAdminRole(dbSession) == 1;
+    boolean isOneRemainingSystemAdminGroup =
+      dbClient.roleDao().countGroupsWithSystemAdminRole(dbSession) == 1;
 
-    checkArgument(!isLastSystemAdminGroup, format("The last system admin group '%s' cannot be deleted", groupName));
+    boolean willLockoutSystemAdmin =
+      hasSystemAdminRole && isOneRemainingSystemAdminGroup;
+
+    checkArgument(!willLockoutSystemAdmin,
+      format("The last system admin group '%s' cannot be deleted", groupName));
   }
 
   private void removeGroupMembers(DbSession dbSession, long groupId) {

--- a/server/sonar-server/src/test/java/org/sonar/server/usergroups/ws/DeleteActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/usergroups/ws/DeleteActionTest.java
@@ -169,14 +169,14 @@ public class DeleteActionTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void cannot_delete_last_admin_group() throws Exception {
-    assertThat(roleDao.countGroupsWithGlobalAdminRole(dbSession)).isEqualTo(0);
+  public void cannot_delete_last_system_admin_group() throws Exception {
+    assertThat(roleDao.countGroupsWithSystemAdminRole(dbSession)).isEqualTo(0);
 
     GroupDto group = groupDao.insert(dbSession, newGroupDto().setName("system-admins"));
     assertThat(groupDao.selectById(dbSession, group.getId())).isNotNull();
 
     roleDao.insertGroupRole(dbSession, new GroupRoleDto().setGroupId(group.getId()).setRole(UserRole.ADMIN));
-    assertThat(roleDao.countGroupsWithGlobalAdminRole(dbSession)).isEqualTo(1);
+    assertThat(roleDao.countGroupsWithSystemAdminRole(dbSession)).isEqualTo(1);
 
     dbSession.commit();
 

--- a/server/sonar-server/src/test/java/org/sonar/server/usergroups/ws/DeleteActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/usergroups/ws/DeleteActionTest.java
@@ -175,7 +175,7 @@ public class DeleteActionTest {
     GroupDto group = groupDao.insert(dbSession, newGroupDto().setName("system-admins"));
     assertThat(groupDao.selectById(dbSession, group.getId())).isNotNull();
 
-    roleDao.insertGroupRole(dbSession, new GroupRoleDto().setGroupId(group.getId()).setRole(UserRole.ADMIN));
+    roleDao.insertGroupRole(dbSession, new GroupRoleDto().setGroupId(group.getId()).setRole(GlobalPermissions.SYSTEM_ADMIN));
     assertThat(roleDao.countGroupsWithSystemAdminRole(dbSession)).isEqualTo(1);
 
     dbSession.commit();

--- a/server/sonar-server/src/test/java/org/sonar/server/usergroups/ws/DeleteActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/usergroups/ws/DeleteActionTest.java
@@ -172,7 +172,7 @@ public class DeleteActionTest {
   public void cannot_delete_last_admin_group() throws Exception {
     assertThat(roleDao.countGroupsWithGlobalAdminRole(dbSession)).isEqualTo(0);
 
-    GroupDto group = groupDao.insert(dbSession, newGroupDto().setName("group_name"));
+    GroupDto group = groupDao.insert(dbSession, newGroupDto().setName("system-admins"));
     assertThat(groupDao.selectById(dbSession, group.getId())).isNotNull();
 
     roleDao.insertGroupRole(dbSession, new GroupRoleDto().setGroupId(group.getId()).setRole(UserRole.ADMIN));

--- a/server/sonar-server/src/test/java/org/sonar/server/usergroups/ws/DeleteActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/usergroups/ws/DeleteActionTest.java
@@ -182,8 +182,8 @@ public class DeleteActionTest {
 
     loginAsAdmin();
     newRequest()
-            .setParam(PARAM_GROUP_NAME, group.getName())
-            .execute().assertNoContent();
+      .setParam(PARAM_GROUP_NAME, group.getName())
+      .execute().assertNoContent();
 
     assertThat(groupDao.selectById(dbSession, group.getId())).isNull();
   }

--- a/server/sonar-server/src/test/java/org/sonar/server/usergroups/ws/DeleteActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/usergroups/ws/DeleteActionTest.java
@@ -184,8 +184,6 @@ public class DeleteActionTest {
     newRequest()
       .setParam(PARAM_GROUP_NAME, group.getName())
       .execute().assertNoContent();
-
-    assertThat(groupDao.selectById(dbSession, group.getId())).isNull();
   }
 
   @Test

--- a/sonar-db/src/main/java/org/sonar/db/user/RoleDao.java
+++ b/sonar-db/src/main/java/org/sonar/db/user/RoleDao.java
@@ -80,6 +80,10 @@ public class RoleDao implements Dao {
     return mapper(session).countUsersWithPermission(permission, allGroupsExceptThisGroupId);
   }
 
+  public int countGroupsWithGlobalAdminRole(DbSession session) {
+    return mapper(session).countGroupsWithGlobalAdminRole();
+  }
+
   public void removeAllPermissions(DbSession session, Long resourceId) {
     deleteGroupRolesByResourceId(session, resourceId);
     deleteUserRolesByResourceId(session, resourceId);

--- a/sonar-db/src/main/java/org/sonar/db/user/RoleDao.java
+++ b/sonar-db/src/main/java/org/sonar/db/user/RoleDao.java
@@ -80,8 +80,8 @@ public class RoleDao implements Dao {
     return mapper(session).countUsersWithPermission(permission, allGroupsExceptThisGroupId);
   }
 
-  public int countGroupsWithGlobalAdminRole(DbSession session) {
-    return mapper(session).countGroupsWithGlobalAdminRole();
+  public int countGroupsWithSystemAdminRole(DbSession session) {
+    return mapper(session).countGroupsWithSystemAdminRole();
   }
 
   public void removeAllPermissions(DbSession session, Long resourceId) {

--- a/sonar-db/src/main/java/org/sonar/db/user/RoleMapper.java
+++ b/sonar-db/src/main/java/org/sonar/db/user/RoleMapper.java
@@ -57,4 +57,6 @@ public interface RoleMapper {
   void deleteGroupRolesByGroupId(long groupId);
 
   int countUsersWithPermission(@Param("permission") String permission, @Nullable @Param("groupId") Long groupId);
+
+  int countGroupsWithGlobalAdminRole();
 }

--- a/sonar-db/src/main/java/org/sonar/db/user/RoleMapper.java
+++ b/sonar-db/src/main/java/org/sonar/db/user/RoleMapper.java
@@ -58,5 +58,5 @@ public interface RoleMapper {
 
   int countUsersWithPermission(@Param("permission") String permission, @Nullable @Param("groupId") Long groupId);
 
-  int countGroupsWithGlobalAdminRole();
+  int countGroupsWithSystemAdminRole();
 }

--- a/sonar-db/src/main/resources/org/sonar/db/user/RoleMapper.xml
+++ b/sonar-db/src/main/resources/org/sonar/db/user/RoleMapper.xml
@@ -136,6 +136,11 @@
     ) c
   </select>
 
+  <select id="countGroupsWithGlobalAdminRole" resultType="int">
+    SELECT count(1)
+    FROM group_roles WHERE resource_id IS NULL AND role = 'admin'
+  </select>
+
   <delete id="deleteGroupRolesByGroupId" parameterType="long">
     delete from group_roles where group_id=#{id}
   </delete>

--- a/sonar-db/src/main/resources/org/sonar/db/user/RoleMapper.xml
+++ b/sonar-db/src/main/resources/org/sonar/db/user/RoleMapper.xml
@@ -136,7 +136,7 @@
     ) c
   </select>
 
-  <select id="countGroupsWithGlobalAdminRole" resultType="int">
+  <select id="countGroupsWithSystemAdminRole" resultType="int">
     SELECT count(1)
     FROM group_roles WHERE resource_id IS NULL AND role = 'admin'
   </select>


### PR DESCRIPTION
Treats one part of one part of [SONAR-6912](https://jira.sonarsource.com/browse/SONAR-6912):

> The checks that should be done:
> - **when deleting a group: check if it's the last group with global admin rights** and there's no global admin user
> - when removing the last user of a group: check if it's the last group with global admin rights and there's no global admin user

That is, it will refuse to delete a group when it is the only system admin group. This is a bit more strict than needs to be. If there is an individual user with system admin role, it should allow deleting the group, but it doesn't, I marked with a "TODO" the place this condition could be implemented.

If you prefer I can implement that missing step now, or in a next Pull Request.

WS concerned: `api/user_groups/delete`
