### PR TITLE
Make links clickable on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ Copyright 2008-2016 SonarSource.
 
 Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt)
 
- [1]: http://www.sonarqube.org/
- [2]: http://jira.sonarsource.com/browse/SONAR
- [3]: http://docs.sonarqube.org/display/SONAR
-
 ### Build status
 
 [![Build Status](https://travis-ci.org/SonarSource/sonarqube.svg?branch=master)](https://travis-ci.org/SonarSource/sonarqube)
+
+### Links
+
+Project website: http://www.sonarqube.org/
+
+Documentation: http://docs.sonarqube.org/display/SONAR
+
+Issue tracking: http://jira.sonarsource.com/browse/SONAR
+
+How to contribute: http://www.sonarqube.org/development/


### PR DESCRIPTION
The links in reference-style syntax are not visible on GitHub, and as such, not clickable either. I converted them to a "Links" section to make them visible and clickable, and added a "How to contribute" link pointing to the Development page on the main website. This should make the project more accessible to potential contributors.