### PR TITLE
SONAR-5857 It should only be possible to use rating metrics defined in core for quality gates

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/qualitygate/QualityGateConditionsUpdater.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/qualitygate/QualityGateConditionsUpdater.java
@@ -48,6 +48,7 @@ import static org.sonar.api.measures.Metric.ValueType.RATING;
 import static org.sonar.api.measures.Metric.ValueType.valueOf;
 import static org.sonar.db.qualitygate.QualityGateConditionDto.isOperatorAllowed;
 import static org.sonar.server.computation.task.projectanalysis.qualitymodel.RatingGrid.Rating.E;
+import static org.sonar.server.qualitygate.ValidRatingMetrics.isCoreRatingMetric;
 
 public class QualityGateConditionsUpdater {
 
@@ -186,6 +187,9 @@ public class QualityGateConditionsUpdater {
   private static void checkRatingMetric(MetricDto metric, @Nullable String warningThreshold, @Nullable String errorThreshold, @Nullable Integer period, Errors errors) {
     if (!metric.getValueType().equals(RATING.name())) {
       return;
+    }
+    if (!isCoreRatingMetric(metric.getKey())) {
+      errors.add(Message.of(format("The metric '%s' cannot be used", metric.getShortName())));
     }
     if (period != null && !metric.getKey().startsWith("new_")) {
       errors.add(Message.of(format("The metric '%s' cannot be used on the leak period", metric.getShortName())));

--- a/server/sonar-server/src/main/java/org/sonar/server/qualitygate/ValidRatingMetrics.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/qualitygate/ValidRatingMetrics.java
@@ -1,0 +1,43 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.server.qualitygate;
+
+import java.util.Set;
+import org.sonar.api.measures.CoreMetrics;
+
+import static org.sonar.api.measures.Metric.ValueType.RATING;
+import static org.sonar.core.util.stream.Collectors.toSet;
+
+public class ValidRatingMetrics {
+
+  private static final Set<String> CORE_RATING_METRICS = CoreMetrics.getMetrics().stream()
+    .filter(metric -> metric.getType().equals(RATING))
+    .map(org.sonar.api.measures.Metric::getKey)
+    .collect(toSet());
+
+  private ValidRatingMetrics() {
+    // only static methods
+  }
+
+  public static boolean isCoreRatingMetric(String metricKey) {
+    return CORE_RATING_METRICS.contains(metricKey);
+  }
+}

--- a/server/sonar-server/src/main/java/org/sonar/server/qualitygate/ws/AppAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/qualitygate/ws/AppAction.java
@@ -31,7 +31,9 @@ import org.sonar.server.user.UserSession;
 import org.sonarqube.ws.WsQualityGates.AppWsResponse.Metric;
 
 import static org.sonar.api.measures.CoreMetrics.ALERT_STATUS_KEY;
+import static org.sonar.api.measures.Metric.ValueType.RATING;
 import static org.sonar.core.permission.GlobalPermissions.QUALITY_GATE_ADMIN;
+import static org.sonar.server.qualitygate.ValidRatingMetrics.isCoreRatingMetric;
 import static org.sonar.server.ws.WsUtils.writeProtobuf;
 import static org.sonarqube.ws.WsQualityGates.AppWsResponse;
 
@@ -84,7 +86,8 @@ public class AppAction implements QualityGatesWsAction {
     DbSession dbSession = dbClient.openSession(false);
     try {
       return dbClient.metricDao().selectEnabled(dbSession).stream()
-        .filter(metric -> !metric.isDataType() && !ALERT_STATUS_KEY.equals(metric.getKey()))
+        .filter(metric -> !metric.isDataType() && !ALERT_STATUS_KEY.equals(metric.getKey()) &&
+          (!RATING.name().equals(metric.getValueType()) || isCoreRatingMetric(metric.getKey())))
         .collect(Collectors.toList());
     } finally {
       dbClient.closeSession(dbSession);


### PR DESCRIPTION
SONAR-5857 It should only be possible to use rating metrics defined in core for quality gates
