### PR TITLE
SONAR-8416 AuthenticationException message start with upper case

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/authentication/BasicAuthenticator.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/authentication/BasicAuthenticator.java
@@ -77,7 +77,7 @@ public class BasicAuthenticator {
     if (semiColonPos <= 0) {
       throw AuthenticationException.newBuilder()
         .setSource(Source.local(Method.BASIC))
-        .setMessage("decoded basic auth does not contain ':'")
+        .setMessage("Decoded basic auth does not contain ':'")
         .build();
     }
     String login = basicAuthDecoded.substring(0, semiColonPos);

--- a/server/sonar-server/src/main/java/org/sonar/server/authentication/JwtCsrfVerifier.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/authentication/JwtCsrfVerifier.java
@@ -73,10 +73,10 @@ public class JwtCsrfVerifier {
   @CheckForNull
   private static String checkCsrf(@Nullable String csrfState, @Nullable String stateInHeader) {
     if (isBlank(csrfState)) {
-      return "missing reference CSRF value";
+      return "Missing reference CSRF value";
     }
     if (!StringUtils.equals(csrfState, stateInHeader)) {
-      return "wrong CSFR in request";
+      return "Wrong CSFR in request";
     }
     return null;
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/authentication/RealmAuthenticator.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/authentication/RealmAuthenticator.java
@@ -105,7 +105,7 @@ public class RealmAuthenticator implements Startable {
         throw AuthenticationException.newBuilder()
           .setSource(realmEventSource(method))
           .setLogin(userLogin)
-          .setMessage("realm returned authenticate=false")
+          .setMessage("Realm returned authenticate=false")
           .build();
       }
       UserDto userDto = synchronize(userLogin, details, request, method);

--- a/server/sonar-server/src/main/java/org/sonar/server/authentication/UserIdentityAuthenticator.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/authentication/UserIdentityAuthenticator.java
@@ -88,7 +88,7 @@ public class UserIdentityAuthenticator {
       throw AuthenticationException.newBuilder()
         .setSource(source)
         .setLogin(user.getLogin())
-        .setMessage("user signup disabled for provider '" + provider.getKey() + "'")
+        .setMessage("User signup disabled for provider '" + provider.getKey() + "'")
         .setPublicMessage(format("'%s' users are not allowed to sign up", provider.getKey()))
         .build();
     }
@@ -98,7 +98,7 @@ public class UserIdentityAuthenticator {
       throw AuthenticationException.newBuilder()
         .setSource(source)
         .setLogin(user.getLogin())
-        .setMessage(format("email '%s' is already used", email))
+        .setMessage(format("Email '%s' is already used", email))
         .setPublicMessage(format(
           "You can't sign up because email '%s' is already used by an existing user. This means that you probably already registered with another account.",
           email))

--- a/server/sonar-server/src/main/java/org/sonar/server/authentication/ws/LoginAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/authentication/ws/LoginAction.java
@@ -120,7 +120,7 @@ public class LoginAction extends ServletFilter implements AuthenticationWsAction
       throw AuthenticationException.newBuilder()
         .setSource(Source.local(Method.FORM))
         .setLogin(login)
-        .setMessage("empty login and/or password")
+        .setMessage("Empty login and/or password")
         .build();
     }
     return credentialsAuthenticator.authenticate(login, password, request, Method.FORM);

--- a/server/sonar-server/src/test/java/org/sonar/server/authentication/JwtCsrfVerifierTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/authentication/JwtCsrfVerifierTest.java
@@ -81,7 +81,7 @@ public class JwtCsrfVerifierTest {
     mockPostJavaWsRequest();
 
     thrown.expect(authenticationException().from(Source.local(Method.JWT)).withLogin(LOGIN).andNoPublicMessage());
-    thrown.expectMessage("wrong CSFR in request");
+    thrown.expectMessage("Wrong CSFR in request");
     underTest.verifyState(request, CSRF_STATE, LOGIN);
   }
 
@@ -91,7 +91,7 @@ public class JwtCsrfVerifierTest {
     mockPostJavaWsRequest();
 
     thrown.expect(authenticationException().from(Source.local(Method.JWT)).withLogin(LOGIN).andNoPublicMessage());
-    thrown.expectMessage("missing reference CSRF value");
+    thrown.expectMessage("Missing reference CSRF value");
     underTest.verifyState(request, null, LOGIN);
   }
 
@@ -101,7 +101,7 @@ public class JwtCsrfVerifierTest {
     mockPostJavaWsRequest();
 
     thrown.expect(authenticationException().from(Source.local(Method.JWT)).withLogin(LOGIN).andNoPublicMessage());
-    thrown.expectMessage("missing reference CSRF value");
+    thrown.expectMessage("Missing reference CSRF value");
     underTest.verifyState(request, "", LOGIN);
   }
 
@@ -112,7 +112,7 @@ public class JwtCsrfVerifierTest {
     when(request.getMethod()).thenReturn("POST");
 
     thrown.expect(authenticationException().from(Source.local(Method.JWT)).withLogin(LOGIN).andNoPublicMessage());
-    thrown.expectMessage("wrong CSFR in request");
+    thrown.expectMessage("Wrong CSFR in request");
     underTest.verifyState(request, CSRF_STATE, LOGIN);
   }
 
@@ -123,7 +123,7 @@ public class JwtCsrfVerifierTest {
     when(request.getMethod()).thenReturn("PUT");
 
     thrown.expect(authenticationException().from(Source.local(Method.JWT)).withLogin(LOGIN).andNoPublicMessage());
-    thrown.expectMessage("wrong CSFR in request");
+    thrown.expectMessage("Wrong CSFR in request");
     underTest.verifyState(request, CSRF_STATE, LOGIN);
   }
 
@@ -134,7 +134,7 @@ public class JwtCsrfVerifierTest {
     when(request.getMethod()).thenReturn("DELETE");
 
     thrown.expect(authenticationException().from(Source.local(Method.JWT)).withLogin(LOGIN).andNoPublicMessage());
-    thrown.expectMessage("wrong CSFR in request");
+    thrown.expectMessage("Wrong CSFR in request");
     underTest.verifyState(request, CSRF_STATE, LOGIN);
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/authentication/RealmAuthenticatorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/authentication/RealmAuthenticatorTest.java
@@ -256,7 +256,7 @@ public class RealmAuthenticatorTest {
     when(authenticator.doAuthenticate(any(Authenticator.Context.class))).thenReturn(false);
 
     expectedException.expect(authenticationException().from(Source.realm(BASIC, REALM_NAME)).withLogin(LOGIN).andNoPublicMessage());
-    expectedException.expectMessage("realm returned authenticate=false");
+    expectedException.expectMessage("Realm returned authenticate=false");
     try {
       underTest.authenticate(LOGIN, PASSWORD, request, BASIC);
     } finally {

--- a/server/sonar-server/src/test/java/org/sonar/server/authentication/UserIdentityAuthenticatorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/authentication/UserIdentityAuthenticatorTest.java
@@ -362,7 +362,7 @@ public class UserIdentityAuthenticatorTest {
     Source source = Source.realm(Method.FORM, identityProvider.getName());
 
     thrown.expect(authenticationException().from(source).withLogin(USER_IDENTITY.getLogin()).andPublicMessage("'github' users are not allowed to sign up"));
-    thrown.expectMessage("user signup disabled for provider 'github'");
+    thrown.expectMessage("User signup disabled for provider 'github'");
     underTest.authenticate(USER_IDENTITY, identityProvider, source);
   }
 
@@ -378,7 +378,7 @@ public class UserIdentityAuthenticatorTest {
       .withLogin(USER_IDENTITY.getLogin())
       .andPublicMessage("You can't sign up because email 'john@email.com' is already used by an existing user. " +
         "This means that you probably already registered with another account."));
-    thrown.expectMessage("email 'john@email.com' is already used");
+    thrown.expectMessage("Email 'john@email.com' is already used");
     underTest.authenticate(USER_IDENTITY, IDENTITY_PROVIDER, source);
   }
 


### PR DESCRIPTION
for consistency, all message of AuthenticationException explicitly set in code has a upper case first char.
This can't be applied when message comes from a caught exception