### PR TITLE
SONAR-6724 : support analyzing root pom in multi-modules projects

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/batch/scan/filesystem/FileIndexer.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/batch/scan/filesystem/FileIndexer.java
@@ -80,10 +80,6 @@ public class FileIndexer {
   }
 
   void index(DefaultModuleFileSystem fileSystem) {
-    if (isAggregator) {
-      // No indexing for an aggregator module
-      return;
-    }
     progressReport = new ProgressReport("Report about progress of file indexation", TimeUnit.SECONDS.toMillis(10));
     progressReport.start("Index files");
     exclusionFilters.prepare();
@@ -95,7 +91,9 @@ public class FileIndexer {
     executorService = Executors.newFixedThreadPool(threads, new ThreadFactoryBuilder().setNameFormat("FileIndexer-%d").build());
     tasks = new ArrayList<>();
     indexFiles(fileSystem, progress, inputFileBuilder, fileSystem.sources(), InputFile.Type.MAIN);
-    indexFiles(fileSystem, progress, inputFileBuilder, fileSystem.tests(), InputFile.Type.TEST);
+        if (!isAggregator) {
+            indexFiles(fileSystem, progress, inputFileBuilder, fileSystem.tests(), InputFile.Type.TEST);
+        }
 
     waitForTasksToComplete();
 

--- a/sonar-scanner-engine/src/test/java/org/sonar/batch/scan/ProjectReactorBuilderTest.java
+++ b/sonar-scanner-engine/src/test/java/org/sonar/batch/scan/ProjectReactorBuilderTest.java
@@ -117,24 +117,34 @@ public class ProjectReactorBuilderTest {
 
   @Test
   public void shouldDefineMultiModuleProjectWithDefinitionsAllInRootProject() throws IOException {
-    ProjectDefinition rootProject = loadProjectDefinition("multi-module-definitions-all-in-root");
+    execMultiModule("multi-module-definitions-all-in-root");
+  }
 
+  @Test
+  public void shouldDefineMultiModuleProjectWithPomFileAtRootLevel() throws IOException {
+    ProjectDefinition project = execMultiModule("multi-module-pom-in-root");
+    assertThat(project.sources()).contains("pom.xml");
+    assertThat(project.sources()).doesNotContain("sources");
+  }
+
+  public ProjectDefinition execMultiModule(String key) throws IOException {
+    ProjectDefinition rootProject = loadProjectDefinition(key);
     // CHECK ROOT
     assertThat(rootProject.getKey()).isEqualTo("com.foo.project");
     assertThat(rootProject.getName()).isEqualTo("Foo Project");
     assertThat(rootProject.getVersion()).isEqualTo("1.0-SNAPSHOT");
     assertThat(rootProject.getDescription()).isEqualTo("Description of Foo Project");
     // root project must not contain some properties - even if they are defined in the root properties file
-    assertThat(rootProject.getSourceDirs().contains("sources")).isFalse();
-    assertThat(rootProject.getTestDirs().contains("tests")).isFalse();
+    assertThat(rootProject.sources().contains("sources")).isFalse();
+    assertThat(rootProject.tests().contains("tests")).isFalse();
     // and module properties must have been cleaned
     assertThat(rootProject.properties().get("module1.sonar.projectKey")).isNull();
     assertThat(rootProject.properties().get("module2.sonar.projectKey")).isNull();
     // Check baseDir and workDir
     assertThat(rootProject.getBaseDir().getCanonicalFile())
-      .isEqualTo(getResource(this.getClass(), "multi-module-definitions-all-in-root"));
+                                                           .isEqualTo(getResource(this.getClass(), key));
     assertThat(rootProject.getWorkDir().getCanonicalFile())
-      .isEqualTo(new File(getResource(this.getClass(), "multi-module-definitions-all-in-root"), ".sonar"));
+                                                           .isEqualTo(new File(getResource(this.getClass(), key), ".sonar"));
 
     // CHECK MODULES
     List<ProjectDefinition> modules = rootProject.getSubProjects();
@@ -142,42 +152,41 @@ public class ProjectReactorBuilderTest {
 
     // Module 1
     ProjectDefinition module1 = modules.get(0);
-    assertThat(module1.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), "multi-module-definitions-all-in-root/module1"));
+    assertThat(module1.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), key + "/module1"));
     assertThat(module1.getKey()).isEqualTo("com.foo.project:module1");
     assertThat(module1.getName()).isEqualTo("module1");
     assertThat(module1.getVersion()).isEqualTo("1.0-SNAPSHOT");
     // Description should not be inherited from parent if not set
     assertThat(module1.getDescription()).isNull();
-    assertThat(module1.getSourceDirs()).contains("sources");
-    assertThat(module1.getTestDirs()).contains("tests");
+    assertThat(module1.sources()).contains("sources");
+    assertThat(module1.tests()).contains("tests");
     assertThat(module1.getBinaries()).contains("target/classes");
     // and module properties must have been cleaned
     assertThat(module1.properties().get("module1.sonar.projectKey")).isNull();
     assertThat(module1.properties().get("module2.sonar.projectKey")).isNull();
     // Check baseDir and workDir
-    assertThat(module1.getBaseDir().getCanonicalFile())
-      .isEqualTo(getResource(this.getClass(), "multi-module-definitions-all-in-root/module1"));
-    assertThat(module1.getWorkDir().getCanonicalFile())
-      .isEqualTo(new File(getResource(this.getClass(), "multi-module-definitions-all-in-root"), ".sonar/com.foo.project_module1"));
+    assertThat(module1.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), key + "/module1"));
+    assertThat(module1.getWorkDir().getCanonicalFile()).isEqualTo(new File(getResource(this.getClass(), key), ".sonar/com.foo.project_module1"));
 
     // Module 2
     ProjectDefinition module2 = modules.get(1);
-    assertThat(module2.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), "multi-module-definitions-all-in-root/module2"));
+    assertThat(module2.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), key + "/module2"));
     assertThat(module2.getKey()).isEqualTo("com.foo.project:com.foo.project.module2");
     assertThat(module2.getName()).isEqualTo("Foo Module 2");
     assertThat(module2.getVersion()).isEqualTo("1.0-SNAPSHOT");
     assertThat(module2.getDescription()).isEqualTo("Description of Module 2");
-    assertThat(module2.getSourceDirs()).contains("src");
-    assertThat(module2.getTestDirs()).contains("tests");
+    assertThat(module2.sources()).contains("src");
+    assertThat(module2.tests()).contains("tests");
     assertThat(module2.getBinaries()).contains("target/classes");
     // and module properties must have been cleaned
     assertThat(module2.properties().get("module1.sonar.projectKey")).isNull();
     assertThat(module2.properties().get("module2.sonar.projectKey")).isNull();
     // Check baseDir and workDir
-    assertThat(module2.getBaseDir().getCanonicalFile())
-      .isEqualTo(getResource(this.getClass(), "multi-module-definitions-all-in-root/module2"));
-    assertThat(module2.getWorkDir().getCanonicalFile())
-      .isEqualTo(new File(getResource(this.getClass(), "multi-module-definitions-all-in-root"), ".sonar/com.foo.project_com.foo.project.module2"));
+    assertThat(module2.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), key + "/module2"));
+    assertThat(module2.getWorkDir().getCanonicalFile()).isEqualTo(
+        new File(getResource(this.getClass(), key), ".sonar/com.foo.project_com.foo.project.module2"));
+
+    return rootProject;
   }
 
   // SONAR-4876

--- a/sonar-scanner-engine/src/test/resources/org/sonar/batch/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module1/pom.xml
+++ b/sonar-scanner-engine/src/test/resources/org/sonar/batch/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module1/pom.xml
@@ -1,0 +1,3 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!-- This is a fake pom -->
+</project>

--- a/sonar-scanner-engine/src/test/resources/org/sonar/batch/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module1/sources/Fake.java
+++ b/sonar-scanner-engine/src/test/resources/org/sonar/batch/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module1/sources/Fake.java
@@ -1,0 +1,1 @@
+class Fake {}

--- a/sonar-scanner-engine/src/test/resources/org/sonar/batch/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module2/src/Fake.java
+++ b/sonar-scanner-engine/src/test/resources/org/sonar/batch/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module2/src/Fake.java
@@ -1,0 +1,1 @@
+class Fake {}

--- a/sonar-scanner-engine/src/test/resources/org/sonar/batch/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/pom.xml
+++ b/sonar-scanner-engine/src/test/resources/org/sonar/batch/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/pom.xml
@@ -1,0 +1,3 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!-- This is a fake pom -->
+</project>

--- a/sonar-scanner-engine/src/test/resources/org/sonar/batch/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/sonar-project.properties
+++ b/sonar-scanner-engine/src/test/resources/org/sonar/batch/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/sonar-project.properties
@@ -1,0 +1,19 @@
+sonar.projectKey=com.foo.project
+sonar.projectName=Foo Project
+sonar.projectVersion=1.0-SNAPSHOT
+sonar.projectDescription=Description of Foo Project
+
+sonar.sources=sources,pom.xml
+sonar.tests=tests
+sonar.binaries=target/classes
+
+sonar.modules=module1,\
+              module2
+
+# Mandatory properties for module1 are all inferred from the module ID
+
+module2.sonar.projectKey=com.foo.project.module2
+module2.sonar.projectName=Foo Module 2
+# redefine some properties
+module2.sonar.projectDescription=Description of Module 2
+module2.sonar.sources=src


### PR DESCRIPTION
This PR allows processing of files in aggregator modules.
When analyzing a multi-modules maven project, this allows the root pom to be indexed and analyzed.
It should also be beneficial to other project types (Gradle was mentioned in SONAR-6724).
This only applies to files, not folders : SONARPLUGINS-2295 introduced a warning for existing folders referenced in property sonar.sources of aggregator modules : it will still be displayed, and these folders will still be ignored.
