### PR TITLE
SONAR-3321 Fix bug in file rename algorithm

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/computation/filemove/FileMoveDetectionStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/filemove/FileMoveDetectionStep.java
@@ -150,7 +150,8 @@ public class FileMoveDetectionStep implements ComputationStep {
 
   private Map<String, DbComponent> getDbFilesByKey() {
     try (DbSession dbSession = dbClient.openSession(false)) {
-      // FIXME no need to use such a complex query, joining on SNAPSHOTS and retrieving all column of table PROJECTS, replace with dedicated mapper method
+      // FIXME no need to use such a complex query, joining on SNAPSHOTS and retrieving all column of table PROJECTS, replace with dedicated
+      // mapper method
       return from(dbClient.componentDao().selectDescendants(
         dbSession,
         ComponentTreeQuery.builder()
@@ -251,15 +252,15 @@ public class FileMoveDetectionStep implements ComputationStep {
       }
 
       List<Match> matchesToValidate = electedMatches.filter(matches);
-      if (matches.isEmpty()) {
+      if (matchesToValidate.isEmpty()) {
         continue;
       }
-      if (matches.size() == 1) {
+      if (matchesToValidate.size() == 1) {
         Match match = matches.get(0);
         electedMatches.add(match);
       } else {
         matchesPerFileForScore.clear();
-        for (Match match : matches) {
+        for (Match match : matchesToValidate) {
           matchesPerFileForScore.put(match.getDbKey(), match);
           matchesPerFileForScore.put(match.getReportKey(), match);
         }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/filemove/MatchesByScore.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/filemove/MatchesByScore.java
@@ -60,7 +60,8 @@ abstract class MatchesByScore implements Iterable<List<Match>> {
         return;
       }
 
-      int index = score - MIN_REQUIRED_SCORE;
+      // Store higher score first so that iterator get higher score first
+      int index = scoreMatrix.getMaxScore() - score;
       if (matches[index] == null) {
         matches[index] = new ArrayList<>(1);
       }
@@ -68,7 +69,6 @@ abstract class MatchesByScore implements Iterable<List<Match>> {
       matches[index].add(match);
       totalMatches++;
     }
-
 
     private static boolean isAcceptableScore(int score) {
       return score >= MIN_REQUIRED_SCORE;

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/filemove/MutableMovedFilesRepositoryImpl.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/filemove/MutableMovedFilesRepositoryImpl.java
@@ -39,7 +39,7 @@ public class MutableMovedFilesRepositoryImpl implements MutableMovedFilesReposit
 
     OriginalFile existingOriginalFile = originalFiles.get(file.getKey());
     checkState(existingOriginalFile == null || existingOriginalFile.equals(originalFile),
-      "Original file %s already registered for file %s", existingOriginalFile, file);
+      "Original file %s already registered for file %s. Unable to register %s.", existingOriginalFile, file, originalFile);
     if (existingOriginalFile == null) {
       originalFiles.put(file.getKey(), originalFile);
     }

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/filemove/MatchesByScoreTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/filemove/MatchesByScoreTest.java
@@ -66,14 +66,14 @@ public class MatchesByScoreTest {
 
     assertThat(matchesByScore.getSize()).isEqualTo(2);
     assertThat(Lists.newArrayList(matchesByScore)).isEqualTo(Arrays.asList(
-      ImmutableList.of(new Match("C", "1")), // 85
+      ImmutableList.of(new Match("A", "1")), // 92
       NO_MATCH,
       NO_MATCH,
       NO_MATCH,
       NO_MATCH,
       NO_MATCH,
       NO_MATCH,
-      ImmutableList.of(new Match("A", "1")) // 92
+      ImmutableList.of(new Match("C", "1")) // 85
     ));
   }
 

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1235_add_component_uuid_to_duplications_index.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1235_add_component_uuid_to_duplications_index.rb
@@ -1,0 +1,29 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class AddComponentUuidToDuplicationsIndex < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.AddComponentUuidColumnToDuplicationsIndex')
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1236_populate_component_uuid_of_duplications_index.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1236_populate_component_uuid_of_duplications_index.rb
@@ -1,0 +1,29 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class PopulateComponentUuidOfDuplicationsIndex < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.PopulateComponentUuidOfDuplicationsIndex')
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1237_delete_orphan_duplications_index_rows_without_component.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1237_delete_orphan_duplications_index_rows_without_component.rb
@@ -1,0 +1,29 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class DeleteOrphanDuplicationsIndexRowsWithoutComponent < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.DeleteOrphanDuplicationsIndexRowsWithoutComponent')
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1238_make_component_uuid_not_null_on_duplications_index.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1238_make_component_uuid_not_null_on_duplications_index.rb
@@ -1,0 +1,29 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class MakeComponentUuidNotNullOnDuplicationsIndex < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.MakeComponentUuidNotNullOnDuplicationsIndex')
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1239_add_analysis_uuid_to_duplications_index.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1239_add_analysis_uuid_to_duplications_index.rb
@@ -1,0 +1,29 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class AddAnalysisUuidToDuplicationsIndex < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.AddAnalysisUuidColumnToDuplicationsIndex')
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1240_populate_analysis_uuid_of_duplications_index.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1240_populate_analysis_uuid_of_duplications_index.rb
@@ -1,0 +1,29 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class PopulateAnalysisUuidOfDuplicationsIndex < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.PopulateAnalysisUuidOfDuplicationsIndex')
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1241_delete_orphan_duplications_index_rows_without_analysis.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1241_delete_orphan_duplications_index_rows_without_analysis.rb
@@ -1,0 +1,29 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class DeleteOrphanDuplicationsIndexRowsWithoutAnalysis < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.DeleteOrphanDuplicationsIndexRowsWithoutAnalysis')
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1242_make_analysis_uuid_not_null_on_duplications_index.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/1242_make_analysis_uuid_not_null_on_duplications_index.rb
@@ -1,0 +1,31 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class MakeAnalysisUuidNotNullOnDuplicationsIndex < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.MakeAnalysisUuidNotNullOnDuplicationsIndex')
+
+    add_index :duplications_index, [:analysis_uuid, :component_uuid], :name => 'duplication_analysis_component'
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/AddAnalysisUuidColumnToDuplicationsIndex.java
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/AddAnalysisUuidColumnToDuplicationsIndex.java
@@ -1,0 +1,45 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.db.version.v60;
+
+import java.sql.SQLException;
+import org.sonar.db.Database;
+import org.sonar.db.version.AddColumnsBuilder;
+import org.sonar.db.version.DdlChange;
+
+import static org.sonar.db.version.VarcharColumnDef.UUID_VARCHAR_SIZE;
+import static org.sonar.db.version.VarcharColumnDef.newVarcharColumnDefBuilder;
+
+public class AddAnalysisUuidColumnToDuplicationsIndex extends DdlChange {
+
+  private static final String TABLE_DUPLICATIONS_INDEX = "duplications_index";
+
+  public AddAnalysisUuidColumnToDuplicationsIndex(Database db) {
+    super(db);
+  }
+
+  @Override
+  public void execute(Context context) throws SQLException {
+    context.execute(new AddColumnsBuilder(getDatabase().getDialect(), TABLE_DUPLICATIONS_INDEX)
+      .addColumn(newVarcharColumnDefBuilder().setColumnName("analysis_uuid").setLimit(UUID_VARCHAR_SIZE).setIsNullable(true).build())
+      .build());
+  }
+
+}

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/AddComponentUuidColumnToDuplicationsIndex.java
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/AddComponentUuidColumnToDuplicationsIndex.java
@@ -1,0 +1,46 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.db.version.v60;
+
+import java.sql.SQLException;
+import org.sonar.db.Database;
+import org.sonar.db.version.AddColumnsBuilder;
+import org.sonar.db.version.DdlChange;
+
+import static org.sonar.db.version.VarcharColumnDef.UUID_VARCHAR_SIZE;
+import static org.sonar.db.version.VarcharColumnDef.newVarcharColumnDefBuilder;
+
+public class AddComponentUuidAndAnalysisUuidColumnToDuplicationsIndex extends DdlChange {
+
+  private static final String TABLE_PUBLICATIONS_INDEX = "duplications_index";
+
+  public AddComponentUuidAndAnalysisUuidColumnToDuplicationsIndex(Database db) {
+    super(db);
+  }
+
+  @Override
+  public void execute(Context context) throws SQLException {
+    context.execute(new AddColumnsBuilder(getDatabase().getDialect(), TABLE_PUBLICATIONS_INDEX)
+      .addColumn(newVarcharColumnDefBuilder().setColumnName("component_uuid").setLimit(UUID_VARCHAR_SIZE).setIsNullable(true).build())
+      .addColumn(newVarcharColumnDefBuilder().setColumnName("analysis_uuid").setLimit(UUID_VARCHAR_SIZE).setIsNullable(true).build())
+      .build());
+  }
+
+}

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/DeleteOrphanDuplicationsIndexRowsWithoutComponent.java
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/DeleteOrphanDuplicationsIndexRowsWithoutComponent.java
@@ -1,0 +1,45 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.db.version.v60;
+
+import java.sql.SQLException;
+import org.sonar.db.Database;
+import org.sonar.db.version.BaseDataChange;
+import org.sonar.db.version.MassUpdate;
+
+public class DeleteOrphanDuplicationsIndexRowsWithoutComponent extends BaseDataChange {
+
+  public DeleteOrphanDuplicationsIndexRowsWithoutComponent(Database db) {
+    super(db);
+  }
+
+  @Override
+  public void execute(Context context) throws SQLException {
+    MassUpdate massUpdate = context.prepareMassUpdate();
+    massUpdate.select("SELECT id from duplications_index where component_uuid is null");
+    massUpdate.update("DELETE from duplications_index WHERE id=?");
+    massUpdate.rowPluralName("resources_index entries");
+    massUpdate.execute((row, update) -> {
+      update.setLong(1, row.getLong(1));
+      return true;
+    });
+  }
+
+}

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/MakeComponentUuidNotNullOnDuplicationsIndex.java
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v1/MakeComponentUuidNotNullOnDuplicationsIndex.java
@@ -1,0 +1,45 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.db.version.v60;
+
+import java.sql.SQLException;
+import org.sonar.db.Database;
+import org.sonar.db.version.AlterColumnsBuilder;
+import org.sonar.db.version.DdlChange;
+
+import static org.sonar.db.version.VarcharColumnDef.UUID_VARCHAR_SIZE;
+import static org.sonar.db.version.VarcharColumnDef.newVarcharColumnDefBuilder;
+
+public class MakeComponentUuidNotNullOnDuplicationsIndex extends DdlChange {
+
+  private static final String TABLE_DUPLICATIONS_INDEX = "duplications_index";
+
+  public MakeComponentUuidNotNullOnDuplicationsIndex(Database db) {
+    super(db);
+  }
+
+  @Override
+  public void execute(Context context) throws SQLException {
+    context.execute(new AlterColumnsBuilder(getDatabase().getDialect(), TABLE_DUPLICATIONS_INDEX)
+      .updateColumn(newVarcharColumnDefBuilder().setColumnName("component_uuid").setLimit(UUID_VARCHAR_SIZE).setIsNullable(false).build())
+      .build());
+  }
+
+}

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/1235_add_component_uuid_and_analysis_uuid_to_duplications_index.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/1235_add_component_uuid_and_analysis_uuid_to_duplications_index.rb
@@ -1,0 +1,29 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class AddComponentUuidAndAnalysisUuidToDuplicationsIndex < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.AddComponentUuidAndAnalysisUuidColumnToDuplicationsIndex')
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/1236_populate_component_uuid_and_analysis_uuid_of_duplications_index.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/1236_populate_component_uuid_and_analysis_uuid_of_duplications_index.rb
@@ -1,0 +1,29 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class PopulateComponentUuidAndAnalysisUuidOfDuplicationsIndex < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.PopulateComponentUuidAndAnalysisUuidOfDuplicationsIndex')
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/1237_delete_orphan_duplications_index_rows_without_component_or_analysis.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/1237_delete_orphan_duplications_index_rows_without_component_or_analysis.rb
@@ -1,0 +1,29 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class DeleteOrphanDuplicationsIndexRowsWithoutComponentOrAnalysis < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.DeleteOrphanDuplicationsIndexRowsWithoutComponentOrAnalysis')
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/1238_make_component_uuid_and_analysis_uuid_not_null_on_duplications_index.rb
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/1238_make_component_uuid_and_analysis_uuid_not_null_on_duplications_index.rb
@@ -1,0 +1,31 @@
+#
+# SonarQube, open source software quality management tool.
+# Copyright (C) 2008-2014 SonarSource
+# mailto:contact AT sonarsource DOT com
+#
+# SonarQube is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# SonarQube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# SonarQube 6.0
+#
+class MakeComponentUuidAndAnalysisUuidNotNullOnDuplicationsIndex < ActiveRecord::Migration
+
+  def self.up
+    execute_java_migration('org.sonar.db.version.v60.MakeComponentUuidAndAnalysisUuidNotNullOnDuplicationsIndex')
+
+    add_index :duplications_index, [:analysis_uuid, :component_uuid], :name => 'duplication_analysis_component'
+  end
+end

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/AddComponentUuidAndAnalysisUuidColumnToDuplicationsIndex.java
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/AddComponentUuidAndAnalysisUuidColumnToDuplicationsIndex.java
@@ -1,0 +1,45 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.db.version.v60;
+
+import java.sql.SQLException;
+import org.sonar.db.Database;
+import org.sonar.db.version.AddColumnsBuilder;
+import org.sonar.db.version.DdlChange;
+
+import static org.sonar.db.version.VarcharColumnDef.UUID_VARCHAR_SIZE;
+import static org.sonar.db.version.VarcharColumnDef.newVarcharColumnDefBuilder;
+
+public class AddComponentUuidColumnToDuplicationsIndex extends DdlChange {
+
+  private static final String TABLE_PUBLICATIONS_INDEX = "duplications_index";
+
+  public AddComponentUuidColumnToDuplicationsIndex(Database db) {
+    super(db);
+  }
+
+  @Override
+  public void execute(Context context) throws SQLException {
+    context.execute(new AddColumnsBuilder(getDatabase().getDialect(), TABLE_PUBLICATIONS_INDEX)
+      .addColumn(newVarcharColumnDefBuilder().setColumnName("component_uuid").setLimit(UUID_VARCHAR_SIZE).setIsNullable(true).build())
+      .build());
+  }
+
+}

--- a/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/MakeComponentUuidAndAnalysisUuidNotNullOnDuplicationsIndex.java
+++ b/server/sonar-server/src/test/resources/org/sonar/server/computation/filemove/FileMoveDetectionStepTest/v2/MakeComponentUuidAndAnalysisUuidNotNullOnDuplicationsIndex.java
@@ -1,0 +1,46 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.db.version.v60;
+
+import java.sql.SQLException;
+import org.sonar.db.Database;
+import org.sonar.db.version.AlterColumnsBuilder;
+import org.sonar.db.version.DdlChange;
+
+import static org.sonar.db.version.VarcharColumnDef.UUID_VARCHAR_SIZE;
+import static org.sonar.db.version.VarcharColumnDef.newVarcharColumnDefBuilder;
+
+public class MakeComponentUuidAndAnalysisUuidNotNullOnDuplicationsIndex extends DdlChange {
+
+  private static final String TABLE_DUPLICATIONS_INDEX = "duplications_index";
+
+  public MakeComponentUuidAndAnalysisUuidNotNullOnDuplicationsIndex(Database db) {
+    super(db);
+  }
+
+  @Override
+  public void execute(Context context) throws SQLException {
+    context.execute(new AlterColumnsBuilder(getDatabase().getDialect(), TABLE_DUPLICATIONS_INDEX)
+      .updateColumn(newVarcharColumnDefBuilder().setColumnName("component_uuid").setLimit(UUID_VARCHAR_SIZE).setIsNullable(false).build())
+      .updateColumn(newVarcharColumnDefBuilder().setColumnName("analysis_uuid").setLimit(UUID_VARCHAR_SIZE).setIsNullable(false).build())
+      .build());
+  }
+
+}


### PR DESCRIPTION
* Real technical bug causing the error was that matches
were not properly filtered so that a file that was already
matched could be matched again
* This also allowed to spot a functional bug: matches candidates were
processed in ascending score order. Means that lowest score got highest priority.