### PR TITLE
DB related fixes for 5.6.3

### DIFF
--- a/sonar-db/src/main/java/org/sonar/db/source/FileSourceDao.java
+++ b/sonar-db/src/main/java/org/sonar/db/source/FileSourceDao.java
@@ -97,7 +97,9 @@ public class FileSourceDao implements Dao {
       rs = pstmt.executeQuery();
       if (rs.next()) {
         reader = rs.getCharacterStream(1);
-        function.apply(reader);
+        if (reader != null) {
+          function.apply(reader);
+        }
       }
     } catch (SQLException e) {
       throw new IllegalStateException("Fail to read FILE_SOURCES.LINE_HASHES of file " + fileUuid, e);

--- a/sonar-db/src/main/java/org/sonar/db/source/FileSourceDao.java
+++ b/sonar-db/src/main/java/org/sonar/db/source/FileSourceDao.java
@@ -26,6 +26,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import org.apache.commons.dbutils.DbUtils;
@@ -70,7 +71,11 @@ public class FileSourceDao implements Dao {
       pstmt.setString(2, Type.SOURCE);
       rs = pstmt.executeQuery();
       if (rs.next()) {
-        return END_OF_LINE_SPLITTER.splitToList(rs.getString(1));
+        String string = rs.getString(1);
+        if (string == null) {
+          return Collections.emptyList();
+        }
+        return END_OF_LINE_SPLITTER.splitToList(string);
       }
       return null;
     } catch (SQLException e) {

--- a/sonar-db/src/main/java/org/sonar/db/version/v51/FeedFileSourcesBinaryData.java
+++ b/sonar-db/src/main/java/org/sonar/db/version/v51/FeedFileSourcesBinaryData.java
@@ -32,6 +32,7 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.utils.DateUtils;
 import org.sonar.db.Database;
 import org.sonar.db.protobuf.DbFileSources;
@@ -147,7 +148,9 @@ public class FeedFileSourcesBinaryData extends BaseDataChange {
       }
       return FileSourceDto.encodeSourceData(dataBuilder.build());
     } catch (Exception e) {
-      throw new IllegalStateException("Invalid FILE_SOURCES.DATA on row with ID " + fileSourceId + ": " + data, e);
+      LoggerFactory.getLogger(FeedFileSourcesBinaryData.class).error(
+        String.format("Invalid FILE_SOURCES.DATA on row with ID %s, data will be ignored: %s", fileSourceId, data), e);
+      return FileSourceDto.encodeSourceData(dataBuilder.clear().build());
     } finally {
       IOUtils.closeQuietly(parser);
     }

--- a/sonar-db/src/test/java/org/sonar/db/source/FileSourceDaoTest.java
+++ b/sonar-db/src/test/java/org/sonar/db/source/FileSourceDaoTest.java
@@ -109,6 +109,25 @@ public class FileSourceDaoTest {
   }
 
   @Test
+  public void selectLineHashes_does_not_fail_when_lineshashes_is_null() {
+
+    dbTester.prepareDbUnit(getClass(), "shared.xml");
+
+    underTest.insert(new FileSourceDto()
+        .setProjectUuid("PRJ_UUID")
+        .setFileUuid("FILE2_UUID")
+        .setBinaryData("FILE2_BINARY_DATA".getBytes())
+        .setDataHash("FILE2_DATA_HASH")
+        .setSrcHash("FILE2_HASH")
+        .setDataType(Type.SOURCE)
+        .setCreatedAt(1500000000000L)
+        .setUpdatedAt(1500000000001L)
+        .setRevision("123456789"));
+
+    assertThat(underTest.selectLineHashes(dbTester.getSession(), "FILE2_UUID")).isEmpty();
+  }
+
+  @Test
   public void update() {
     dbTester.prepareDbUnit(getClass(), "shared.xml");
 

--- a/sonar-db/src/test/java/org/sonar/db/version/v51/FeedFileSourcesBinaryDataTest.java
+++ b/sonar-db/src/test/java/org/sonar/db/version/v51/FeedFileSourcesBinaryDataTest.java
@@ -68,15 +68,18 @@ public class FeedFileSourcesBinaryDataTest {
   }
 
   @Test
-  public void fail_to_parse_csv() throws Exception {
+  public void execute_does_not_fail_when_data_can_not_be_parsed_and_row_is_ignored() throws Exception {
     db.prepareDbUnit(getClass(), "bad_data.xml");
 
     MigrationStep migration = new FeedFileSourcesBinaryData(db.database());
 
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Error during processing of row: [id=1,data=");
-
     migration.execute();
+
+    try (Connection connection = db.openConnection()) {
+      DbFileSources.Data data = selectData(connection, 1L);
+
+      assertThat(data.getLinesList()).isEmpty();
+    }
   }
 
   private DbFileSources.Data selectData(Connection connection, long fileSourceId) throws SQLException {


### PR DESCRIPTION
This fixes:
* SONAR-8148 exception proof FeedFileSourcesBinaryData
* SONAR-8185 support at DAO level of null in FILES_SOURCES.LINES_HASHES