### PR TITLE
SONAR-7857 Update to use of Update Center 1.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
   </distributionManagement>
 
   <properties>
-    <sonarUpdateCenter.version>1.13</sonarUpdateCenter.version>
+    <sonarUpdateCenter.version>1.15.1</sonarUpdateCenter.version>
     <sonarJava.version>3.13.1</sonarJava.version>
     <sonarJavaScript.version>2.11</sonarJavaScript.version>
     <sonarCSharp.version>5.0</sonarCSharp.version>
@@ -465,7 +465,7 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.sonar</groupId>
+        <groupId>org.sonarsource.update-center</groupId>
         <artifactId>sonar-update-center-common</artifactId>
         <version>${sonarUpdateCenter.version}</version>
       </dependency>

--- a/server/sonar-server/pom.xml
+++ b/server/sonar-server/pom.xml
@@ -88,7 +88,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.sonar</groupId>
+      <groupId>org.sonarsource.update-center</groupId>
       <artifactId>sonar-update-center-common</artifactId>
     </dependency>
     <dependency>

--- a/sonar-core/pom.xml
+++ b/sonar-core/pom.xml
@@ -44,7 +44,7 @@
       <artifactId>sonar-plugin-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.sonar</groupId>
+      <groupId>org.sonarsource.update-center</groupId>
       <artifactId>sonar-update-center-common</artifactId>
     </dependency>
 


### PR DESCRIPTION
The use of 1.15.1 will bring a couple of bug fixes, it does not require any change on SQ.

The group-id of the UpdateCenter artifact has changed by v1.15.