### PR TITLE
SONAR-8875 Add language facet on projects page

### DIFF
--- a/server/sonar-web/src/main/js/apps/projects/components/PageSidebar.js
+++ b/server/sonar-web/src/main/js/apps/projects/components/PageSidebar.js
@@ -26,6 +26,7 @@ import QualityGateFilter from '../filters/QualityGateFilter';
 import ReliabilityFilter from '../filters/ReliabilityFilter';
 import SecurityFilter from '../filters/SecurityFilter';
 import MaintainabilityFilter from '../filters/MaintainabilityFilter';
+import LanguageFilter from '../filters/LanguageFilter';
 import { translate } from '../../../helpers/l10n';
 
 export default class PageSidebar extends React.Component {
@@ -82,6 +83,10 @@ export default class PageSidebar extends React.Component {
               isFavorite={this.props.isFavorite}
               organization={this.props.organization}/>
           <SizeFilter
+              query={this.props.query}
+              isFavorite={this.props.isFavorite}
+              organization={this.props.organization}/>
+          <LanguageFilter
               query={this.props.query}
               isFavorite={this.props.isFavorite}
               organization={this.props.organization}/>

--- a/server/sonar-web/src/main/js/apps/projects/filters/CoverageFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/CoverageFilter.js
@@ -43,7 +43,7 @@ export default class CoverageFilter extends React.Component {
     return (
         <FilterContainer
             property="coverage"
-            options={[1, 2, 3, 4, 5]}
+            getOptions={() => [1, 2, 3, 4, 5]}
             renderName={() => 'Coverage'}
             renderOption={this.renderOption}
             getFacetValueForOption={this.getFacetValueForOption}

--- a/server/sonar-web/src/main/js/apps/projects/filters/DuplicationsFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/DuplicationsFilter.js
@@ -43,7 +43,7 @@ export default class DuplicationsFilter extends React.Component {
     return (
         <FilterContainer
             property="duplications"
-            options={[1, 2, 3, 4, 5]}
+            getOptions={() => [1, 2, 3, 4, 5]}
             renderName={() => 'Duplications'}
             renderOption={this.renderOption}
             getFacetValueForOption={this.getFacetValueForOption}

--- a/server/sonar-web/src/main/js/apps/projects/filters/Filter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/Filter.js
@@ -44,6 +44,27 @@ export default class Filter extends React.Component {
     halfWidth: false
   };
 
+  isSelected (option) {
+    const { value } = this.props;
+    return Array.isArray(value) ? value.includes(option) : option === value;
+  }
+
+  getPath (option) {
+    const { property, value } = this.props;
+    let urlOption;
+
+    if (Array.isArray(value)) {
+      if (this.isSelected(option)) {
+        urlOption = value.length > 1 ? value.filter(val => val !== option).join(',') : null;
+      } else {
+        urlOption = value.concat(option).join(',');
+      }
+    } else {
+      urlOption = this.isSelected(option) ? null : option;
+    }
+    return this.props.getFilterUrl({ [property]: urlOption });
+  }
+
   renderHeader () {
     return (
         <div className="search-navigator-facet-header projects-facet-header">
@@ -66,22 +87,20 @@ export default class Filter extends React.Component {
   }
 
   renderOption (option) {
-    const { property, value, facet, getFacetValueForOption } = this.props;
+    const { facet, getFacetValueForOption } = this.props;
     const className = classNames('facet', 'search-navigator-facet', 'projects-facet', {
-      'active': option === value,
+      'active': this.isSelected(option),
       'search-navigator-facet-half': this.props.halfWidth
     }, this.props.optionClassName);
 
-    const path = option === value ?
-        this.props.getFilterUrl({ [property]: null }) :
-        this.props.getFilterUrl({ [property]: option });
+    const path = this.getPath(option);
 
     const facetValue = (facet && getFacetValueForOption) ? getFacetValueForOption(facet, option) : null;
 
     return (
         <Link key={option} className={className} to={path} data-key={option}>
           <span className="facet-name">
-            {this.props.renderOption(option, option === value)}
+            {this.props.renderOption(option, this.isSelected(option))}
           </span>
           {facetValue != null && (
               <span className="facet-stat">

--- a/server/sonar-web/src/main/js/apps/projects/filters/Filter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/Filter.js
@@ -26,7 +26,7 @@ export default class Filter extends React.Component {
   static propTypes = {
     value: React.PropTypes.any,
     property: React.PropTypes.string.isRequired,
-    options: React.PropTypes.array.isRequired,
+    getOptions: React.PropTypes.func.isRequired,
     maxFacetValue: React.PropTypes.number,
     optionClassName: React.PropTypes.string,
 
@@ -96,7 +96,7 @@ export default class Filter extends React.Component {
   renderOptions () {
     return (
         <div className="search-navigator-facet-list">
-          {this.props.options.map(option => this.renderOption(option))}
+          {this.props.getOptions(this.props.facet).map(option => this.renderOption(option))}
         </div>
     );
   }

--- a/server/sonar-web/src/main/js/apps/projects/filters/IssuesFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/IssuesFilter.js
@@ -41,7 +41,7 @@ export default class IssuesFilter extends React.Component {
     return (
         <FilterContainer
             property={this.props.property}
-            options={[1, 2, 3, 4, 5]}
+            getOptions={() => [1, 2, 3, 4, 5]}
             renderName={() => this.props.name}
             renderOption={this.renderOption}
             getFacetValueForOption={this.getFacetValueForOption}

--- a/server/sonar-web/src/main/js/apps/projects/filters/LanguageFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/LanguageFilter.js
@@ -1,0 +1,50 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import React from 'react';
+import FilterContainer from './FilterContainer';
+import LanguageFilterOption from './LanguageFilterOption';
+
+export default class LanguageFilter extends React.Component {
+  renderOption = option => {
+    return (
+      <span>
+        <LanguageFilterOption languageKey={option}/>
+      </span>
+    );
+  };
+
+  getFacetValueForOption = (facet, option) => {
+    return facet[option];
+  };
+
+  render () {
+    return (
+        <FilterContainer
+            property="language"
+            getOptions={facet => facet ? Object.keys(facet) : []}
+            renderName={() => 'Languages'}
+            renderOption={this.renderOption}
+            getFacetValueForOption={this.getFacetValueForOption}
+            query={this.props.query}
+            isFavorite={this.props.isFavorite}
+            organization={this.props.organization}/>
+    );
+  }
+}

--- a/server/sonar-web/src/main/js/apps/projects/filters/LanguageFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/LanguageFilter.js
@@ -24,9 +24,7 @@ import LanguageFilterOption from './LanguageFilterOption';
 export default class LanguageFilter extends React.Component {
   renderOption = option => {
     return (
-      <span>
-        <LanguageFilterOption languageKey={option}/>
-      </span>
+      <LanguageFilterOption languageKey={option}/>
     );
   };
 

--- a/server/sonar-web/src/main/js/apps/projects/filters/LanguageFilterOption.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/LanguageFilterOption.js
@@ -22,8 +22,9 @@ import React from 'react';
 
 class LanguageFilterOption extends React.Component {
   render () {
+    const languageName = this.props.language ? this.props.language.name : this.props.languageKey;
     return (
-      <span>{this.props.language.name}</span>
+      <span>{languageName}</span>
     );
   }
 }

--- a/server/sonar-web/src/main/js/apps/projects/filters/LanguageFilterOption.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/LanguageFilterOption.js
@@ -1,0 +1,35 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import { connect } from 'react-redux';
+import React from 'react';
+
+class LanguageFilterOption extends React.Component {
+  render () {
+    return (
+      <span>{this.props.language.name}</span>
+    );
+  }
+}
+
+const mapStateToProps = (state, ownProps) => ({
+  language: state.languages[ownProps.languageKey]
+});
+
+export default connect(mapStateToProps)(LanguageFilterOption);

--- a/server/sonar-web/src/main/js/apps/projects/filters/QualityGateFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/QualityGateFilter.js
@@ -36,7 +36,7 @@ export default class QualityGateFilter extends React.Component {
     return (
         <FilterContainer
             property="gate"
-            options={['OK', 'WARN', 'ERROR']}
+            getOptions={() => ['OK', 'WARN', 'ERROR']}
             renderName={() => 'Quality Gate'}
             renderOption={this.renderOption}
             getFacetValueForOption={this.getFacetValueForOption}

--- a/server/sonar-web/src/main/js/apps/projects/filters/SizeFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/SizeFilter.js
@@ -43,7 +43,7 @@ export default class SizeFilter extends React.Component {
     return (
         <FilterContainer
             property="size"
-            options={[1, 2, 3, 4, 5]}
+            getOptions={() => [1, 2, 3, 4, 5]}
             renderName={() => 'Size'}
             renderOption={this.renderOption}
             getFacetValueForOption={this.getFacetValueForOption}

--- a/server/sonar-web/src/main/js/apps/projects/store/actions.js
+++ b/server/sonar-web/src/main/js/apps/projects/store/actions.js
@@ -53,7 +53,8 @@ const FACETS = [
   'coverage',
   'duplicated_lines_density',
   'ncloc',
-  'alert_status'
+  'alert_status',
+  'language'
 ];
 
 const onFail = dispatch => error => {

--- a/server/sonar-web/src/main/js/apps/projects/store/facetsDuck.js
+++ b/server/sonar-web/src/main/js/apps/projects/store/facetsDuck.js
@@ -29,7 +29,8 @@ const CUMULATIVE_FACETS = [
   'maintainability',
   'coverage',
   'duplications',
-  'size'
+  'size',
+  'language'
 ];
 
 const REVERSED_FACETS = [

--- a/server/sonar-web/src/main/js/apps/projects/store/utils.js
+++ b/server/sonar-web/src/main/js/apps/projects/store/utils.js
@@ -39,6 +39,13 @@ const getAsString = value => {
   return value;
 };
 
+const getAsArray = getAsType => (values => {
+  if (!values) {
+    return null;
+  }
+  return values.split(',').map(getAsType);
+});
+
 export const parseUrlQuery = urlQuery => ({
   'gate': getAsLevel(urlQuery['gate']),
   'reliability': getAsNumericRating(urlQuery['reliability']),
@@ -47,7 +54,7 @@ export const parseUrlQuery = urlQuery => ({
   'coverage': getAsNumericRating(urlQuery['coverage']),
   'duplications': getAsNumericRating(urlQuery['duplications']),
   'size': getAsNumericRating(urlQuery['size']),
-  'language': getAsString(urlQuery['language'])
+  'language': getAsArray(getAsString)(urlQuery['language'])
 });
 
 const convertIssuesRating = (metric, rating) => {
@@ -145,7 +152,11 @@ export const convertToFilter = (query, isFavorite) => {
   }
 
   if (query['language'] != null) {
-    conditions.push('language = ' + query['language']);
+    if (!Array.isArray(query['language']) || query['language'].length < 2) {
+      conditions.push('language = ' + query['language']);
+    } else {
+      conditions.push('language IN (' + query['language'].join(', ') + ')');
+    }
   }
 
   return conditions.join(' and ');

--- a/server/sonar-web/src/main/js/apps/projects/store/utils.js
+++ b/server/sonar-web/src/main/js/apps/projects/store/utils.js
@@ -32,6 +32,13 @@ const getAsLevel = value => {
   return null;
 };
 
+const getAsString = value => {
+  if (!value) {
+    return null;
+  }
+  return value;
+};
+
 export const parseUrlQuery = urlQuery => ({
   'gate': getAsLevel(urlQuery['gate']),
   'reliability': getAsNumericRating(urlQuery['reliability']),
@@ -39,7 +46,8 @@ export const parseUrlQuery = urlQuery => ({
   'maintainability': getAsNumericRating(urlQuery['maintainability']),
   'coverage': getAsNumericRating(urlQuery['coverage']),
   'duplications': getAsNumericRating(urlQuery['duplications']),
-  'size': getAsNumericRating(urlQuery['size'])
+  'size': getAsNumericRating(urlQuery['size']),
+  'language': getAsString(urlQuery['language'])
 });
 
 const convertIssuesRating = (metric, rating) => {
@@ -136,6 +144,10 @@ export const convertToFilter = (query, isFavorite) => {
     conditions.push(convertIssuesRating('sqale_rating', query['maintainability']));
   }
 
+  if (query['language'] != null) {
+    conditions.push('language = ' + query['language']);
+  }
+
   return conditions.join(' and ');
 };
 
@@ -147,7 +159,8 @@ export const mapMetricToProperty = metricKey => {
     'coverage': 'coverage',
     'duplicated_lines_density': 'duplications',
     'ncloc': 'size',
-    'alert_status': 'gate'
+    'alert_status': 'gate',
+    'language': 'language'
   };
   return map[metricKey];
 };


### PR DESCRIPTION
The following additional filtering criterion should be added:
 * Project languages (Java, JavaScript, PHP, ... )
 * This filter should offer all the languages with LoC in the instance.
 * The bar graph on the right of the filter should represent the count of projects with LoC of that language
 * Multiple languages should be selectable at once as OR criteria