### PR TITLE
SONAR-8039 Return invalid server id when no server id generated and license not set to "*"

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/license/ws/ListAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/license/ws/ListAction.java
@@ -161,7 +161,9 @@ public class ListAction implements WsAction {
       if (licenseServerId != null) {
         licenseBuilder.setServerId(licenseServerId);
       }
-      if (!Objects.equals(ALL_SERVERS_VALUE, licenseServerId) && serverId.isPresent() && !serverId.get().equals(licenseServerId)) {
+      boolean isValidServerId = Objects.equals(licenseServerId, ALL_SERVERS_VALUE)
+        || (serverId.isPresent() && Objects.equals(licenseServerId, serverId.get()));
+      if (!isValidServerId) {
         licenseBuilder.setInvalidServerId(true);
       }
     }

--- a/server/sonar-server/src/test/java/org/sonar/server/license/ws/ListActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/license/ws/ListActionTest.java
@@ -191,6 +191,19 @@ public class ListActionTest {
   }
 
   @Test
+  public void return_bad_server_id_when_server_has_no_server_id() throws Exception {
+    setUserAsSystemAdmin();
+    addLicenseSetting(LICENSE_KEY_SAMPLE, LICENSE_NAME_SAMPLE,
+      createBase64License(ORGANISATION_SAMPLE, PRODUCT_SAMPLE, SERVER_ID_SAMPLE, EXPIRATION_SAMPLE, TYPE_SAMPLE, Collections.emptyMap()));
+
+    ListWsResponse result = executeRequest();
+
+    assertThat(result.getLicensesList()).hasSize(1);
+    Licenses.License license = result.getLicenses(0);
+    assertThat(license.getInvalidServerId()).isTrue();
+  }
+
+  @Test
   public void does_not_return_invalid_server_id_when_all_servers_accepted_and_no_server_id_setting() throws Exception {
     setUserAsSystemAdmin();
     addLicenseSetting(LICENSE_KEY_SAMPLE, LICENSE_NAME_SAMPLE,


### PR DESCRIPTION
SONAR-8039 Return invalid server id when no server id generated and license not set to "*"