### PR TITLE
SONAR-7896 set env var TMPDIR to make JRuby use SQ tmp dir for tmp files

### DIFF
--- a/sonar-application/src/main/java/org/sonar/application/App.java
+++ b/sonar-application/src/main/java/org/sonar/application/App.java
@@ -92,6 +92,8 @@ public class App implements Stoppable {
       .addJavaOptions(props.nonNullValue(ProcessProperties.WEB_JAVA_ADDITIONAL_OPTS))
       // required for logback tomcat valve
       .setEnvVariable(ProcessProperties.PATH_LOGS, props.nonNullValue(ProcessProperties.PATH_LOGS))
+      // ensure JRuby uses SQ's temp directory as temp directory (eg. for temp files used during HTTP uploads)
+      .setEnvVariable("TMPDIR", props.nonNullValue(ProcessProperties.PATH_TEMP))
       .setClassName("org.sonar.server.app.WebServer")
       .setArguments(props.rawProperties())
       .addClasspath("./lib/common/*")

--- a/sonar-application/src/test/java/org/sonar/application/AppTest.java
+++ b/sonar-application/src/test/java/org/sonar/application/AppTest.java
@@ -35,6 +35,7 @@ import org.sonar.process.monitor.JavaCommand;
 import org.sonar.process.monitor.Monitor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -107,6 +108,21 @@ public class AppTest {
     verify(monitor).start(argument.capture());
 
     assertThat(argument.getValue().get(1).getClasspath()).contains("oracle/ojdbc6.jar");
+  }
+
+  @Test
+  public void sets_TMPDIR_env_var_of_Web_process() throws Exception {
+    Monitor monitor = mock(Monitor.class);
+    App app = new App(monitor);
+    Props props = initDefaultProps();
+    String expectedTmpDir = "expected tmp dir";
+    props.set("sonar.path.temp", expectedTmpDir);
+    app.start(props);
+
+    ArgumentCaptor<List<JavaCommand>> argument = newJavaCommandArgumentCaptor();
+    verify(monitor).start(argument.capture());
+
+    assertThat(argument.getValue().get(1).getEnvVariables()).contains(entry("TMPDIR", expectedTmpDir));
   }
 
   private Props initDefaultProps() throws IOException {


### PR DESCRIPTION
these temp file are especially used when uploading