### PR TITLE
Add aria labels to issue rule and filter buttons in issue list.

### DIFF
--- a/server/sonar-web/src/main/js/apps/issues/templates/issues-issue-filter.hbs
+++ b/server/sonar-web/src/main/js/apps/issues/templates/issues-issue-filter.hbs
@@ -1,5 +1,5 @@
 <li class="issue-meta">
-  <button class="button-link issue-action issue-action-with-options js-issue-filter">
+  <button class="button-link issue-action issue-action-with-options js-issue-filter" aria-label="filter similar issues">
     <i class="icon-filter icon-half-transparent"></i>&nbsp;<i class="icon-dropdown"></i>
   </button>
 </li>

--- a/server/sonar-web/src/main/js/components/issue/templates/issue.hbs
+++ b/server/sonar-web/src/main/js/components/issue/templates/issue.hbs
@@ -5,7 +5,7 @@
       <td>
         <div class="issue-message">
           {{message}}&nbsp;
-          <button class="button-link js-issue-rule issue-rule icon-ellipsis-h"></button>
+          <button class="button-link js-issue-rule issue-rule icon-ellipsis-h" aria-label="rule info"></button>
         </div>
       </td>
 


### PR DESCRIPTION
Add aria labels to issue rule and filter buttons in issue list. This is required since these buttons do not have text describing what they do so are announced as "button" when using Jaws screen reading software. Note I was planning on opening up an issue on JIRA but am unable to do so. The current JIRA instance for Sonar does not appear to offer an audio captcha option, so since I am a totally blind screen reader user I am unable to create a user account.