### PR TITLE
Improve reliability of UpgradeTest

### DIFF
--- a/tests/upgrade/src/test/java/org/sonarsource/sonarqube/upgrade/UpgradeTest.java
+++ b/tests/upgrade/src/test/java/org/sonarsource/sonarqube/upgrade/UpgradeTest.java
@@ -120,7 +120,9 @@ public class UpgradeTest {
 
   private void upgrade(Version sqVersion) {
     checkSystemStatus(sqVersion, ServerStatusResponse.Status.DB_MIGRATION_NEEDED);
-    checkUrlsBeforeUpgrade();
+    if (sqVersion.equals(VERSION_CURRENT)) {
+      checkUrlsBeforeUpgrade();
+    }
     ServerMigrationResponse serverMigrationResponse = new ServerMigrationCall(orchestrator).callAndWait();
     assertThat(serverMigrationResponse.getStatus())
       .describedAs("Migration status of version " + sqVersion + " should be MIGRATION_SUCCEEDED")


### PR DESCRIPTION
Do not test URLs on old versions of SQ. Checks
are not valid.