### PR TITLE
Added support for mariadb

### DIFF
--- a/sonar-db/src/main/java/org/sonar/db/DatabaseChecker.java
+++ b/sonar-db/src/main/java/org/sonar/db/DatabaseChecker.java
@@ -45,6 +45,7 @@ public class DatabaseChecker implements Startable {
     // MsSQL 2014 is 12.x
     // https://support.microsoft.com/en-us/kb/321185
     MsSql.ID, Version.create(11, 0, 0),
+    MsSql.ID, Version.create(10, 0, 0),
     MySql.ID, Version.create(5, 6, 0),
     Oracle.ID, Version.create(11, 0, 0),
     PostgreSql.ID, Version.create(8, 0, 0));


### PR DESCRIPTION
I have an exception with Mariadb about 
```
org.sonar.api.utils.MessageException: Unsupported mysql version: 5.5. Minimal supported version is 5.6.
```

This should help...