### PR TITLE
Functional interface annotation added when needed

### DIFF
--- a/server/sonar-plugin-bridge/src/main/java/org/sonar/plugin/ce/ReportAnalysisComponentProvider.java
+++ b/server/sonar-plugin-bridge/src/main/java/org/sonar/plugin/ce/ReportAnalysisComponentProvider.java
@@ -22,6 +22,7 @@ package org.sonar.plugin.ce;
 import java.util.List;
 import org.sonar.api.ce.ComputeEngineSide;
 
+@FunctionalInterface
 @ComputeEngineSide
 public interface ReportAnalysisComponentProvider {
 

--- a/server/sonar-process/src/main/java/org/sonar/process/Stoppable.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/Stoppable.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.process;
 
+@FunctionalInterface
 public interface Stoppable {
 
   void stopAsync();

--- a/server/sonar-process/src/main/java/org/sonar/process/systeminfo/SystemInfoSection.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/systeminfo/SystemInfoSection.java
@@ -21,6 +21,7 @@ package org.sonar.process.systeminfo;
 
 import org.sonar.process.systeminfo.protobuf.ProtobufSystemInfo;
 
+@FunctionalInterface
 public interface SystemInfoSection {
 
   ProtobufSystemInfo.Section toProtobuf();

--- a/server/sonar-server/src/main/java/org/sonar/ce/queue/CeQueueListener.java
+++ b/server/sonar-server/src/main/java/org/sonar/ce/queue/CeQueueListener.java
@@ -21,6 +21,7 @@ package org.sonar.ce.queue;
 
 import org.sonar.db.ce.CeActivityDto;
 
+@FunctionalInterface
 public interface CeQueueListener {
 
   void onRemoved(CeTask task, CeActivityDto.Status status);

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/batch/BatchReportDirectoryHolder.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/batch/BatchReportDirectoryHolder.java
@@ -22,6 +22,7 @@ package org.sonar.server.computation.batch;
 import java.io.File;
 import org.sonar.ce.queue.CeTask;
 
+@FunctionalInterface
 public interface BatchReportDirectoryHolder {
   /**
    * The File of the directory where the Batch report files for the current {@link CeTask} are stored.

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/component/ComponentCrawler.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/component/ComponentCrawler.java
@@ -22,6 +22,7 @@ package org.sonar.server.computation.component;
 /**
  * Allow to crawl a component tree from a given component
  */
+@FunctionalInterface
 public interface ComponentCrawler {
 
   void visit(Component tree);

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/component/SettingsRepository.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/component/SettingsRepository.java
@@ -24,6 +24,7 @@ import org.sonar.api.config.Settings;
 /**
  * Repository of component settings.
  */
+@FunctionalInterface
 public interface SettingsRepository {
   /**
    * Returns the settings for the specified Component.

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/container/ContainerFactory.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/container/ContainerFactory.java
@@ -24,6 +24,7 @@ import org.sonar.ce.queue.CeTask;
 import org.sonar.core.platform.ComponentContainer;
 import org.sonar.plugin.ce.ReportAnalysisComponentProvider;
 
+@FunctionalInterface
 public interface ContainerFactory {
 
   ComputeEngineContainer create(ComponentContainer parent, CeTask task, @Nullable ReportAnalysisComponentProvider[] componentProviders);

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/developer/PersistDevelopersDelegate.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/developer/PersistDevelopersDelegate.java
@@ -22,6 +22,7 @@ package org.sonar.server.computation.developer;
 /**
  * This interface is used to delegate the persistence of developers to the Developer Cockpit plugin
  */
+@FunctionalInterface
 public interface PersistDevelopersDelegate {
 
   void execute();

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/duplication/CrossProjectDuplicationStatusHolder.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/duplication/CrossProjectDuplicationStatusHolder.java
@@ -26,6 +26,7 @@ import org.sonar.server.computation.analysis.AnalysisMetadataHolder;
  *
  * A log will be displayed whether or not the cross project duplication is enabled or not.
  */
+@FunctionalInterface
 public interface CrossProjectDuplicationStatusHolder {
 
   /**

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/duplication/Duplicate.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/duplication/Duplicate.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.server.computation.duplication;
 
+@FunctionalInterface
 public interface Duplicate {
   TextBlock getTextBlock();
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/filemove/SourceSimilarity.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/filemove/SourceSimilarity.java
@@ -21,6 +21,7 @@ package org.sonar.server.computation.filemove;
 
 import java.util.List;
 
+@FunctionalInterface
 public interface SourceSimilarity {
 
   // TODO verify algorithm http://stackoverflow.com/questions/6087281/similarity-score-levenshtein

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/issue/ComponentIssuesRepository.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/issue/ComponentIssuesRepository.java
@@ -31,6 +31,7 @@ import org.sonar.server.computation.component.Component;
  *
  * This repository must NEVER contains more issues than in issues from one component order to not consume to much memory.
  */
+@FunctionalInterface
 public interface ComponentIssuesRepository {
 
   /**

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/issue/commonrule/CommonRuleEngine.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/issue/commonrule/CommonRuleEngine.java
@@ -27,6 +27,7 @@ import org.sonar.server.computation.component.Component;
  * Generate the issues related to "common rules", which are
  * the rules based on measure thresholds.
  */
+@FunctionalInterface
 public interface CommonRuleEngine {
 
   Collection<DefaultIssue> process(Component component);

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/language/LanguageRepository.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/language/LanguageRepository.java
@@ -22,6 +22,7 @@ package org.sonar.server.computation.language;
 import com.google.common.base.Optional;
 import org.sonar.api.resources.Language;
 
+@FunctionalInterface
 public interface LanguageRepository {
   Optional<Language> find(String languageKey);
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/measure/MeasureComputersHolder.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/measure/MeasureComputersHolder.java
@@ -21,6 +21,7 @@ package org.sonar.server.computation.measure;
 
 import org.sonar.server.computation.measure.api.MeasureComputerWrapper;
 
+@FunctionalInterface
 public interface MeasureComputersHolder {
 
   /**

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/metric/ReportMetricValidator.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/metric/ReportMetricValidator.java
@@ -22,6 +22,7 @@ package org.sonar.server.computation.metric;
 /**
  * Validate metric to know if it can be read from the batch
  */
+@FunctionalInterface
 public interface ReportMetricValidator {
 
   boolean validate(String metricKey);

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/qualitygate/EvaluationResultTextConverter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/qualitygate/EvaluationResultTextConverter.java
@@ -21,6 +21,7 @@ package org.sonar.server.computation.qualitygate;
 
 import javax.annotation.CheckForNull;
 
+@FunctionalInterface
 public interface EvaluationResultTextConverter {
   @CheckForNull
   String asText(Condition condition, EvaluationResult evaluationResult);

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/qualitygate/QualityGateHolder.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/qualitygate/QualityGateHolder.java
@@ -21,6 +21,7 @@ package org.sonar.server.computation.qualitygate;
 
 import com.google.common.base.Optional;
 
+@FunctionalInterface
 public interface QualityGateHolder {
   /**
    * The QualityGate for the project if there is any.

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/qualitygate/QualityGateService.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/qualitygate/QualityGateService.java
@@ -21,6 +21,7 @@ package org.sonar.server.computation.qualitygate;
 
 import com.google.common.base.Optional;
 
+@FunctionalInterface
 public interface QualityGateService {
   /**
    * Retrieve the {@link QualityGate} from the database with the specified id, it it exists.

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/qualityprofile/ActiveRulesHolder.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/qualityprofile/ActiveRulesHolder.java
@@ -22,6 +22,7 @@ package org.sonar.server.computation.qualityprofile;
 import com.google.common.base.Optional;
 import org.sonar.api.rule.RuleKey;
 
+@FunctionalInterface
 public interface ActiveRulesHolder {
 
   Optional<ActiveRule> get(RuleKey ruleKey);

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/scm/ScmInfoRepository.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/scm/ScmInfoRepository.java
@@ -27,6 +27,7 @@ import org.sonar.server.computation.component.Component;
  *
  * It will always search in the db if there's nothing in the report.
  */
+@FunctionalInterface
 public interface ScmInfoRepository {
 
   /**

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/source/LineReader.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/source/LineReader.java
@@ -21,6 +21,7 @@ package org.sonar.server.computation.source;
 
 import org.sonar.db.protobuf.DbFileSources;
 
+@FunctionalInterface
 public interface LineReader {
 
   void read(DbFileSources.Line.Builder lineBuilder);

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/source/SourceHashRepository.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/source/SourceHashRepository.java
@@ -21,6 +21,7 @@ package org.sonar.server.computation.source;
 
 import org.sonar.server.computation.component.Component;
 
+@FunctionalInterface
 public interface SourceHashRepository {
 
   /**

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/source/SourceLinesRepository.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/source/SourceLinesRepository.java
@@ -22,6 +22,7 @@ package org.sonar.server.computation.source;
 import org.sonar.core.util.CloseableIterator;
 import org.sonar.server.computation.component.Component;
 
+@FunctionalInterface
 public interface SourceLinesRepository {
 
   /**

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/taskprocessor/CeProcessingScheduler.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/taskprocessor/CeProcessingScheduler.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.server.computation.taskprocessor;
 
+@FunctionalInterface
 public interface CeProcessingScheduler {
 
   void startScheduling();

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/taskprocessor/CeTaskProcessorRepository.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/taskprocessor/CeTaskProcessorRepository.java
@@ -23,6 +23,7 @@ import com.google.common.base.Optional;
 import org.sonar.ce.queue.CeTask;
 import org.sonar.ce.taskprocessor.CeTaskProcessor;
 
+@FunctionalInterface
 public interface CeTaskProcessorRepository {
 
   /**

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/taskprocessor/TaskResultHolder.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/taskprocessor/TaskResultHolder.java
@@ -21,6 +21,7 @@ package org.sonar.server.computation.taskprocessor;
 
 import org.sonar.ce.queue.CeTaskResult;
 
+@FunctionalInterface
 public interface TaskResultHolder {
   /**
    * @throws IllegalStateException if holder holds no CeTaskResult

--- a/server/sonar-server/src/main/java/org/sonar/server/es/BaseIndexer.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/es/BaseIndexer.java
@@ -110,6 +110,7 @@ public abstract class BaseIndexer implements Startable {
     executor.shutdown();
   }
 
+  @FunctionalInterface
   public interface IndexerTask {
     long index(long lastUpdatedAt);
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/ruby/CallInvalidateMetricCache.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/ruby/CallInvalidateMetricCache.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.server.ruby;
 
+@FunctionalInterface
 public interface CallInvalidateMetricCache {
   void callInvalidate();
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/ruby/CallLoadJavaWebServices.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/ruby/CallLoadJavaWebServices.java
@@ -23,6 +23,7 @@ package org.sonar.server.ruby;
  * Interface which must be a top-level public class to be used by the Ruby engine but that hides name of the Ruby
  * method in the Ruby script from the rest of the platform (only {@link RubyRailsRoutes} is known to the platform).
  */
+@FunctionalInterface
 public interface CallLoadJavaWebServices {
   /**
    * Java method that calls the call_upgrade_and_start method defined in the {@code call_load_java_web_services.rb} script.

--- a/server/sonar-server/src/main/java/org/sonar/server/ruby/RackBridge.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/ruby/RackBridge.java
@@ -24,6 +24,7 @@ import org.jruby.Ruby;
 /**
  * Acts as a bridge between the Java application of the platform and the Rack application.
  */
+@FunctionalInterface
 public interface RackBridge {
   /**
    * Provides access to {@link Ruby} runtime instance created by the Rack application.

--- a/server/sonar-server/src/main/java/org/sonar/server/rule/CommonRuleDefinitions.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/rule/CommonRuleDefinitions.java
@@ -21,6 +21,7 @@ package org.sonar.server.rule;
 
 import org.sonar.api.server.rule.RulesDefinition;
 
+@FunctionalInterface
 public interface CommonRuleDefinitions {
   void define(RulesDefinition.Context context);
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/search/ws/BaseMapping.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/search/ws/BaseMapping.java
@@ -90,6 +90,7 @@ public abstract class BaseMapping<DOC extends BaseDoc, CTX> {
     return this;
   }
 
+  @FunctionalInterface
   public interface Mapper<DOC extends BaseDoc, CTX> {
     void write(JsonWriter json, DOC doc, CTX context);
   }

--- a/sonar-core/src/main/java/org/sonar/core/issue/tracking/Tracker.java
+++ b/sonar-core/src/main/java/org/sonar/core/issue/tracking/Tracker.java
@@ -87,6 +87,7 @@ public class Tracker<RAW extends Trackable, BASE extends Trackable> {
   private interface SearchKey {
   }
 
+  @FunctionalInterface
   private interface SearchKeyFactory {
     SearchKey create(Trackable trackable);
   }

--- a/sonar-core/src/main/java/org/sonar/core/util/UuidFactory.java
+++ b/sonar-core/src/main/java/org/sonar/core/util/UuidFactory.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.core.util;
 
+@FunctionalInterface
 public interface UuidFactory {
 
   /**

--- a/sonar-db/src/main/java/org/sonar/db/activity/ActivityMapper.java
+++ b/sonar-db/src/main/java/org/sonar/db/activity/ActivityMapper.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.db.activity;
 
+@FunctionalInterface
 public interface ActivityMapper {
 
   void insert(ActivityDto dto);

--- a/sonar-db/src/main/java/org/sonar/db/charset/SqlExecutor.java
+++ b/sonar-db/src/main/java/org/sonar/db/charset/SqlExecutor.java
@@ -57,7 +57,8 @@ public class SqlExecutor {
     }
   }
 
-  public interface RowConverter<T> {
+  @FunctionalInterface
+    public interface RowConverter<T> {
     T convert(ResultSet rs) throws SQLException;
   }
 

--- a/sonar-db/src/main/java/org/sonar/db/version/MassUpdate.java
+++ b/sonar-db/src/main/java/org/sonar/db/version/MassUpdate.java
@@ -27,6 +27,7 @@ import org.sonar.db.Database;
 
 public class MassUpdate {
 
+  @FunctionalInterface
   public interface Handler {
     /**
      * Convert some column values of a given row.

--- a/sonar-db/src/main/java/org/sonar/db/version/MigrationStep.java
+++ b/sonar-db/src/main/java/org/sonar/db/version/MigrationStep.java
@@ -25,6 +25,7 @@ import java.sql.SQLException;
  * Java alternative of ActiveRecord::Migration. Do not forget to declare implementation classes in {@link MigrationStepModule}
  * @since 3.7
  */
+@FunctionalInterface
 public interface MigrationStep {
 
   void execute() throws SQLException;

--- a/sonar-db/src/main/java/org/sonar/db/version/Select.java
+++ b/sonar-db/src/main/java/org/sonar/db/version/Select.java
@@ -126,6 +126,7 @@ public interface Select extends SqlStatement<Select> {
     }
   }
 
+  @FunctionalInterface
   interface RowReader<T> {
     T read(Row row) throws SQLException;
   }
@@ -154,6 +155,7 @@ public interface Select extends SqlStatement<Select> {
 
   RowReader<String> STRING_READER = new StringReader();
 
+  @FunctionalInterface
   interface RowHandler {
     void handle(Row row) throws SQLException;
   }

--- a/sonar-db/src/main/java/org/sonar/db/version/v53/Migration53Mapper.java
+++ b/sonar-db/src/main/java/org/sonar/db/version/v53/Migration53Mapper.java
@@ -24,6 +24,7 @@ import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.Select;
 
+@FunctionalInterface
 public interface Migration53Mapper {
 
   /**

--- a/sonar-duplications/src/main/java/net/sourceforge/pmd/cpd/Tokenizer.java
+++ b/sonar-duplications/src/main/java/net/sourceforge/pmd/cpd/Tokenizer.java
@@ -47,6 +47,7 @@ import java.io.IOException;
  * @since 2.2
  * @deprecated since 5.5
  */
+@FunctionalInterface
 @Deprecated
 public interface Tokenizer {
 

--- a/sonar-home/src/main/java/org/sonar/home/cache/FileCache.java
+++ b/sonar-home/src/main/java/org/sonar/home/cache/FileCache.java
@@ -69,6 +69,7 @@ public class FileCache {
     return null;
   }
 
+  @FunctionalInterface
   public interface Downloader {
     void download(String filename, File toFile) throws IOException;
   }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/CheckProject.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/CheckProject.java
@@ -25,6 +25,7 @@ import org.sonar.api.resources.Project;
  * @since 1.10
  * @deprecated since 5.6
  */
+@FunctionalInterface
 @Deprecated
 public interface CheckProject {
 

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/PostJob.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/PostJob.java
@@ -31,6 +31,7 @@ import org.sonar.api.resources.Project;
  * @since 1.10
  * @deprecated since 5.6 use org.sonar.api.batch.postjob.PostJob
  */
+@FunctionalInterface
 @Deprecated
 @BatchSide
 @ExtensionPoint

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/ResourceFilter.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/ResourceFilter.java
@@ -31,6 +31,7 @@ import org.sonar.api.resources.Resource;
  * @since 1.12
  * @deprecated since 4.2. Analysis is file-system oriented. See {@link org.sonar.api.batch.fs.InputFileFilter}
  */
+@FunctionalInterface
 @Deprecated
 @BatchSide
 @ExtensionPoint

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/bootstrap/ProjectBuilder.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/bootstrap/ProjectBuilder.java
@@ -44,6 +44,7 @@ public abstract class ProjectBuilder {
    * Plugins can use the implementation {@link org.sonar.api.batch.bootstrap.internal.ProjectBuilderContext}
    * for their unit tests.
    */
+  @FunctionalInterface
   public interface Context {
     ProjectReactor projectReactor();
   }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/bootstrap/ProjectKey.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/bootstrap/ProjectKey.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.api.batch.bootstrap;
 
+@FunctionalInterface
 public interface ProjectKey {
   String get();
 }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/FilePredicate.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/FilePredicate.java
@@ -25,6 +25,7 @@ package org.sonar.api.batch.fs;
  * and {@link org.sonar.api.batch.fs.FilePredicates}.
  * @since 4.2
  */
+@FunctionalInterface
 public interface FilePredicate {
   /**
    * Test if provided file is valid for this predicate

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/InputFileFilter.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/InputFileFilter.java
@@ -26,6 +26,7 @@ import org.sonar.api.ExtensionPoint;
  * Extension point to exclude some files from inspection
  * @since 4.2
  */
+@FunctionalInterface
 @BatchSide
 @ExtensionPoint
 public interface InputFileFilter {

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/internal/FileMetadata.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/internal/FileMetadata.java
@@ -364,6 +364,7 @@ public class FileMetadata {
     }
   }
 
+  @FunctionalInterface
   public interface LineHashConsumer {
 
     void consume(int lineIdx, @Nullable byte[] hash);

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/scm/BlameCommand.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/scm/BlameCommand.java
@@ -63,6 +63,7 @@ public abstract class BlameCommand {
   /**
    * Callback for the provider to report results of blame per file.
    */
+  @FunctionalInterface
   public interface BlameOutput {
 
     /**

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/Issue.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/sensor/issue/Issue.java
@@ -32,6 +32,7 @@ import org.sonar.api.rule.RuleKey;
  */
 public interface Issue {
 
+  @FunctionalInterface
   interface Flow {
     /**
      * @return Ordered list of locations for the execution flow

--- a/sonar-plugin-api/src/main/java/org/sonar/api/issue/condition/Condition.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/issue/condition/Condition.java
@@ -25,6 +25,7 @@ import org.sonar.api.issue.Issue;
 /**
  * @since 3.6
  */
+@FunctionalInterface
 @Beta
 public interface Condition {
 

--- a/sonar-plugin-api/src/main/java/org/sonar/api/measures/MeasuresFilter.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/measures/MeasuresFilter.java
@@ -25,6 +25,7 @@ import java.util.Collection;
  * @since 1.10
  * @deprecated since 5.6. Sensor should only save measures and not read them.
  */
+@FunctionalInterface
 @Deprecated
 public interface MeasuresFilter<M> {
 

--- a/sonar-plugin-api/src/main/java/org/sonar/api/measures/Metrics.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/measures/Metrics.java
@@ -30,6 +30,7 @@ import org.sonar.api.server.ServerSide;
  * This is the extension point used by plugins to declare new metrics.
  * @since 1.10
  */
+@FunctionalInterface
 @BatchSide
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
 @ServerSide

--- a/sonar-plugin-api/src/main/java/org/sonar/api/platform/ServerStartHandler.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/platform/ServerStartHandler.java
@@ -26,6 +26,7 @@ import org.sonar.api.server.ServerSide;
 /**
  * @since 2.2
  */
+@FunctionalInterface
 @ServerSide
 @ComputeEngineSide
 @ExtensionPoint

--- a/sonar-plugin-api/src/main/java/org/sonar/api/platform/ServerStopHandler.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/platform/ServerStopHandler.java
@@ -26,6 +26,7 @@ import org.sonar.api.server.ServerSide;
 /**
  * @since 2.2
  */
+@FunctionalInterface
 @ServerSide
 @ComputeEngineSide
 @ExtensionPoint

--- a/sonar-plugin-api/src/main/java/org/sonar/api/scan/issue/filter/IssueFilter.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/scan/issue/filter/IssueFilter.java
@@ -22,6 +22,7 @@ package org.sonar.api.scan.issue.filter;
 import org.sonar.api.ExtensionPoint;
 import org.sonar.api.batch.BatchSide;
 
+@FunctionalInterface
 @BatchSide
 @ExtensionPoint
 /**

--- a/sonar-plugin-api/src/main/java/org/sonar/api/scan/issue/filter/IssueFilterChain.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/scan/issue/filter/IssueFilterChain.java
@@ -29,6 +29,7 @@ package org.sonar.api.scan.issue.filter;
  * 
  * @since 5.3
  */
+@FunctionalInterface
 public interface IssueFilterChain {
   /**
    * Called by a filter to let downstream filters decide the fate of the issue

--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/ws/Definable.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/ws/Definable.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.api.server.ws;
 
+@FunctionalInterface
 public interface Definable<T> {
 
   void define(T context);

--- a/sonar-plugin-api/src/main/java/org/sonar/api/server/ws/RequestHandler.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/server/ws/RequestHandler.java
@@ -27,6 +27,7 @@ import org.sonar.api.server.ServerSide;
  * @since 4.2
  * @see WebService
  */
+@FunctionalInterface
 @ServerSide
 @ExtensionPoint
 public interface RequestHandler {

--- a/sonar-plugin-api/src/main/java/org/sonar/api/task/Task.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/task/Task.java
@@ -26,6 +26,7 @@ import org.sonar.api.batch.InstantiationStrategy;
  * Implement this interface to provide the behavior of a task.
  * @since 3.6
  */
+@FunctionalInterface
 @BatchSide
 @InstantiationStrategy(InstantiationStrategy.PER_TASK)
 public interface Task {

--- a/sonar-plugin-api/src/main/java/org/sonar/api/utils/StaxParser.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/utils/StaxParser.java
@@ -135,6 +135,7 @@ public class StaxParser {
   /**
    * Simple interface for handling XML stream to parse
    */
+  @FunctionalInterface
   public interface XmlStreamHandler {
     void stream(SMHierarchicCursor rootCursor) throws XMLStreamException;
   }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/utils/ZipUtils.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/utils/ZipUtils.java
@@ -209,6 +209,7 @@ public final class ZipUtils {
     }
   }
 
+  @FunctionalInterface
   public interface ZipEntryFilter {
     boolean accept(ZipEntry entry);
   }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/utils/command/StreamConsumer.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/utils/command/StreamConsumer.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.api.utils.command;
 
+@FunctionalInterface
 public interface StreamConsumer {
 
   void consumeLine(String line);

--- a/sonar-plugin-api/src/main/java/org/sonar/api/web/Footer.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/web/Footer.java
@@ -25,6 +25,7 @@ import org.sonar.api.server.ServerSide;
 /**
  * @since 1.10
  */
+@FunctionalInterface
 @ServerSide
 @ExtensionPoint
 public interface Footer {

--- a/sonar-plugin-api/src/main/java/org/sonar/api/web/Webservice.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/web/Webservice.java
@@ -28,6 +28,7 @@ import org.sonar.api.server.ServerSide;
  * @since 1.11
  * @deprecated in 4.2. Replaced by {@link org.sonar.api.server.ws.WebService}
  */
+@FunctionalInterface
 @Deprecated
 @ServerSide
 @ExtensionPoint

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/bootstrap/ExtensionMatcher.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/bootstrap/ExtensionMatcher.java
@@ -24,6 +24,7 @@ import org.sonar.api.batch.BatchSide;
 /**
  * @since 3.6
  */
+@FunctionalInterface
 @BatchSide
 public interface ExtensionMatcher {
   boolean accept(Object extension);

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/issue/IssueCallback.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/issue/IssueCallback.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.batch.issue;
 
+@FunctionalInterface
 public interface IssueCallback {
   void execute();
 }

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/issue/tracking/ServerLineHashesLoader.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/issue/tracking/ServerLineHashesLoader.java
@@ -21,6 +21,7 @@ package org.sonar.batch.issue.tracking;
 
 import org.sonar.api.batch.BatchSide;
 
+@FunctionalInterface
 @BatchSide
 public interface ServerLineHashesLoader {
 

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/mediumtest/ScanTaskObserver.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/mediumtest/ScanTaskObserver.java
@@ -23,6 +23,7 @@ import org.sonar.api.batch.BatchSide;
 import org.sonar.api.ExtensionPoint;
 import org.sonar.batch.scan.ProjectScanContainer;
 
+@FunctionalInterface
 @BatchSide
 @ExtensionPoint
 public interface ScanTaskObserver {

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/report/CoveragePublisher.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/report/CoveragePublisher.java
@@ -133,6 +133,7 @@ public class CoveragePublisher implements ReportPublisherStep {
     }
   }
 
+  @FunctionalInterface
   interface MeasureOperation {
     void apply(String value, LineCoverage.Builder builder);
   }

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/report/ReportPublisherStep.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/report/ReportPublisherStep.java
@@ -24,6 +24,7 @@ import org.sonar.scanner.protocol.output.ScannerReportWriter;
 /**
  * Adds a sub-part of data to output report
  */
+@FunctionalInterface
 public interface ReportPublisherStep {
 
   void publish(ScannerReportWriter writer);

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/repository/GlobalRepositoriesLoader.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/repository/GlobalRepositoriesLoader.java
@@ -21,6 +21,7 @@ package org.sonar.batch.repository;
 
 import org.sonar.scanner.protocol.input.GlobalRepositories;
 
+@FunctionalInterface
 public interface GlobalRepositoriesLoader {
   GlobalRepositories load();
 }

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/repository/ProjectRepositoriesLoader.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/repository/ProjectRepositoriesLoader.java
@@ -20,6 +20,7 @@
 package org.sonar.batch.repository;
 
 
+@FunctionalInterface
 public interface ProjectRepositoriesLoader {
   ProjectRepositories load(String projectKeyWithBranch, boolean issuesMode);
 }

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/repository/ServerIssuesLoader.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/repository/ServerIssuesLoader.java
@@ -22,6 +22,7 @@ package org.sonar.batch.repository;
 import com.google.common.base.Function;
 import org.sonar.scanner.protocol.input.ScannerInput.ServerIssue;
 
+@FunctionalInterface
 public interface ServerIssuesLoader {
 
   void load(String componentKey, Function<ServerIssue, Void> consumer);

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/rule/ActiveRulesLoader.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/rule/ActiveRulesLoader.java
@@ -21,6 +21,7 @@ package org.sonar.batch.rule;
 
 import java.util.List;
 
+@FunctionalInterface
 public interface ActiveRulesLoader {
   List<LoadedActiveRule> load(String qualityProfileKey);
 }

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/rule/RulesLoader.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/rule/RulesLoader.java
@@ -22,6 +22,7 @@ package org.sonar.batch.rule;
 import java.util.List;
 import org.sonarqube.ws.Rules.ListResponse.Rule;
 
+@FunctionalInterface
 public interface RulesLoader {
   List<Rule> load();
 }

--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/scan/report/Reporter.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/scan/report/Reporter.java
@@ -21,6 +21,7 @@ package org.sonar.batch.scan.report;
 
 import org.sonar.api.batch.BatchSide;
 
+@FunctionalInterface
 @BatchSide
 public interface Reporter {
 

--- a/sonar-ws/src/main/java/org/sonarqube/ws/client/WsClientFactory.java
+++ b/sonar-ws/src/main/java/org/sonarqube/ws/client/WsClientFactory.java
@@ -24,6 +24,7 @@ package org.sonarqube.ws.client;
  *
  * @since 5.5
  */
+@FunctionalInterface
 public interface WsClientFactory {
 
   WsClient newClient(WsConnector connector);


### PR DESCRIPTION
Hi,

I am sending to you an automatic correction to add the @FunctionalInterface annotation in interfaces that only contains one method. If it is too much to verify, let me know how would you like to proceed. For example: per module. 

According to the nemo project, it should reduce 2 hours approximately of technical debt :)