### PR TITLE
better command line message if trying to stop without having compiled

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -8,4 +8,7 @@ else
   OS='linux-x86-64'
 fi
 
-sh sonar-application/target/sonarqube-*/bin/$OS/sonar.sh stop
+SONAR_SH=sonar-application/target/sonarqube-*/bin/$OS/sonar.sh
+if [ -f $SONAR_SH ]; then
+  sh $SONAR_SH stop
+fi


### PR DESCRIPTION
I am recompiling and starting/stopping the server all day long. The usual error message `sh: 0: Can't open sonar-application/target/sonarqube-*/bin/linux-x86-64/sonar.sh` should be replaced by a better readable, in my opinion.