### PR TITLE
SONAR-8704 update indices authorization if browse permission is fully removed

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/component/ws/SearchAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/component/ws/SearchAction.java
@@ -160,6 +160,12 @@ public class SearchAction implements ComponentsWsAction {
   }
 
   private List<ComponentDto> filterAuthorizedComponents(DbSession dbSession, List<ComponentDto> componentDtos) {
+    if (userSession.isRoot()) {
+      // the method AuthorizationDao#keepAuthorizedProjectIds() should be replaced by
+      // a call to UserSession, which would transparently support roots.
+      // Meanwhile root is explicitly handled.
+      return componentDtos;
+    }
     Set<String> projectUuids = componentDtos.stream().map(ComponentDto::projectUuid).collect(Collectors.toSet());
     List<ComponentDto> projects = dbClient.componentDao().selectByUuids(dbSession, projectUuids);
     Map<String, Long> projectIdsByUuids = projects.stream().collect(uniqueIndex(ComponentDto::uuid, ComponentDto::getId));

--- a/server/sonar-server/src/main/java/org/sonar/server/measure/ws/SearchAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/measure/ws/SearchAction.java
@@ -137,6 +137,12 @@ public class SearchAction implements MeasuresWsAction {
     }
 
     private List<ComponentDto> getAuthorizedProjects(List<ComponentDto> projectDtos) {
+      if (userSession.isRoot()) {
+        // the method AuthorizationDao#keepAuthorizedProjectIds() should be replaced by
+        // a call to UserSession, which would transparently support roots.
+        // Meanwhile root is explicitly handled.
+        return projectDtos;
+      }
       Map<String, Long> projectIdsByUuids = projectDtos.stream().collect(uniqueIndex(ComponentDto::uuid, ComponentDto::getId));
       Set<Long> authorizedProjectIds = dbClient.authorizationDao().keepAuthorizedProjectIds(dbSession,
         projectDtos.stream().map(ComponentDto::getId).collect(toList()),

--- a/server/sonar-server/src/main/java/org/sonar/server/permission/index/PermissionIndexerDao.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/permission/index/PermissionIndexerDao.java
@@ -96,10 +96,10 @@ public class PermissionIndexerDao {
   /**
    * Number of "{projectsCondition}" in SQL template
    */
-  private static final int NB_OF_CONDITION_PLACEHOLDERS = 3;
+  private static final int NB_OF_CONDITION_PLACEHOLDERS = 4;
 
   private enum RowKind {
-    USER, GROUP, ANYONE
+    USER, GROUP, ANYONE, NONE
   }
 
   private static final String SQL_TEMPLATE = "SELECT " +
@@ -160,6 +160,21 @@ public class PermissionIndexerDao {
     "        AND projects.copy_component_uuid is NULL " +
     "        {projectsCondition} " +
     "        AND group_roles.group_id IS NULL " +
+    "      UNION " +
+
+    // project is returned when no authorization
+    "      SELECT '" + RowKind.NONE + "' as kind," +
+    "      projects.uuid AS project, " +
+    "      projects.authorization_updated_at AS updated_at, " +
+    "      projects.qualifier AS qualifier, " +
+    "      NULL AS user_id, " +
+    "      NULL  AS group_id " +
+    "      FROM projects " +
+    "      WHERE " +
+    "        (projects.qualifier = 'TRK' or  projects.qualifier = 'VW') " +
+    "        AND projects.copy_component_uuid is NULL " +
+    "        {projectsCondition} " +
+
     "    ) project_authorization";
 
   List<Dto> selectAll(DbClient dbClient, DbSession session) {
@@ -221,6 +236,8 @@ public class PermissionIndexerDao {
       dtosByProjectUuid.put(projectUuid, dto);
     }
     switch (rowKind) {
+      case NONE:
+        break;
       case USER:
         dto.addUserId(rs.getLong(3));
         break;

--- a/server/sonar-server/src/main/java/org/sonar/server/project/ws/IndexAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/project/ws/IndexAction.java
@@ -22,7 +22,6 @@ package org.sonar.server.project.ws;
 import com.google.common.io.Resources;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -125,8 +124,11 @@ public class IndexAction implements ProjectsWsAction {
   }
 
   private List<ComponentDto> getAuthorizedComponents(DbSession dbSession, List<ComponentDto> components) {
-    if (components.isEmpty()) {
-      return Collections.emptyList();
+    if (userSession.isRoot() || components.isEmpty()) {
+      // the method AuthorizationDao#keepAuthorizedProjectIds() should be replaced by
+      // a call to UserSession, which would transparently support roots.
+      // Meanwhile root is explicitly handled.
+      return components;
     }
     Set<String> projectUuids = components.stream().map(ComponentDto::projectUuid).collect(Collectors.toSet());
     List<ComponentDto> projects = dbClient.componentDao().selectByUuids(dbSession, projectUuids);

--- a/server/sonar-server/src/main/java/org/sonar/server/qualitygate/QgateProjectFinder.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/qualitygate/QgateProjectFinder.java
@@ -81,6 +81,12 @@ public class QgateProjectFinder {
   }
 
   private List<ProjectQgateAssociationDto> keepAuthorizedProjects(DbSession dbSession, List<ProjectQgateAssociationDto> projects) {
+    if (userSession.isRoot()) {
+      // the method AuthorizationDao#keepAuthorizedProjectIds() should be replaced by
+      // a call to UserSession, which would transparently support roots.
+      // Meanwhile root is explicitly handled.
+      return projects;
+    }
     List<Long> projectIds = projects.stream().map(ProjectQgateAssociationDto::getId).collect(Collectors.toList());
     Collection<Long> authorizedProjectIds = dbClient.authorizationDao().keepAuthorizedProjectIds(dbSession, projectIds, userSession.getUserId(), UserRole.USER);
     return projects.stream().filter(project -> authorizedProjectIds.contains(project.getId())).collect(Collectors.toList());

--- a/server/sonar-server/src/test/java/org/sonar/server/permission/index/PermissionIndexerDaoTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/permission/index/PermissionIndexerDaoTest.java
@@ -95,21 +95,21 @@ public class PermissionIndexerDaoTest {
 
     PermissionIndexerDao.Dto view1Authorization = getByProjectUuid(view1.uuid(), dtos);
     assertThat(view1Authorization.getGroupIds()).containsOnly(group.getId());
-    assertThat(view1Authorization.isAllowAnyone()).isTrue();
+    assertThat(view1Authorization.isAllowAnyone()).isFalse();
     assertThat(view1Authorization.getUserIds()).containsOnly(user1.getId());
     assertThat(view1Authorization.getUpdatedAt()).isNotNull();
     assertThat(view1Authorization.getQualifier()).isEqualTo(VIEW);
 
     PermissionIndexerDao.Dto project2Authorization = getByProjectUuid(project2.uuid(), dtos);
     assertThat(project2Authorization.getGroupIds()).isEmpty();
-    assertThat(project2Authorization.isAllowAnyone()).isTrue();
+    assertThat(project2Authorization.isAllowAnyone()).isFalse();
     assertThat(project2Authorization.getUserIds()).containsOnly(user1.getId(), user2.getId());
     assertThat(project2Authorization.getUpdatedAt()).isNotNull();
     assertThat(project2Authorization.getQualifier()).isEqualTo(PROJECT);
 
     PermissionIndexerDao.Dto view2Authorization = getByProjectUuid(view2.uuid(), dtos);
     assertThat(view2Authorization.getGroupIds()).isEmpty();
-    assertThat(view2Authorization.isAllowAnyone()).isTrue();
+    assertThat(view2Authorization.isAllowAnyone()).isFalse();
     assertThat(view2Authorization.getUserIds()).containsOnly(user1.getId(), user2.getId());
     assertThat(view2Authorization.getUpdatedAt()).isNotNull();
     assertThat(view2Authorization.getQualifier()).isEqualTo(VIEW);
@@ -133,21 +133,21 @@ public class PermissionIndexerDaoTest {
 
     PermissionIndexerDao.Dto view1Authorization = dtos.get(view1.uuid());
     assertThat(view1Authorization.getGroupIds()).containsOnly(group.getId());
-    assertThat(view1Authorization.isAllowAnyone()).isTrue();
+    assertThat(view1Authorization.isAllowAnyone()).isFalse();
     assertThat(view1Authorization.getUserIds()).containsOnly(user1.getId());
     assertThat(view1Authorization.getUpdatedAt()).isNotNull();
     assertThat(view1Authorization.getQualifier()).isEqualTo(VIEW);
 
     PermissionIndexerDao.Dto project2Authorization = dtos.get(project2.uuid());
     assertThat(project2Authorization.getGroupIds()).isEmpty();
-    assertThat(project2Authorization.isAllowAnyone()).isTrue();
+    assertThat(project2Authorization.isAllowAnyone()).isFalse();
     assertThat(project2Authorization.getUserIds()).containsOnly(user1.getId(), user2.getId());
     assertThat(project2Authorization.getUpdatedAt()).isNotNull();
     assertThat(project2Authorization.getQualifier()).isEqualTo(PROJECT);
 
     PermissionIndexerDao.Dto view2Authorization = dtos.get(view2.uuid());
     assertThat(view2Authorization.getGroupIds()).isEmpty();
-    assertThat(view2Authorization.isAllowAnyone()).isTrue();
+    assertThat(view2Authorization.isAllowAnyone()).isFalse();
     assertThat(view2Authorization.getUserIds()).containsOnly(user1.getId(), user2.getId());
     assertThat(view2Authorization.getUpdatedAt()).isNotNull();
     assertThat(view2Authorization.getQualifier()).isEqualTo(VIEW);
@@ -176,16 +176,17 @@ public class PermissionIndexerDaoTest {
   }
 
   @Test
-  public void return_zero_rows_if_no_authorization() {
-    userDbTester.insertProjectPermissionOnUser(user1, USER, project2);
-    userDbTester.insertProjectPermissionOnGroup(group, USER, project2);
-    userDbTester.insertProjectPermissionOnUser(user1, USER, view2);
-    userDbTester.insertProjectPermissionOnGroup(group, USER, view2);
+  public void return_project_without_permission_if_no_authorization() {
+    List<PermissionIndexerDao.Dto> dtos = underTest.selectByUuids(dbClient, dbSession, asList(project1.uuid()));
 
-    Collection<PermissionIndexerDao.Dto> dtos = underTest.selectAll(dbClient, dbSession);
-
-    // project1 and view1 don't have any permission
-    assertThat(dtos).extracting(PermissionIndexerDao.Dto::getProjectUuid).containsOnly(project2.uuid(), view2.uuid());
+    // no permissions
+    assertThat(dtos).hasSize(1);
+    PermissionIndexerDao.Dto dto = dtos.get(0);
+    assertThat(dto.getGroupIds()).isEmpty();
+    assertThat(dto.getUserIds()).isEmpty();
+    assertThat(dto.isAllowAnyone()).isFalse();
+    assertThat(dto.getProjectUuid()).isEqualTo(project1.uuid());
+    assertThat(dto.getQualifier()).isEqualTo(project1.qualifier());
   }
 
   private static PermissionIndexerDao.Dto getByProjectUuid(String projectUuid, Collection<PermissionIndexerDao.Dto> dtos) {
@@ -214,9 +215,5 @@ public class PermissionIndexerDaoTest {
     // Anyone group has user access on both projects
     userDbTester.insertProjectPermissionOnAnyone(USER, project1);
     userDbTester.insertProjectPermissionOnAnyone(ADMIN, project1);
-    userDbTester.insertProjectPermissionOnAnyone(USER, project2);
-    userDbTester.insertProjectPermissionOnAnyone(USER, view1);
-    userDbTester.insertProjectPermissionOnAnyone(ADMIN, view1);
-    userDbTester.insertProjectPermissionOnAnyone(USER, view2);
   }
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/project/ws/IndexActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/project/ws/IndexActionTest.java
@@ -169,6 +169,28 @@ public class IndexActionTest {
   }
 
   @Test
+  public void do_not_verify_permissions_if_user_is_root() throws Exception {
+    ComponentDto project = db.components().insertProject(p -> p.setKey("P1").setName("POne"));
+
+    String result = call(null, null, null);
+
+    userSession.setNonRoot();
+    assertThat(result).isEqualTo("[]");
+
+    userSession.setRoot();
+    result = call(null, null, null);
+    assertJson(result).isSimilarTo("[" +
+      "  {" +
+      "  \"id\":" + project.getId() + "," +
+      "  \"k\":\"P1\"," +
+      "  \"nm\":\"POne\"," +
+      "  \"sc\":\"PRJ\"," +
+      "   \"qu\":\"TRK\"" +
+      "  }" +
+      "]");
+  }
+
+  @Test
   public void test_example() {
     insertProjectsAuthorizedForUser(
       newProjectDto(db.getDefaultOrganization()).setKey("org.jenkins-ci.plugins:sonar").setName("Jenkins Sonar Plugin"),
@@ -199,7 +221,6 @@ public class IndexActionTest {
   private void insertProjectsAuthorizedForUser(ComponentDto... projects) {
     db.components().insertComponents(projects);
     setBrowsePermissionOnUser(projects);
-    db.commit();
   }
 
   private void setBrowsePermissionOnUser(ComponentDto... projects) {

--- a/server/sonar-server/src/test/java/org/sonar/server/qualitygate/QgateProjectFinderTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualitygate/QgateProjectFinderTest.java
@@ -37,6 +37,7 @@ import org.sonar.db.component.ComponentDto;
 import org.sonar.db.organization.OrganizationDto;
 import org.sonar.db.property.PropertyDto;
 import org.sonar.db.qualitygate.ProjectQgateAssociation;
+import org.sonar.db.qualitygate.ProjectQgateAssociationQuery;
 import org.sonar.db.qualitygate.QualityGateDto;
 import org.sonar.db.user.UserDto;
 import org.sonar.server.exceptions.NotFoundException;
@@ -157,6 +158,21 @@ public class QgateProjectFinderTest {
         .build());
 
     verifyProjects(result, project1.getId());
+  }
+
+  @Test
+  public void do_not_verify_permissions_if_user_is_root() throws Exception {
+    OrganizationDto org = dbTester.organizations().insert();
+    ComponentDto project = componentDbTester.insertProject(org);
+    ProjectQgateAssociationQuery query = builder()
+      .gateId(Long.toString(qGate.getId()))
+      .build();
+
+    userSession.logIn().setNonRoot();
+    verifyProjects(underTest.find(query));
+
+    userSession.logIn().setRoot();
+    verifyProjects(underTest.find(query), project.getId());
   }
 
   @Test


### PR DESCRIPTION
SONAR-8704 update indices authorization if browse permission is fully removed

The types "authorization" of ES indices should be updated when all
the groups and users loose the projet permission "browse". Currently
this change was silently ignored and old permissions were still used.