### PR TITLE
SONAR-7816 Measures on new lines should always be computed but only when SCM is available

### DIFF
--- a/it/it-tests/src/test/java/it/dbCleaner/PurgeTest.java
+++ b/it/it-tests/src/test/java/it/dbCleaner/PurgeTest.java
@@ -115,10 +115,10 @@ public class PurgeTest {
     // must be a different date, else a single snapshot is kept per day
     scan(PROJECT_SAMPLE_PATH, DateFormatUtils.ISO_DATE_FORMAT.format(today));
 
-    int newMeasuresOnTrk = 56;
-    int newMeasuresOnBrc = 292;
-    int newMeasuresOnDir = 48;
-    int newMeasuresOnFil = 4;
+    int newMeasuresOnTrk = 55;
+    int newMeasuresOnBrc = 286;
+    int newMeasuresOnDir = 44;
+    int newMeasuresOnFil = 0;
 
     assertMeasuresCountForQualifier("TRK", measuresOnTrk + newMeasuresOnTrk);
     assertMeasuresCountForQualifier("BRC", measuresOnBrc + newMeasuresOnBrc);
@@ -129,7 +129,7 @@ public class PurgeTest {
     collector.checkThat(
       "Wrong number of measure of new_ metrics",
       count("project_measures, metrics where metrics.id = project_measures.metric_id and metrics.name like 'new_%'"),
-      equalTo(136));
+      equalTo(121));
 
     // added measures relate to project and new_* metrics
     expectedMeasures += newMeasuresOnTrk + newMeasuresOnBrc + newMeasuresOnDir + newMeasuresOnFil;

--- a/it/it-tests/src/test/java/it/measureHistory/DifferentialPeriodsTest.java
+++ b/it/it-tests/src/test/java/it/measureHistory/DifferentialPeriodsTest.java
@@ -19,24 +19,35 @@
  */
 package it.measureHistory;
 
+import com.google.common.collect.ImmutableMap;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.locator.FileLocation;
 import it.Category1Suite;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.sonar.wsclient.services.Measure;
 import org.sonar.wsclient.services.Resource;
 import org.sonar.wsclient.services.ResourceQuery;
+import org.sonarqube.ws.WsMeasures;
+import org.sonarqube.ws.client.WsClient;
+import org.sonarqube.ws.client.measure.ComponentWsRequest;
 import pageobjects.Navigation;
-import util.ItUtils;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.apache.commons.lang.time.DateUtils.addDays;
 import static org.assertj.core.api.Assertions.assertThat;
 import static util.ItUtils.formatDate;
+import static util.ItUtils.newAdminWsClient;
+import static util.ItUtils.resetPeriods;
 import static util.ItUtils.runProjectAnalysis;
 import static util.ItUtils.setServerProperty;
 
@@ -45,24 +56,24 @@ public class DifferentialPeriodsTest {
   static final String PROJECT_KEY = "sample";
   static final String MULTI_MODULE_PROJECT_KEY = "com.sonarsource.it.samples:multi-modules-sample";
 
+  static WsClient CLIENT;
+
   @ClassRule
   public static final Orchestrator orchestrator = Category1Suite.ORCHESTRATOR;
+
+  @BeforeClass
+  public static void createWsClient() throws Exception {
+    CLIENT = newAdminWsClient(orchestrator);
+  }
 
   @Before
   public void cleanUpAnalysisData() {
     orchestrator.resetData();
   }
 
-  @Before
-  public void initPeriods() throws Exception {
-    setServerProperty(orchestrator, "sonar.timemachine.period1", "previous_analysis");
-    setServerProperty(orchestrator, "sonar.timemachine.period2", "previous_analysis");
-    setServerProperty(orchestrator, "sonar.timemachine.period3", "previous_analysis");
-  }
-
   @After
-  public void resetPeriods() throws Exception {
-    ItUtils.resetPeriods(orchestrator);
+  public void reset() throws Exception {
+    resetPeriods(orchestrator);
   }
 
   /**
@@ -71,6 +82,9 @@ public class DifferentialPeriodsTest {
   @Test
   public void ensure_differential_period_4_and_5_defined_at_project_level_is_taken_into_account() throws Exception {
     orchestrator.getServer().provisionProject(PROJECT_KEY, PROJECT_KEY);
+    setServerProperty(orchestrator, "sonar.timemachine.period1", "previous_analysis");
+    setServerProperty(orchestrator, "sonar.timemachine.period2", "previous_analysis");
+    setServerProperty(orchestrator, "sonar.timemachine.period3", "previous_analysis");
     setServerProperty(orchestrator, PROJECT_KEY, "sonar.timemachine.period4", "30");
     setServerProperty(orchestrator, PROJECT_KEY, "sonar.timemachine.period5", "previous_analysis");
 
@@ -95,8 +109,7 @@ public class DifferentialPeriodsTest {
     runProjectAnalysis(orchestrator, "shared/xoo-sample");
 
     newTechnicalDebt = orchestrator.getServer().getWsClient().find(
-      ResourceQuery.createForMetrics("sample:src/main/xoo/sample/Sample.xoo", "new_technical_debt").setIncludeTrends(true)
-      );
+      ResourceQuery.createForMetrics("sample:src/main/xoo/sample/Sample.xoo", "new_technical_debt").setIncludeTrends(true));
 
     // No variation => measure is purged
     assertThat(newTechnicalDebt).isNull();
@@ -148,22 +161,78 @@ public class DifferentialPeriodsTest {
     orchestrator.getServer().associateProjectToQualityProfile(MULTI_MODULE_PROJECT_KEY, "xoo", "empty");
     runProjectAnalysis(orchestrator, "shared/xoo-multi-modules-sample",
       "sonar.projectDate", formatDate(addDays(new Date(), -60)),
-      "sonar.modules", "module_a"
-    );
+      "sonar.modules", "module_a");
 
     // Second analysis, 20 days ago, issues will be created
     orchestrator.getServer().restoreProfile(FileLocation.ofClasspath("/measureHistory/one-issue-per-line-profile.xml"));
     orchestrator.getServer().associateProjectToQualityProfile(MULTI_MODULE_PROJECT_KEY, "xoo", "one-issue-per-line");
     runProjectAnalysis(orchestrator, "shared/xoo-multi-modules-sample",
       "sonar.projectDate", formatDate(addDays(new Date(), -20)),
-      "sonar.modules", "module_a,module_b"
-    );
+      "sonar.modules", "module_a,module_b");
 
     // Variation on module b should exist
     Resource ncloc = orchestrator.getServer().getWsClient()
       .find(ResourceQuery.createForMetrics(MULTI_MODULE_PROJECT_KEY + ":module_b", "ncloc").setIncludeTrends(true));
     List<Measure> measures = ncloc.getMeasures();
     assertThat(measures.get(0).getVariation1()).isEqualTo(24);
+  }
+
+  @Test
+  public void compute_no_new_lines_measures_when_changes_but_no_scm() throws Exception {
+    orchestrator.getServer().provisionProject(MULTI_MODULE_PROJECT_KEY, MULTI_MODULE_PROJECT_KEY);
+    setServerProperty(orchestrator, MULTI_MODULE_PROJECT_KEY, "sonar.timemachine.period1", "previous_analysis");
+
+    // Execute an analysis 60 days ago without module b
+    orchestrator.getServer().associateProjectToQualityProfile(MULTI_MODULE_PROJECT_KEY, "xoo", "empty");
+    runProjectAnalysis(orchestrator, "shared/xoo-multi-modules-sample",
+      "sonar.projectDate", formatDate(addDays(new Date(), -60)),
+      "sonar.modules", "module_a");
+
+    // Second analysis, 20 days ago
+    orchestrator.getServer().restoreProfile(FileLocation.ofClasspath("/measureHistory/one-issue-per-line-profile.xml"));
+    orchestrator.getServer().associateProjectToQualityProfile(MULTI_MODULE_PROJECT_KEY, "xoo", "one-issue-per-line");
+    runProjectAnalysis(orchestrator, "shared/xoo-multi-modules-sample",
+      "sonar.projectDate", formatDate(addDays(new Date(), -20)),
+      "sonar.modules", "module_a,module_b");
+
+    // No new lines measure
+    assertNoMeasures(MULTI_MODULE_PROJECT_KEY, "new_lines", "new_lines_to_cover");
+  }
+
+  @Test
+  public void compute_zero_new_lines_measures_when_no_changes_and_scm_available() throws Exception {
+    String projectKey = "sample-scm";
+    orchestrator.getServer().provisionProject(projectKey, projectKey);
+    setServerProperty(orchestrator, projectKey, "sonar.timemachine.period1", "previous_analysis");
+
+    // Execute an analysis 60 days ago
+    runProjectAnalysis(orchestrator, "scm/xoo-sample-with-scm", "sonar.projectDate", formatDate(addDays(new Date(), -60)),
+      "sonar.scm.provider", "xoo", "sonar.scm.disabled", "false");
+
+    // Second analysis, 20 days ago
+    runProjectAnalysis(orchestrator, "scm/xoo-sample-with-scm", "sonar.projectDate", formatDate(addDays(new Date(), -20)),
+      "sonar.scm.provider", "xoo", "sonar.scm.disabled", "false");
+
+    // New lines measures is zero
+    assertMeasures(projectKey, ImmutableMap.of("new_lines", 0, "new_lines_to_cover", 0));
+  }
+
+  private void assertMeasures(String projectKey, Map<String, Integer> expectedMeasures) {
+    WsMeasures.ComponentWsResponse response = CLIENT.measures().component(new ComponentWsRequest()
+      .setComponentKey(projectKey)
+      .setMetricKeys(new ArrayList<>(expectedMeasures.keySet()))
+      .setAdditionalFields(singletonList("periods")));
+    Map<String, Integer> measures = response.getComponent().getMeasuresList().stream()
+      .collect(Collectors.toMap(WsMeasures.Measure::getMetric, m -> Integer.parseInt(m.getPeriods().getPeriodsValue(0).getValue())));
+    assertThat(measures).isEqualTo(expectedMeasures);
+  }
+
+  private void assertNoMeasures(String projectKey, String... metrics) {
+    WsMeasures.ComponentWsResponse response = CLIENT.measures().component(new ComponentWsRequest()
+      .setComponentKey(projectKey)
+      .setMetricKeys(asList(metrics))
+      .setAdditionalFields(singletonList("periods")));
+    assertThat(response.getComponent().getMeasuresList()).isEmpty();
   }
 
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/step/NewCoverageMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/step/NewCoverageMeasuresStep.java
@@ -375,11 +375,14 @@ public class NewCoverageMeasuresStep implements ComputationStep {
       }
       ScmInfo componentScm = scmInfoOptional.get();
 
-      Optional<Measure> hitsByLineMeasure = context.getMeasure(metricKeys.getCoverageLineHitsData());
-      if (!hitsByLineMeasure.isPresent() || hitsByLineMeasure.get().getValueType() == Measure.ValueType.NO_VALUE) {
-        return;
-      }
+      context.getPeriods().forEach(period -> {
+        newLines.increment(period, 0);
+        newCoveredLines.increment(period, 0);
+        newConditions.increment(period, 0);
+        newCoveredConditions.increment(period, 0);
+      });
 
+      Optional<Measure> hitsByLineMeasure = context.getMeasure(metricKeys.getCoverageLineHitsData());
       Map<Integer, Integer> hitsByLine = parseCountByLine(hitsByLineMeasure);
       Map<Integer, Integer> conditionsByLine = parseCountByLine(context.getMeasure(metricKeys.getConditionsByLine()));
       Map<Integer, Integer> coveredConditionsByLine = parseCountByLine(context.getMeasure(metricKeys.getCoveredConditionsByLine()));

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/step/NewSizeMeasuresStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/step/NewSizeMeasuresStep.java
@@ -123,16 +123,17 @@ public class NewSizeMeasuresStep implements ComputationStep {
     @Override
     public void initialize(CounterInitializationContext context) {
       Component leaf = context.getLeaf();
+      Optional<ScmInfo> scmInfo = scmInfoRepository.getScmInfo(leaf);
+      if (!scmInfo.isPresent()) {
+        return;
+      }
+
       context.getPeriods().forEach(period -> newLines.increment(period, 0));
       if (leaf.getType() != Component.Type.FILE) {
         context.getPeriods().forEach(period -> {
           newDuplicatedLines.increment(period, 0);
           newDuplicatedBlocks.increment(period, 0);
         });
-        return;
-      }
-      Optional<ScmInfo> scmInfo = scmInfoRepository.getScmInfo(leaf);
-      if (!scmInfo.isPresent()) {
         return;
       }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/NewSizeMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/NewSizeMeasuresStepTest.java
@@ -126,10 +126,10 @@ public class NewSizeMeasuresStepTest {
 
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(FILE_1_REF, NEW_LINES_KEY, 11);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(FILE_2_REF, NEW_LINES_KEY, 11);
-    assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(FILE_3_REF, NEW_LINES_KEY, 0);
+    assertNoRawMeasure(FILE_3_REF, NEW_LINES_KEY);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(FILE_4_REF, NEW_LINES_KEY, 11);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(DIRECTORY_REF, NEW_LINES_KEY, 22);
-    assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(DIRECTORY_2_REF, NEW_LINES_KEY, 0);
+    assertNoRawMeasure(DIRECTORY_2_REF, NEW_LINES_KEY);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(SUB_MODULE_1_REF, NEW_LINES_KEY, 22);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(SUB_MODULE_2_REF, NEW_LINES_KEY, 11);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(MODULE_REF, NEW_LINES_KEY, 33);
@@ -137,17 +137,10 @@ public class NewSizeMeasuresStepTest {
   }
 
   @Test
-  public void compute_new_lines_with_no_changeset() {
+  public void does_not_compute_new_lines_when_no_changeset() {
     underTest.execute();
 
-    assertComputedAndAggregatedToZeroInt(NEW_LINES_KEY);
-  }
-
-  @Test
-  public void compute_new_lines_with_no_ncloc_data() {
-    underTest.execute();
-
-    assertComputedAndAggregatedToZeroInt(NEW_LINES_KEY);
+    assertNoRawMeasures(NEW_LINES_KEY);
   }
 
   @Test
@@ -235,7 +228,7 @@ public class NewSizeMeasuresStepTest {
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(FILE_3_REF, NEW_DUPLICATED_LINES_KEY, 9d);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(FILE_4_REF, NEW_DUPLICATED_LINES_KEY, 11d);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(DIRECTORY_REF, NEW_DUPLICATED_LINES_KEY, 2d);
-    assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(DIRECTORY_2_REF, NEW_DUPLICATED_LINES_KEY, 0d);
+    assertNoRawMeasure(DIRECTORY_2_REF, NEW_DUPLICATED_LINES_KEY);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(SUB_MODULE_1_REF, NEW_DUPLICATED_LINES_KEY, 2d);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(SUB_MODULE_2_REF, NEW_DUPLICATED_LINES_KEY, 20d);
     assertRawMeasureValueOnPeriod2AndZeroOnPeriod5(MODULE_REF, NEW_DUPLICATED_LINES_KEY, 22d);

--- a/server/sonar-web/src/main/js/apps/overview/main/Coverage.js
+++ b/server/sonar-web/src/main/js/apps/overview/main/Coverage.js
@@ -137,7 +137,7 @@ class Coverage extends React.Component {
         <span>—</span>
     );
 
-    const label = newLinesToCoverValue != null ? (
+    const label = (newLinesToCoverValue != null && newLinesToCoverValue > 0) ? (
         <div className="overview-domain-measure-label">
           {translate('overview.coverage_on')}
           <br/>

--- a/server/sonar-web/src/main/js/apps/overview/main/Duplications.js
+++ b/server/sonar-web/src/main/js/apps/overview/main/Duplications.js
@@ -98,7 +98,7 @@ class Duplications extends React.Component {
         <span>—</span>
     );
 
-    const label = newLinesValue != null ? (
+    const label = (newLinesValue != null && newLinesValue > 0) ? (
         <div className="overview-domain-measure-label">
           {translate('overview.duplications_on')}
           <br/>


### PR DESCRIPTION
SONAR-7816 Measures on new lines should always be computed but only when SCM is available