### PR TITLE
Fix maths in sonar.properties

### DIFF
--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -57,7 +57,7 @@
 # at the same time, or negative for no limit.
 # The recommended value is 1.2 * max sizes of HTTP pools. For example if HTTP ports are
 # enabled with default sizes (50, see property sonar.web.http.maxThreads)
-# then sonar.jdbc.maxActive should be 1.2 * (50) = 120.
+# then sonar.jdbc.maxActive should be 1.2 * 50 = 60.
 #sonar.jdbc.maxActive=60
 
 # The maximum number of connections that can remain idle in the


### PR DESCRIPTION
Maths are wrong since HTTPS was dropped ([PR 887](https://github.com/SonarSource/sonarqube/pull/887))
