### PR TITLE
SONAR-7282 fix module number count in ComputeEngineContainerImplTest

### DIFF
--- a/server/sonar-ce/src/test/java/org/sonar/ce/container/ComputeEngineContainerImplTest.java
+++ b/server/sonar-ce/src/test/java/org/sonar/ce/container/ComputeEngineContainerImplTest.java
@@ -88,10 +88,11 @@ public class ComputeEngineContainerImplTest {
     assertThat(picoContainer.getComponentAdapters())
       .hasSize(
         CONTAINER_ITSELF
-          + 78 // level 4
+          + 75 // level 4
           + 4 // content of CeConfigurationModule
-          + 3 // content of CeHttpModule
           + 5 // content of CeQueueModule
+          + 3 // content of CeHttpModule
+          + 3 // content of CeTaskCommonsModule
           + 4 // content of ProjectAnalysisTaskModule
           + 4 // content of CeTaskProcessorModule
     );


### PR DESCRIPTION
During my investigations about PurgeListener I ran into this malformed unit test calculation. I would love to fix it, so that I do not stumble over it in future developments again.