### PR TITLE
Improve start script

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,7 +12,7 @@ while getopts ":p:" opt; do
     p) PATCHES=$OPTARG
        ;;
     \?)
-      >&2 echo "Unsupported option $OPTARG"
+      echo "Unsupported option $OPTARG" >&2
       exit 1 
       ;;
   esac
@@ -24,14 +24,14 @@ else
   OS='linux-x86-64'
 fi
 
-ls sonar-application/target/sonarqube-*.zip 1> /dev/null 2>&1
+ls sonar-application/target/sonarqube-*.zip &> /dev/null
 if [ "$?" != "0" ]; then
   echo 'Sources are not built'
   ./build.sh
 fi
 
 cd sonar-application/target/
-ls sonarqube-*/bin/$OS/sonar.sh 1> /dev/null 2>&1
+ls sonarqube-*/bin/$OS/sonar.sh &> /dev/null
 if [ "$?" != "0" ]; then
   echo "Unzipping SQ..."
   unzip -qq sonarqube-*.zip

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -39,20 +39,20 @@ cd sonarqube-*
 # from that point on, strict bash
 set -euo pipefail
 SQ_HOME=$(pwd)
-cd $ROOT
+cd "$ROOT"
 
-source $ROOT/scripts/patches_utils.sh
+source "$ROOT"/scripts/patches_utils.sh
 
 SQ_EXEC=$SQ_HOME/bin/$OS/sonar.sh
 
-$SQ_EXEC stop
+"$SQ_EXEC" stop
 
 # invoke patches if at least one was specified
 # each patch is passed the path to the SQ instance home directory as first and only argument
 if [ "$PATCHES" != "" ]; then
-  call_patches $PATCHES $SQ_HOME
+  call_patches "$PATCHES" "$SQ_HOME"
 fi
 
-$SQ_EXEC start
+"$SQ_EXEC" start
 sleep 1
-tail -100f $SQ_HOME/logs/sonar.log
+tail -100f "$SQ_HOME"/logs/sonar.log

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -49,7 +49,7 @@ SQ_EXEC=$SQ_HOME/bin/$OS/sonar.sh
 
 # invoke patches if at least one was specified
 # each patch is passed the path to the SQ instance home directory as first and only argument
-if [ "$PATCHES" != "" ]; then
+if [ "$PATCHES" ]; then
   call_patches "$PATCHES" "$SQ_HOME"
 fi
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -55,4 +55,4 @@ fi
 
 "$SQ_EXEC" start
 sleep 1
-tail -100f "$SQ_HOME"/logs/sonar.log
+tail -fn 100 "$SQ_HOME"/logs/sonar.log

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -24,15 +24,13 @@ else
   OS='linux-x86-64'
 fi
 
-ls sonar-application/target/sonarqube-*.zip &> /dev/null
-if [ "$?" != "0" ]; then
+if ! ls sonar-application/target/sonarqube-*.zip &> /dev/null; then
   echo 'Sources are not built'
   ./build.sh
 fi
 
 cd sonar-application/target/
-ls sonarqube-*/bin/$OS/sonar.sh &> /dev/null
-if [ "$?" != "0" ]; then
+if ! ls sonarqube-*/bin/$OS/sonar.sh &> /dev/null; then
   echo "Unzipping SQ..."
   unzip -qq sonarqube-*.zip
 fi


### PR DESCRIPTION
* Fail early when multiple installations detected
* Double-quote variables to prevent globbing and word splitting
* Improve writing style
