### PR TITLE
PropsBuilder respects property "sonar.path.home" if it is set

### DIFF
--- a/sonar-application/src/main/java/org/sonar/application/PropsBuilder.java
+++ b/sonar-application/src/main/java/org/sonar/application/PropsBuilder.java
@@ -28,6 +28,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.sonar.process.ConfigurationUtils;
 import org.sonar.process.ProcessProperties;
 import org.sonar.process.Props;
@@ -70,6 +71,14 @@ class PropsBuilder {
   }
 
   static File detectHomeDir() throws URISyntaxException {
+    String homeProp = System.getProperty(ProcessProperties.PATH_HOME, "");
+    if (!StringUtils.isEmpty(homeProp)) {
+      File homeDir = new File((homeProp));
+      if (homeDir.exists() && homeDir.isDirectory()) {
+        return homeDir;
+      }
+    }
+
     File appJar = new File(PropsBuilder.class.getProtectionDomain().getCodeSource().getLocation().toURI());
     return appJar.getParentFile().getParentFile();
   }

--- a/sonar-application/src/test/java/org/sonar/application/PropsBuilderTest.java
+++ b/sonar-application/src/test/java/org/sonar/application/PropsBuilderTest.java
@@ -21,6 +21,7 @@ package org.sonar.application;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import org.apache.commons.io.FileUtils;
@@ -28,13 +29,14 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.sonar.process.ProcessProperties;
 import org.sonar.process.Props;
 
+import static junit.framework.TestCase.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class PropsBuilderTest {
-
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -92,8 +94,15 @@ public class PropsBuilderTest {
   }
 
   @Test
-  public void detectHomeDir() throws Exception {
-    assertThat(PropsBuilder.detectHomeDir()).isDirectory().exists();
+  public void detectHomeDir_uses_CodeSource_when_PATH_HOME_is_not_set() throws Exception {
+    File expected = new File(PropsBuilder.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile();
+    assertEquals(expected, PropsBuilder.detectHomeDir());
+  }
 
+  @Test
+  public void detectHomeDir_uses_PATH_HOME_when_it_is_set() throws Exception {
+    System.setProperty(ProcessProperties.PATH_HOME, homeDir.getAbsolutePath());
+
+    assertEquals(homeDir, PropsBuilder.detectHomeDir());
   }
 }


### PR DESCRIPTION
I'm trying to divide my sonarqube-install in such a way that the libraries etc. which do not change and all data and configuration are kept in separate directories (e.g. app/sonarqube and work/sonarqube). 

This is not possible right now because PropsBuilder#detectHome() does not respect the property "sonar.path.home" but uses a path relative to the location of the libraries.