### PR TITLE
SONAR-8314 Some rework on generic test executions report

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/bootstrap/GlobalSettings.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/bootstrap/GlobalSettings.java
@@ -54,9 +54,8 @@ public class GlobalSettings extends Settings {
   public GlobalSettings(GlobalProperties bootstrapProps, PropertyDefinitions propertyDefinitions,
     GlobalRepositories globalReferentials, GlobalMode mode) {
 
-    super(propertyDefinitions, new Encryption(null));
+    super(propertyDefinitions, new Encryption(bootstrapProps.property(CoreProperties.ENCRYPTION_SECRET_KEY_PATH)));
     this.mode = mode;
-    getEncryption().setPathToSecretKey(bootstrapProps.property(CoreProperties.ENCRYPTION_SECRET_KEY_PATH));
     this.bootstrapProps = bootstrapProps;
     this.globalReferentials = globalReferentials;
     init();

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/genericcoverage/GenericTestExecutionSensor.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/genericcoverage/GenericTestExecutionSensor.java
@@ -37,12 +37,12 @@ public class GenericTestExecutionSensor implements Sensor {
 
   private static final Logger LOG = Loggers.get(GenericTestExecutionSensor.class);
 
-  private static final String REPORT_PATHS_PROPERTY_KEY = "sonar.testExecutionReportPaths";
+  static final String REPORT_PATHS_PROPERTY_KEY = "sonar.testExecutionReportPaths";
   /**
    * @deprecated since 6.2
    */
   @Deprecated
-  private static final String OLD_UNIT_TEST_REPORT_PATHS_PROPERTY_KEY = "sonar.genericcoverage.unitTestReportPaths";
+  static final String OLD_UNIT_TEST_REPORT_PATHS_PROPERTY_KEY = "sonar.genericcoverage.unitTestReportPaths";
 
   private final TestPlanBuilder testPlanBuilder;
 
@@ -65,21 +65,24 @@ public class GenericTestExecutionSensor implements Sensor {
 
   @Override
   public void describe(SensorDescriptor descriptor) {
-    descriptor.name("Generic Tests Excution Report")
+    descriptor.name("Generic Test Executions Report")
       .requireProperty(REPORT_PATHS_PROPERTY_KEY);
   }
 
   @Override
   public void execute(SensorContext context) {
+    if (context.settings().hasKey(OLD_UNIT_TEST_REPORT_PATHS_PROPERTY_KEY)) {
+      LOG.warn("Property '{}' is deprecated. Please use '{}' instead.", OLD_UNIT_TEST_REPORT_PATHS_PROPERTY_KEY, REPORT_PATHS_PROPERTY_KEY);
+    }
     for (String reportPath : context.settings().getStringArray(REPORT_PATHS_PROPERTY_KEY)) {
       File reportFile = context.fileSystem().resolvePath(reportPath);
       LOG.info("Parsing {}", reportFile);
       GenericTestExecutionReportParser parser = new GenericTestExecutionReportParser(testPlanBuilder);
       parser.parse(reportFile, context);
-      LOG.info("Imported coverage data for {} files", parser.numberOfMatchedFiles());
+      LOG.info("Imported test execution data for {} files", parser.numberOfMatchedFiles());
       int numberOfUnknownFiles = parser.numberOfUnknownFiles();
       if (numberOfUnknownFiles > 0) {
-        LOG.info("Coverage data ignored for " + numberOfUnknownFiles + " unknown files, including:\n" + parser.firstUnknownFiles().stream().collect(Collectors.joining("\n")));
+        LOG.info("Test execution data ignored for {} unknown files, including:\n{}", numberOfUnknownFiles, parser.firstUnknownFiles().stream().collect(Collectors.joining("\n")));
       }
     }
 

--- a/sonar-scanner-engine/src/test/java/org/sonar/scanner/genericcoverage/GenericTestExecutionSensorTest.java
+++ b/sonar-scanner-engine/src/test/java/org/sonar/scanner/genericcoverage/GenericTestExecutionSensorTest.java
@@ -1,0 +1,65 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scanner.genericcoverage;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.MapSettings;
+import org.sonar.api.config.PropertyDefinitions;
+import org.sonar.api.config.Settings;
+import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.scanner.deprecated.test.TestPlanBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class GenericTestExecutionSensorTest {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Rule
+  public LogTester logTester = new LogTester();
+
+  @Test
+  public void logWhenDeprecatedPropsAreUsed() throws IOException {
+    File basedir = temp.newFolder();
+    File report = new File(basedir, "report.xml");
+    FileUtils.write(report, "<unitTest version=\"1\"><file path=\"A.java\"><testCase name=\"test1\" duration=\"500\"/></file></unitTest>");
+    SensorContextTester context = SensorContextTester.create(basedir);
+    Settings settings = new MapSettings(new PropertyDefinitions(GenericTestExecutionSensor.properties()));
+    settings.setProperty(GenericTestExecutionSensor.OLD_UNIT_TEST_REPORT_PATHS_PROPERTY_KEY, "report.xml");
+    context.setSettings(settings);
+    new GenericTestExecutionSensor(mock(TestPlanBuilder.class)).execute(context);
+    assertThat(logTester.logs(LoggerLevel.WARN)).contains(
+      "Using 'unitTest' as root element of the report is deprecated. Please change to 'testExecutions'.",
+      "Property 'sonar.genericcoverage.unitTestReportPaths' is deprecated. Please use 'sonar.testExecutionReportPaths' instead.");
+
+    assertThat(logTester.logs(LoggerLevel.INFO)).contains(
+      "Imported test execution data for 0 files",
+      "Test execution data ignored for 1 unknown files, including:\nA.java");
+  }
+}

--- a/sonar-scanner-engine/src/test/resources/mediumtest/xoo/sample-generic-test-exec/unittest.xml
+++ b/sonar-scanner-engine/src/test/resources/mediumtest/xoo/sample-generic-test-exec/unittest.xml
@@ -1,4 +1,4 @@
-<unitTest version="1">
+<testExecutions version="1">
   <file path="testx/ClassOneTest.xoo">
     <testCase name="test1" duration="5"/>
     <testCase name="test2" duration="500">
@@ -11,4 +11,4 @@
       <error message="short">stacktrace</error>
     </testCase>
   </file>
-</unitTest>
+</testExecutions>

--- a/sonar-scanner-engine/src/test/resources/mediumtest/xoo/sample-generic-test-exec/unittest2.xml
+++ b/sonar-scanner-engine/src/test/resources/mediumtest/xoo/sample-generic-test-exec/unittest2.xml
@@ -1,8 +1,8 @@
-<unitTest version="1">
+<testExecutions version="1">
   <file path="testx/ClassOneTest.xoo">
     <testCase name="test1b" duration="5"/>
     <testCase name="test2" duration="500">
       <skipped message="short message">other</skipped>
     </testCase>
   </file>
-</unitTest>
+</testExecutions>


### PR DESCRIPTION
  * show warning in case of use of deprecated props
  * deprecate root element 'unitTest' and support 'testExecutions'
  * few other minor fixes