### PR TITLE
do not send an overriden language if none is configured locally

### DIFF
--- a/server/sonar-web/src/main/js/helpers/l10n.js
+++ b/server/sonar-web/src/main/js/helpers/l10n.js
@@ -66,7 +66,11 @@ export function requestMessages () {
   }
 
   const bundleTimestamp = localStorage.getItem('l10n.timestamp');
-  const params = { locale: currentLocale };
+  if (currentLocale)
+    const params = { locale: currentLocale };
+  else
+    const params = {}
+
   if (bundleTimestamp !== null) {
     params.ts = bundleTimestamp;
   }


### PR DESCRIPTION
If the browser does not have any language configured
`window.navigator.languages == []` and
`window.navigator.language == ""`.
(at least on FF)
In this case an empty GET parameter is submitted to `/api/l10n/index?locale=`.
This leads to a 400 Bad Request response and no language data.
Therefore the navbar has no UI elements and is unusable, make login impossible.

*Note*: This is untested and probably not the most pretty fix. However it shows the issue.