### PR TITLE
SONAR-8415 Low max memory of main process can lead to OOM in log Gobbler

### DIFF
--- a/sonar-application/src/main/assembly/conf/wrapper.conf
+++ b/sonar-application/src/main/assembly/conf/wrapper.conf
@@ -19,8 +19,8 @@ wrapper.java.classpath.1=../../lib/jsw/*.jar
 wrapper.java.classpath.2=../../lib/*.jar
 wrapper.java.library.path.1=./lib
 wrapper.app.parameter.1=org.sonar.application.App
-wrapper.java.initmemory=3
-wrapper.java.maxmemory=3
+wrapper.java.initmemory=8
+wrapper.java.maxmemory=8
 
 #********************************************************************
 # Wrapper Logs


### PR DESCRIPTION
Increase memory of app process to 8MB