### PR TITLE
SONAR-7973 Do not return error 500 when email sending is failing

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/notification/email/EmailNotificationChannel.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/notification/email/EmailNotificationChannel.java
@@ -217,7 +217,7 @@ public class EmailNotificationChannel extends NotificationChannel {
       emailMessage.setMessage(message);
       send(emailMessage);
     } catch (EmailException e) {
-      LOG.error("Fail to send test email to: " + toAddress, e);
+      LOG.debug("Fail to send test email to: " + toAddress, e);
       throw e;
     }
   }

--- a/server/sonar-server/src/test/java/org/sonar/server/email/ws/SendActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/email/ws/SendActionTest.java
@@ -21,18 +21,24 @@
 package org.sonar.server.email.ws;
 
 import javax.annotation.Nullable;
+import org.apache.commons.mail.EmailException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sonar.api.server.ws.WebService;
 import org.sonar.core.permission.GlobalPermissions;
+import org.sonar.server.exceptions.BadRequestException;
 import org.sonar.server.exceptions.ForbiddenException;
+import org.sonar.server.exceptions.Message;
 import org.sonar.server.notification.email.EmailNotificationChannel;
 import org.sonar.server.tester.UserSessionRule;
 import org.sonar.server.ws.TestRequest;
 import org.sonar.server.ws.WsActionTester;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.sonar.core.permission.GlobalPermissions.SYSTEM_ADMIN;
@@ -89,6 +95,24 @@ public class SendActionTest {
     expectedException.expect(ForbiddenException.class);
 
     ws.newRequest().execute();
+  }
+
+  @Test
+  public void fail_with_BadRequestException_when_EmailException_is_generated() throws Exception {
+    setUserAsSystemAdmin();
+    IllegalArgumentException exception1 = new IllegalArgumentException("root cause");
+    IllegalArgumentException exception2 = new IllegalArgumentException("parent cause", exception1);
+    IllegalArgumentException exception3 = new IllegalArgumentException("child cause", exception2);
+    EmailException emailException = new EmailException("last message", exception3);
+    doThrow(emailException).when(emailNotificationChannel).sendTestEmail(anyString(), anyString(), anyString());
+
+    try {
+      executeRequest("john@doo.com", "Test Message from SonarQube", "This is a test message from SonarQube at http://localhost:9000");
+      fail();
+    } catch (BadRequestException e) {
+      assertThat(e.errors().messages()).extracting(Message::getKey).containsExactly(
+        "root cause", "parent cause", "child cause", "last message");
+    }
   }
 
   @Test


### PR DESCRIPTION
SONAR-7973 Do not return error 500 when email sending is failing