### PR TITLE
Add `hasFilename` predicate with caching

### DIFF
--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/FilePredicates.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/FilePredicates.java
@@ -56,6 +56,15 @@ public interface FilePredicates {
   FilePredicate hasRelativePath(String s);
 
   /**
+   * Predicate that gets a file by its filename, in any directory.
+   * For example, the parameter <code>Foo.java</code> will match both
+   * <code>some/path/Foo.java</code> and <code>other/path/Foo.java</code>.
+   * The parameter must match exactly, no patterns are allowed,
+   * and it must not be <code>null</code>.
+   */
+  FilePredicate hasFilename(String s);
+
+  /**
    * Predicate that gets the files which relative or absolute path matches a wildcard pattern.
    * <br>
    * If the parameter starts with <code>file:</code>, then absolute path is used, else relative path. Pattern

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/FileSystem.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/FileSystem.java
@@ -165,5 +165,7 @@ public interface FileSystem {
     InputDir inputDir(String relativePath);
     
     InputModule module();
+
+    Iterable<InputFile> getFilesByName(String filename);
   }
 }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/internal/DefaultFilePredicates.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/internal/DefaultFilePredicates.java
@@ -76,6 +76,11 @@ public class DefaultFilePredicates implements FilePredicates {
   }
 
   @Override
+  public FilePredicate hasFilename(String s) {
+    return new FilenamePredicate(s);
+  }
+
+  @Override
   public FilePredicate matchesPathPattern(String inclusionPattern) {
     return new PathPatternPredicate(PathPattern.create(inclusionPattern));
   }

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/internal/DefaultFileSystem.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/internal/DefaultFileSystem.java
@@ -20,6 +20,8 @@
 package org.sonar.api.batch.fs.internal;
 
 import com.google.common.collect.Iterables;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.SetMultimap;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -264,6 +266,7 @@ public class DefaultFileSystem implements FileSystem {
     private final Map<String, InputFile> fileMap = new HashMap<>();
     private final Map<String, InputDir> dirMap = new HashMap<>();
     private InputModule module;
+    private final SetMultimap<String, InputFile> filesByNameCache = LinkedHashMultimap.create();
 
     @Override
     public Iterable<InputFile> inputFiles() {
@@ -286,8 +289,14 @@ public class DefaultFileSystem implements FileSystem {
     }
 
     @Override
+    public Iterable<InputFile> getFilesByName(String filename) {
+      return filesByNameCache.get(filename);
+    }
+
+    @Override
     protected void doAdd(InputFile inputFile) {
       fileMap.put(inputFile.relativePath(), inputFile);
+      filesByNameCache.put(inputFile.file().getName(), inputFile);
     }
 
     @Override

--- a/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/internal/FilenamePredicate.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/batch/fs/internal/FilenamePredicate.java
@@ -1,0 +1,44 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.batch.fs.internal;
+
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.fs.InputFile;
+
+/**
+ * @since 6.3
+ */
+public class FilenamePredicate extends AbstractFilePredicate {
+  private final String filename;
+
+  public FilenamePredicate(String filename) {
+    this.filename = filename;
+  }
+
+  @Override
+  public boolean apply(InputFile inputFile) {
+    return filename.equals(inputFile.file().getName());
+  }
+
+  @Override
+  public Iterable<InputFile> get(FileSystem.Index index) {
+    return index.getFilesByName(filename);
+  }
+}

--- a/sonar-plugin-api/src/test/java/org/sonar/api/batch/fs/internal/DefaultFilePredicatesTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/batch/fs/internal/DefaultFilePredicatesTest.java
@@ -214,4 +214,9 @@ public class DefaultFilePredicatesTest {
     assertThat(predicates.or(new FilePredicate[] {predicates.all(), predicates.none()}).apply(javaFile)).isTrue();
     assertThat(predicates.or(new FilePredicate[] {predicates.none(), predicates.none()}).apply(javaFile)).isFalse();
   }
+
+  @Test
+  public void hasFilename() {
+    assertThat(predicates.hasFilename("Action.java").apply(javaFile)).isTrue();
+  }
 }

--- a/sonar-plugin-api/src/test/java/org/sonar/api/batch/fs/internal/FilenamePredicateTest.java
+++ b/sonar-plugin-api/src/test/java/org/sonar/api/batch/fs/internal/FilenamePredicateTest.java
@@ -1,0 +1,65 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.api.batch.fs.internal;
+
+import java.io.IOException;
+import java.util.Collections;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.fs.InputFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class FilenamePredicateTest {
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void should_match_file_by_filename() throws IOException {
+    String filename = "some name";
+    InputFile inputFile = mock(InputFile.class);
+    when(inputFile.file()).thenReturn(temporaryFolder.newFile(filename));
+
+    assertThat(new FilenamePredicate(filename).apply(inputFile)).isTrue();
+  }
+
+  @Test
+  public void should_not_match_file_by_different_filename() throws IOException {
+    String filename = "some name";
+    InputFile inputFile = mock(InputFile.class);
+    when(inputFile.file()).thenReturn(temporaryFolder.newFile(filename + "x"));
+
+    assertThat(new FilenamePredicate(filename).apply(inputFile)).isFalse();
+  }
+
+  @Test
+  public void should_find_matching_file_in_index() throws IOException {
+    String filename = "some name";
+    InputFile inputFile = mock(InputFile.class);
+    when(inputFile.file()).thenReturn(temporaryFolder.newFile(filename));
+
+    FileSystem.Index index = mock(FileSystem.Index.class);
+    when(index.getFilesByName(filename)).thenReturn(Collections.singleton(inputFile));
+
+    assertThat(new FilenamePredicate(filename).get(index)).containsOnly(inputFile);
+  }
+}

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/InputComponentStore.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/InputComponentStore.java
@@ -19,6 +19,8 @@
  */
 package org.sonar.scanner.scan.filesystem;
 
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.SetMultimap;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,6 +49,7 @@ public class InputComponentStore {
   private final Table<String, String, InputDir> inputDirCache = TreeBasedTable.create();
   private final Map<String, InputModule> inputModuleCache = new HashMap<>();
   private final Map<String, InputComponent> inputComponents = new HashMap<>();
+  private final SetMultimap<String, InputFile> filesByNameCache = LinkedHashMultimap.create();
   private InputModule root;
 
   public Collection<InputComponent> all() {
@@ -104,6 +107,7 @@ public class InputComponentStore {
     DefaultInputFile file = (DefaultInputFile) inputFile;
     inputFileCache.put(file.moduleKey(), inputFile.relativePath(), inputFile);
     inputComponents.put(inputFile.key(), inputFile);
+    filesByNameCache.put(inputFile.file().getName(), inputFile);
     return this;
   }
 
@@ -134,4 +138,7 @@ public class InputComponentStore {
     inputModuleCache.put(inputModule.key(), inputModule);
   }
 
+  public Iterable<InputFile> getFilesByName(String filename) {
+    return filesByNameCache.get(filename);
+  }
 }

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/ModuleInputComponentStore.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/ModuleInputComponentStore.java
@@ -70,4 +70,9 @@ public class ModuleInputComponentStore extends DefaultFileSystem.Cache {
   public InputModule module() {
     return inputComponentStore.getModule(moduleKey);
   }
+
+  @Override
+  public Iterable<InputFile> getFilesByName(String filename) {
+    return inputComponentStore.getFilesByName(filename);
+  }
 }

--- a/sonar-scanner-engine/src/test/java/org/sonar/scanner/scan/filesystem/ModuleInputComponentStoreTest.java
+++ b/sonar-scanner-engine/src/test/java/org/sonar/scanner/scan/filesystem/ModuleInputComponentStoreTest.java
@@ -1,0 +1,48 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scanner.scan.filesystem;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.InputModule;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class ModuleInputComponentStoreTest {
+  @Test
+  public void should_cache_files_by_filename() throws IOException {
+    ModuleInputComponentStore store = new ModuleInputComponentStore(mock(InputModule.class), new InputComponentStore());
+
+    String filename = "some name";
+    InputFile inputFile1 = new TestInputFileBuilder("dummy key", "some/path/" + filename).build();
+    store.doAdd(inputFile1);
+
+    InputFile inputFile2 = new TestInputFileBuilder("dummy key", "other/path/" + filename).build();
+    store.doAdd(inputFile2);
+
+    InputFile dummyInputFile = new TestInputFileBuilder("dummy key", "some/path/Dummy.java").build();
+    store.doAdd(dummyInputFile);
+
+    assertThat(store.getFilesByName(filename)).containsOnly(inputFile1, inputFile2);
+  }
+}


### PR DESCRIPTION
To be merged later, not now, to `master` instead of this branch.

Let me know if this is going in the right direction. In particular, I'm not too thrilled about adding methods in `FileSystem.Index` and in `ModuleInputComponentStore` but I don't see a better solution. Let me know if I missed something.

I plan to follow the same pattern for querying by extension, so one more method in these interfaces/classes, and one more multimap.