### PR TITLE
[RFC] create issues for decreasing coverage

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/issue/commonrule/AbstractCoverageRule.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/issue/commonrule/AbstractCoverageRule.java
@@ -49,9 +49,14 @@ public abstract class AbstractCoverageRule extends CommonRule {
   @Override
   protected CommonRuleIssue doProcessFile(Component file, ActiveRule activeRule) {
     Optional<Measure> coverageMeasure = measureRepository.getRawMeasure(file, coverageMetric);
+    Optional<Measure> baseCoverageMeasure = measureRepository.getBaseMeasure(file, coverageMetric);
+    Double baseCoverage = null;
+    if (baseCoverageMeasure.isPresent()) {
+        baseCoverage = baseCoverageMeasure.get().getDoubleValue();
+    }
     if (!file.getFileAttributes().isUnitTest() && coverageMeasure.isPresent()) {
       double coverage = coverageMeasure.get().getDoubleValue();
-      double minimumCoverage = getMinDensityParam(activeRule, minPropertyKey);
+      double minimumCoverage = getMinDensityParam(activeRule, minPropertyKey, baseCoverage);
       if (coverage < minimumCoverage) {
         return generateIssue(file, minimumCoverage);
       }

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/issue/commonrule/CommonRule.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/issue/commonrule/CommonRule.java
@@ -79,11 +79,18 @@ public abstract class CommonRule {
   }
 
   protected static double getMinDensityParam(ActiveRule activeRule, String paramKey) {
+    return getMinDensityParam(activeRule, paramKey, null);
+  }
+
+  protected static double getMinDensityParam(ActiveRule activeRule, String paramKey, Double baseValue) {
     String s = activeRule.getParams().get(paramKey);
     if (isNotBlank(s)) {
       double d = Double.parseDouble(s);
       if (d < 0.0 || d > 100.0) {
         throw new IllegalStateException(String.format("Minimum density of rule [%s] is incorrect. Got [%s] but must be between 0 and 100.", activeRule.getRuleKey(), s));
+      }
+      if (baseValue != null && d < 0.000001) {
+          d = baseValue;
       }
       return d;
     }


### PR DESCRIPTION
This is a RFC to start a discussion about a rule which triggers when the
coverage on a component decreases.

The implementation uses the magic parameter '0' to the existing coverage
rules to have a minimal impact on the existing code.
(And it does not make sense to set this parameter to '0')