### PR TITLE
Do not throw UnsupportedOperationException when httpRequest.getSession(false) is called

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/platform/web/RootFilter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/platform/web/RootFilter.java
@@ -147,6 +147,9 @@ public class RootFilter implements Filter {
 
     @Override
     public HttpSession getSession(boolean create) {
+      if (!create) {
+        return null;
+      }
       throw notSupported();
     }
 


### PR DESCRIPTION
When httpRequest.getSession(false) is called, the callers does not ask to create a http session.
(javadoc of HttpServletRequest: "If create is false and the request has no valid HttpSession, this method returns null.")

So throwing UnsupportedOperationException is not needed in this case and returning null is enough.

This will fix a [blocking issue](https://github.com/javamelody/sonar-javamelody/issues/4) in the [Sonar JavaMelody plugin](https://github.com/javamelody/javamelody/wiki/UserGuide#sonar-plugin).