### PR TITLE
SONAR-6724 : support analyzing root pom in multi-modules projects (branch-6.2)

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/ProjectReactorBuilder.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/ProjectReactorBuilder.java
@@ -48,6 +48,8 @@ import org.sonar.scanner.analysis.AnalysisProperties;
 import org.sonar.scanner.bootstrap.DroppedPropertyChecker;
 import org.sonar.scanner.util.BatchUtils;
 
+import static java.util.stream.Collectors.*;
+
 /**
  * Class that creates a project definition based on a set of properties.
  */
@@ -354,21 +356,34 @@ public class ProjectReactorBuilder {
   @VisibleForTesting
   protected static void cleanAndCheckAggregatorProjectProperties(ProjectDefinition project) {
     Map<String, String> properties = project.properties();
+    // "aggregator" project must not have tests or source folders (but can have source files at root level, such as pom.xml)
+    properties.remove(PROPERTY_TESTS);
 
-    // SONARPLUGINS-2295
-    String[] sourceDirs = getListFromProperty(properties, PROPERTY_SOURCES);
-    for (String path : sourceDirs) {
-      File sourceFolder = resolvePath(project.getBaseDir(), path);
-      if (sourceFolder.isDirectory()) {
-        LOG.warn("/!\\ A multi-module project can't have source folders, so '{}' won't be used for the analysis. " +
-          "If you want to analyse files of this folder, you should create another sub-module and move them inside it.",
-          sourceFolder.toString());
+    if (properties.containsKey(PROPERTY_SOURCES)) {
+      String[] sourceDirs = getListFromProperty(properties, PROPERTY_SOURCES);
+      String sourceFiles = Arrays.stream(sourceDirs)
+        .collect(toMap(s -> s, s -> resolvePath(project.getBaseDir(), s)))
+        .entrySet().stream()
+        .peek(ProjectReactorBuilder::warnFolderInAggregatorSources)
+        .filter(e -> e.getValue().isFile())
+        .collect(mapping(e -> e.getKey(), joining(",")));
+
+      if (StringUtils.isBlank(sourceFiles)) {
+        properties.remove(PROPERTY_SOURCES);
+      } else {
+        properties.put(PROPERTY_SOURCES, sourceFiles);
       }
     }
 
-    // "aggregator" project must not have the following properties:
-    properties.remove(PROPERTY_SOURCES);
-    properties.remove(PROPERTY_TESTS);
+  }
+
+  private static void warnFolderInAggregatorSources(Entry<String, File> sourceFolder) {
+    // SONARPLUGINS-2295
+    if (sourceFolder.getValue().isDirectory()) {
+      LOG.warn("/!\\ A multi-module project can't have source folders, so '{}' won't be used for the analysis. " +
+        "If you want to analyse files of this folder, you should create another sub-module and move them inside it.",
+        sourceFolder.toString());
+    }
   }
 
   @VisibleForTesting

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/FileIndexer.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/FileIndexer.java
@@ -82,10 +82,6 @@ public class FileIndexer {
   }
 
   void index(DefaultModuleFileSystem fileSystem) {
-    if (isAggregator) {
-      // No indexing for an aggregator module
-      return;
-    }
     progressReport = new ProgressReport("Report about progress of file indexation", TimeUnit.SECONDS.toMillis(10));
     progressReport.start("Index files");
     exclusionFilters.prepare();
@@ -97,7 +93,9 @@ public class FileIndexer {
     executorService = Executors.newFixedThreadPool(threads, new ThreadFactoryBuilder().setNameFormat("FileIndexer-%d").build());
     tasks = new ArrayList<>();
     indexFiles(fileSystem, progress, inputFileBuilder, fileSystem.sources(), InputFile.Type.MAIN);
-    indexFiles(fileSystem, progress, inputFileBuilder, fileSystem.tests(), InputFile.Type.TEST);
+    if (!isAggregator) {
+      indexFiles(fileSystem, progress, inputFileBuilder, fileSystem.tests(), InputFile.Type.TEST);
+    }
 
     waitForTasksToComplete();
 

--- a/sonar-scanner-engine/src/test/java/org/sonar/scanner/scan/ProjectReactorBuilderTest.java
+++ b/sonar-scanner-engine/src/test/java/org/sonar/scanner/scan/ProjectReactorBuilderTest.java
@@ -39,9 +39,8 @@ import org.sonar.api.utils.MessageException;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.scanner.analysis.AnalysisProperties;
-import org.sonar.scanner.scan.ProjectReactorBuilder;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class ProjectReactorBuilderTest {
 
@@ -118,8 +117,18 @@ public class ProjectReactorBuilderTest {
 
   @Test
   public void shouldDefineMultiModuleProjectWithDefinitionsAllInRootProject() throws IOException {
-    ProjectDefinition rootProject = loadProjectDefinition("multi-module-definitions-all-in-root");
+    execMultiModule("multi-module-definitions-all-in-root");
+  }
 
+  @Test
+  public void shouldDefineMultiModuleProjectWithPomFileAtRootLevel() throws IOException {
+    ProjectDefinition project = execMultiModule("multi-module-pom-in-root");
+    assertThat(project.sources()).contains("pom.xml");
+    assertThat(project.sources()).doesNotContain("sources");
+  }
+
+  public ProjectDefinition execMultiModule(String key) throws IOException {
+    ProjectDefinition rootProject = loadProjectDefinition(key);
     // CHECK ROOT
     assertThat(rootProject.getKey()).isEqualTo("com.foo.project");
     assertThat(rootProject.getName()).isEqualTo("Foo Project");
@@ -132,10 +141,8 @@ public class ProjectReactorBuilderTest {
     assertThat(rootProject.properties().get("module1.sonar.projectKey")).isNull();
     assertThat(rootProject.properties().get("module2.sonar.projectKey")).isNull();
     // Check baseDir and workDir
-    assertThat(rootProject.getBaseDir().getCanonicalFile())
-      .isEqualTo(getResource(this.getClass(), "multi-module-definitions-all-in-root"));
-    assertThat(rootProject.getWorkDir().getCanonicalFile())
-      .isEqualTo(new File(getResource(this.getClass(), "multi-module-definitions-all-in-root"), ".sonar"));
+    assertThat(rootProject.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), key));
+    assertThat(rootProject.getWorkDir().getCanonicalFile()).isEqualTo(new File(getResource(this.getClass(), key), ".sonar"));
 
     // CHECK MODULES
     List<ProjectDefinition> modules = rootProject.getSubProjects();
@@ -143,7 +150,7 @@ public class ProjectReactorBuilderTest {
 
     // Module 1
     ProjectDefinition module1 = modules.get(0);
-    assertThat(module1.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), "multi-module-definitions-all-in-root/module1"));
+    assertThat(module1.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), key + "/module1"));
     assertThat(module1.getKey()).isEqualTo("com.foo.project:module1");
     assertThat(module1.getName()).isEqualTo("module1");
     assertThat(module1.getVersion()).isEqualTo("1.0-SNAPSHOT");
@@ -155,14 +162,12 @@ public class ProjectReactorBuilderTest {
     assertThat(module1.properties().get("module1.sonar.projectKey")).isNull();
     assertThat(module1.properties().get("module2.sonar.projectKey")).isNull();
     // Check baseDir and workDir
-    assertThat(module1.getBaseDir().getCanonicalFile())
-      .isEqualTo(getResource(this.getClass(), "multi-module-definitions-all-in-root/module1"));
-    assertThat(module1.getWorkDir().getCanonicalFile())
-      .isEqualTo(new File(getResource(this.getClass(), "multi-module-definitions-all-in-root"), ".sonar/com.foo.project_module1"));
+    assertThat(module1.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), key + "/module1"));
+    assertThat(module1.getWorkDir().getCanonicalFile()).isEqualTo(new File(getResource(this.getClass(), key), ".sonar/com.foo.project_module1"));
 
     // Module 2
     ProjectDefinition module2 = modules.get(1);
-    assertThat(module2.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), "multi-module-definitions-all-in-root/module2"));
+    assertThat(module2.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), key + "/module2"));
     assertThat(module2.getKey()).isEqualTo("com.foo.project:com.foo.project.module2");
     assertThat(module2.getName()).isEqualTo("Foo Module 2");
     assertThat(module2.getVersion()).isEqualTo("1.0-SNAPSHOT");
@@ -173,10 +178,11 @@ public class ProjectReactorBuilderTest {
     assertThat(module2.properties().get("module1.sonar.projectKey")).isNull();
     assertThat(module2.properties().get("module2.sonar.projectKey")).isNull();
     // Check baseDir and workDir
-    assertThat(module2.getBaseDir().getCanonicalFile())
-      .isEqualTo(getResource(this.getClass(), "multi-module-definitions-all-in-root/module2"));
-    assertThat(module2.getWorkDir().getCanonicalFile())
-      .isEqualTo(new File(getResource(this.getClass(), "multi-module-definitions-all-in-root"), ".sonar/com.foo.project_com.foo.project.module2"));
+    assertThat(module2.getBaseDir().getCanonicalFile()).isEqualTo(getResource(this.getClass(), key + "/module2"));
+    assertThat(module2.getWorkDir().getCanonicalFile()).isEqualTo(
+      new File(getResource(this.getClass(), key), ".sonar/com.foo.project_com.foo.project.module2"));
+
+    return rootProject;
   }
 
   // SONAR-4876

--- a/sonar-scanner-engine/src/test/resources/org/sonar/scanner/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module1/pom.xml
+++ b/sonar-scanner-engine/src/test/resources/org/sonar/scanner/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module1/pom.xml
@@ -1,0 +1,3 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!-- This is a fake pom -->
+</project> 

--- a/sonar-scanner-engine/src/test/resources/org/sonar/scanner/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module1/sources/Fake.java
+++ b/sonar-scanner-engine/src/test/resources/org/sonar/scanner/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module1/sources/Fake.java
@@ -1,0 +1,1 @@
+public class Fake {}

--- a/sonar-scanner-engine/src/test/resources/org/sonar/scanner/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module2/src/Fake.java
+++ b/sonar-scanner-engine/src/test/resources/org/sonar/scanner/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/module2/src/Fake.java
@@ -1,0 +1,1 @@
+public class Fake {}

--- a/sonar-scanner-engine/src/test/resources/org/sonar/scanner/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/pom.xml
+++ b/sonar-scanner-engine/src/test/resources/org/sonar/scanner/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/pom.xml
@@ -1,0 +1,3 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!-- This is a fake pom -->
+</project> 

--- a/sonar-scanner-engine/src/test/resources/org/sonar/scanner/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/sonar-project.properties
+++ b/sonar-scanner-engine/src/test/resources/org/sonar/scanner/scan/ProjectReactorBuilderTest/multi-module-pom-in-root/sonar-project.properties
@@ -1,0 +1,19 @@
+sonar.projectKey=com.foo.project
+sonar.projectName=Foo Project
+sonar.projectVersion=1.0-SNAPSHOT
+sonar.projectDescription=Description of Foo Project
+
+sonar.sources=sources,pom.xml
+sonar.tests=tests
+sonar.binaries=target/classes
+
+sonar.modules=module1,\
+              module2
+
+# Mandatory properties for module1 are all inferred from the module ID
+
+module2.sonar.projectKey=com.foo.project.module2
+module2.sonar.projectName=Foo Module 2
+# redefine some properties
+module2.sonar.projectDescription=Description of Module 2
+module2.sonar.sources=src


### PR DESCRIPTION
I initially implemented this on branch-5.6 and submitted it as PR #1293 .

> This PR allows processing of files in aggregator modules.
> When analyzing a multi-modules maven project, this allows the root pom to be indexed and analyzed.
> It should also be beneficial to other project types (Gradle was mentioned in SONAR-6724).
> This only applies to files, not folders : SONARPLUGINS-2295 introduced a warning for existing folders referenced in property sonar.sources of aggregator modules : it will still be displayed, and these folders will still be ignored.

I understand @henryju's concerns about merging to the LTS release branch, so I have ported my changes onto the 6.2 branch.
