### PR TITLE
SONAR-8857 api/qualityprofiles/projects must filter on org

### DIFF
--- a/server/sonar-db-dao/src/main/java/org/sonar/db/qualityprofile/QualityProfileDao.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/qualityprofile/QualityProfileDao.java
@@ -165,19 +165,19 @@ public class QualityProfileDao implements Dao {
     DatabaseUtils.executeLargeUpdates(profileKeys, mapper::deleteProjectAssociationByProfileKeys);
   }
 
-  public List<ProjectQprofileAssociationDto> selectSelectedProjects(String profileKey, @Nullable String query, DbSession session) {
+  public List<ProjectQprofileAssociationDto> selectSelectedProjects(OrganizationDto organization, String profileKey, @Nullable String query, DbSession session) {
     String nameQuery = sqlQueryString(query);
-    return mapper(session).selectSelectedProjects(profileKey, nameQuery);
+    return mapper(session).selectSelectedProjects(organization.getUuid(), profileKey, nameQuery);
   }
 
-  public List<ProjectQprofileAssociationDto> selectDeselectedProjects(String profileKey, @Nullable String query, DbSession session) {
+  public List<ProjectQprofileAssociationDto> selectDeselectedProjects(OrganizationDto organization, String profileKey, @Nullable String query, DbSession session) {
     String nameQuery = sqlQueryString(query);
-    return mapper(session).selectDeselectedProjects(profileKey, nameQuery);
+    return mapper(session).selectDeselectedProjects(organization.getUuid(), profileKey, nameQuery);
   }
 
-  public List<ProjectQprofileAssociationDto> selectProjectAssociations(String profileKey, @Nullable String query, DbSession session) {
+  public List<ProjectQprofileAssociationDto> selectProjectAssociations(OrganizationDto organization, String profileKey, @Nullable String query, DbSession session) {
     String nameQuery = sqlQueryString(query);
-    return mapper(session).selectProjectAssociations(profileKey, nameQuery);
+    return mapper(session).selectProjectAssociations(organization.getUuid(), profileKey, nameQuery);
   }
 
   private static String sqlQueryString(@Nullable String query) {

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/qualityprofile/QualityProfileMapper.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/qualityprofile/QualityProfileMapper.java
@@ -73,9 +73,18 @@ public interface QualityProfileMapper {
 
   void deleteProjectAssociationByProfileKeys(@Param("profileKeys") Collection<String> profileKeys);
 
-  List<ProjectQprofileAssociationDto> selectSelectedProjects(@Param("profileKey") String profileKey, @Param("nameQuery") String nameQuery);
+  List<ProjectQprofileAssociationDto> selectSelectedProjects(
+    @Param("organizationUuid") String organizationUuid,
+    @Param("profileKey") String profileKey,
+    @Param("nameQuery") String nameQuery);
 
-  List<ProjectQprofileAssociationDto> selectDeselectedProjects(@Param("profileKey") String profileKey, @Param("nameQuery") String nameQuery);
+  List<ProjectQprofileAssociationDto> selectDeselectedProjects(
+    @Param("organizationUuid") String organizationUuid,
+    @Param("profileKey") String profileKey,
+    @Param("nameQuery") String nameQuery);
 
-  List<ProjectQprofileAssociationDto> selectProjectAssociations(@Param("profileKey") String profileKey, @Param("nameQuery") String nameQuery);
+  List<ProjectQprofileAssociationDto> selectProjectAssociations(
+    @Param("organizationUuid") String organizationUuid,
+    @Param("profileKey") String profileKey,
+    @Param("nameQuery") String nameQuery);
 }

--- a/server/sonar-db-dao/src/main/resources/org/sonar/db/qualityprofile/QualityProfileMapper.xml
+++ b/server/sonar-db-dao/src/main/resources/org/sonar/db/qualityprofile/QualityProfileMapper.xml
@@ -137,11 +137,10 @@
     SELECT pp.id as id, pj.id as projectId, pj.uuid as projectUuid, pj.kee as projectKey, pj.name as projectName, pp.profile_key as profileKey
     FROM projects pj
     JOIN project_qprofiles pp ON pp.project_uuid = pj.uuid
-    AND pp.profile_key = #{profileKey}
-    <where>
-      AND pj.scope='PRJ' AND pj.qualifier='TRK'
-      AND UPPER(pj.name) LIKE #{nameQuery}
-    </where>
+    AND pp.profile_key = #{profileKey, jdbcType=VARCHAR}
+    WHERE pj.scope='PRJ' AND pj.qualifier='TRK'
+      AND UPPER(pj.name) LIKE #{nameQuery, jdbcType=VARCHAR}
+      AND pj.organization_uuid = #{organizationUuid, jdbcType=VARCHAR}
     ORDER BY pj.name ASC
   </select>
 
@@ -149,12 +148,11 @@
     SELECT pp.id as id, pj.id as projectId, pj.uuid as projectUuid, pj.kee as projectKey, pj.name as projectName, pp.profile_key as profileKey
     FROM projects pj
     LEFT JOIN project_qprofiles pp ON pp.project_uuid = pj.uuid
-    AND pp.profile_key = #{profileKey}
-    <where>
-      AND pj.scope='PRJ' AND pj.qualifier='TRK'
-      AND UPPER(pj.name) LIKE #{nameQuery}
+    AND pp.profile_key = #{profileKey, jdbcType=VARCHAR}
+    WHERE pj.scope='PRJ' AND pj.qualifier='TRK'
+      AND UPPER(pj.name) LIKE #{nameQuery, jdbcType=VARCHAR}
       AND pp.profile_key IS NULL
-    </where>
+      AND pj.organization_uuid = #{organizationUuid, jdbcType=VARCHAR}
     ORDER BY pj.name ASC
   </select>
 
@@ -162,11 +160,10 @@
     SELECT pp.id as id, pj.id as projectId, pj.uuid as projectUuid, pj.kee as projectKey, pj.name as projectName, pp.profile_key as profileKey
     FROM projects pj
     LEFT JOIN project_qprofiles pp ON pp.project_uuid = pj.uuid
-    AND pp.profile_key = #{profileKey}
-    <where>
-      AND pj.scope='PRJ' AND pj.qualifier='TRK'
-      AND UPPER(pj.name) LIKE #{nameQuery}
-    </where>
+    AND pp.profile_key = #{profileKey, jdbcType=VARCHAR}
+    WHERE pj.scope='PRJ' AND pj.qualifier='TRK'
+      AND UPPER(pj.name) LIKE #{nameQuery, jdbcType=VARCHAR}
+      AND pj.organization_uuid = #{organizationUuid, jdbcType=VARCHAR}
     ORDER BY pj.name ASC
   </select>
 

--- a/server/sonar-db-dao/src/test/java/org/sonar/db/component/ComponentDbTester.java
+++ b/server/sonar-db-dao/src/test/java/org/sonar/db/component/ComponentDbTester.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.db.component;
 
+import java.util.Arrays;
 import java.util.function.Consumer;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
@@ -70,12 +71,12 @@ public class ComponentDbTester {
     return insertComponentImpl(newProjectDto(db.getDefaultOrganization()), noExtraConfiguration());
   }
 
-  public ComponentDto insertProject(Consumer<ComponentDto> dtoPopulator) {
-    return insertComponentImpl(newProjectDto(db.getDefaultOrganization()), dtoPopulator);
+  public ComponentDto insertProject(Consumer<ComponentDto>... dtoPopulators) {
+    return insertComponentImpl(newProjectDto(db.getDefaultOrganization()), dtoPopulators);
   }
 
-  public ComponentDto insertProject(OrganizationDto organizationDto, Consumer<ComponentDto> dtoPopulator) {
-    return insertComponentImpl(newProjectDto(organizationDto), dtoPopulator);
+  public ComponentDto insertProject(OrganizationDto organizationDto, Consumer<ComponentDto>... dtoPopulators) {
+    return insertComponentImpl(newProjectDto(organizationDto), dtoPopulators);
   }
 
   public ComponentDto insertProject(OrganizationDto organizationDto) {
@@ -127,8 +128,9 @@ public class ComponentDbTester {
     };
   }
 
-  private ComponentDto insertComponentImpl(ComponentDto component, Consumer<ComponentDto> dtoPopulator) {
-    dtoPopulator.accept(component);
+  private ComponentDto insertComponentImpl(ComponentDto component, Consumer<ComponentDto>... dtoPopulators) {
+    Arrays.stream(dtoPopulators)
+      .forEach(dtoPopulator -> dtoPopulator.accept(component));
     dbClient.componentDao().insert(dbSession, component);
     db.commit();
 

--- a/server/sonar-db-dao/src/test/java/org/sonar/db/qualityprofile/QualityProfileDaoTest.java
+++ b/server/sonar-db-dao/src/test/java/org/sonar/db/qualityprofile/QualityProfileDaoTest.java
@@ -357,9 +357,11 @@ public class QualityProfileDaoTest {
 
   @Test
   public void select_selected_projects() throws Exception {
-    ComponentDto project1 = dbTester.components().insertProject((t) -> t.setName("Project1 name"));
-    ComponentDto project2 = dbTester.components().insertProject((t) -> t.setName("Project2 name"));
-    ComponentDto project3 = dbTester.components().insertProject((t) -> t.setName("Project3 name"));
+    ComponentDto project1 = dbTester.components().insertProject(t -> t.setName("Project1 name"), t -> t.setOrganizationUuid(organization.getUuid()));
+    ComponentDto project2 = dbTester.components().insertProject(t -> t.setName("Project2 name"), t -> t.setOrganizationUuid(organization.getUuid()));
+    ComponentDto project3 = dbTester.components().insertProject(t -> t.setName("Project3 name"), t -> t.setOrganizationUuid(organization.getUuid()));
+    OrganizationDto organization2 = dbTester.organizations().insert();
+    ComponentDto project4 = dbTester.components().insertProject(t -> t.setName("Project4 name"), t -> t.setOrganizationUuid(organization2.getUuid()));
 
     QualityProfileDto profile1 = newQualityProfileDto();
     qualityProfileDb.insertQualityProfiles(profile1);
@@ -370,21 +372,23 @@ public class QualityProfileDaoTest {
     qualityProfileDb.insertQualityProfiles(profile2);
     qualityProfileDb.associateProjectWithQualityProfile(project3, profile2);
 
-    assertThat(underTest.selectSelectedProjects(profile1.getKey(), null, dbSession))
+    assertThat(underTest.selectSelectedProjects(organization, profile1.getKey(), null, dbSession))
       .extracting("projectId", "projectUuid", "projectKey", "projectName", "profileKey")
       .containsOnly(
         tuple(project1.getId(), project1.uuid(), project1.key(), project1.name(), profile1.getKey()),
         tuple(project2.getId(), project2.uuid(), project2.key(), project2.name(), profile1.getKey()));
 
-    assertThat(underTest.selectSelectedProjects(profile1.getKey(), "ect1", dbSession)).hasSize(1);
-    assertThat(underTest.selectSelectedProjects("unknown", null, dbSession)).isEmpty();
+    assertThat(underTest.selectSelectedProjects(organization, profile1.getKey(), "ect1", dbSession)).hasSize(1);
+    assertThat(underTest.selectSelectedProjects(organization, "unknown", null, dbSession)).isEmpty();
   }
 
   @Test
   public void select_deselected_projects() throws Exception {
-    ComponentDto project1 = dbTester.components().insertProject((t) -> t.setName("Project1 name"));
-    ComponentDto project2 = dbTester.components().insertProject((t) -> t.setName("Project2 name"));
-    ComponentDto project3 = dbTester.components().insertProject((t) -> t.setName("Project3 name"));
+    ComponentDto project1 = dbTester.components().insertProject(t -> t.setName("Project1 name"), t -> t.setOrganizationUuid(organization.getUuid()));
+    ComponentDto project2 = dbTester.components().insertProject(t -> t.setName("Project2 name"), t -> t.setOrganizationUuid(organization.getUuid()));
+    ComponentDto project3 = dbTester.components().insertProject(t -> t.setName("Project3 name"), t -> t.setOrganizationUuid(organization.getUuid()));
+    OrganizationDto organization2 = dbTester.organizations().insert();
+    ComponentDto project4 = dbTester.components().insertProject(t -> t.setName("Project4 name"), t -> t.setOrganizationUuid(organization2.getUuid()));
 
     QualityProfileDto profile1 = newQualityProfileDto();
     qualityProfileDb.insertQualityProfiles(profile1);
@@ -394,21 +398,23 @@ public class QualityProfileDaoTest {
     qualityProfileDb.insertQualityProfiles(profile2);
     qualityProfileDb.associateProjectWithQualityProfile(project2, profile2);
 
-    assertThat(underTest.selectDeselectedProjects(profile1.getKey(), null, dbSession))
+    assertThat(underTest.selectDeselectedProjects(organization, profile1.getKey(), null, dbSession))
       .extracting("projectId", "projectUuid", "projectKey", "projectName", "profileKey")
-      .containsOnly(
+      .containsExactly(
         tuple(project2.getId(), project2.uuid(), project2.key(), project2.name(), null),
         tuple(project3.getId(), project3.uuid(), project3.key(), project3.name(), null));
 
-    assertThat(underTest.selectDeselectedProjects(profile1.getKey(), "ect2", dbSession)).hasSize(1);
-    assertThat(underTest.selectDeselectedProjects("unknown", null, dbSession)).hasSize(3);
+    assertThat(underTest.selectDeselectedProjects(organization, profile1.getKey(), "ect2", dbSession)).hasSize(1);
+    assertThat(underTest.selectDeselectedProjects(organization, "unknown", null, dbSession)).hasSize(3);
   }
 
   @Test
   public void select_project_associations() throws Exception {
-    ComponentDto project1 = dbTester.components().insertProject((t) -> t.setName("Project1 name"));
-    ComponentDto project2 = dbTester.components().insertProject((t) -> t.setName("Project2 name"));
-    ComponentDto project3 = dbTester.components().insertProject((t) -> t.setName("Project3 name"));
+    ComponentDto project1 = dbTester.components().insertProject(t -> t.setName("Project1 name"), t -> t.setOrganizationUuid(organization.getUuid()));
+    ComponentDto project2 = dbTester.components().insertProject(t -> t.setName("Project2 name"), t -> t.setOrganizationUuid(organization.getUuid()));
+    ComponentDto project3 = dbTester.components().insertProject(t -> t.setName("Project3 name"), t -> t.setOrganizationUuid(organization.getUuid()));
+    OrganizationDto organization2 = dbTester.organizations().insert();
+    ComponentDto project4 = dbTester.components().insertProject(t -> t.setName("Project4 name"), t -> t.setOrganizationUuid(organization2.getUuid()));
 
     QualityProfileDto profile1 = newQualityProfileDto();
     qualityProfileDb.insertQualityProfiles(profile1);
@@ -418,15 +424,15 @@ public class QualityProfileDaoTest {
     qualityProfileDb.insertQualityProfiles(profile2);
     qualityProfileDb.associateProjectWithQualityProfile(project2, profile2);
 
-    assertThat(underTest.selectProjectAssociations(profile1.getKey(), null, dbSession))
+    assertThat(underTest.selectProjectAssociations(organization, profile1.getKey(), null, dbSession))
       .extracting("projectId", "projectUuid", "projectKey", "projectName", "profileKey")
       .containsOnly(
         tuple(project1.getId(), project1.uuid(), project1.key(), project1.name(), profile1.getKey()),
         tuple(project2.getId(), project2.uuid(), project2.key(), project2.name(), null),
         tuple(project3.getId(), project3.uuid(), project3.key(), project3.name(), null));
 
-    assertThat(underTest.selectProjectAssociations(profile1.getKey(), "ect2", dbSession)).hasSize(1);
-    assertThat(underTest.selectProjectAssociations("unknown", null, dbSession)).hasSize(3);
+    assertThat(underTest.selectProjectAssociations(organization, profile1.getKey(), "ect2", dbSession)).hasSize(1);
+    assertThat(underTest.selectProjectAssociations(organization, "unknown", null, dbSession)).hasSize(3);
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/DeleteActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/DeleteActionTest.java
@@ -84,7 +84,7 @@ public class DeleteActionTest {
       .execute();
     assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
 
-    verifyProfileDoesNotExist(profile1);
+    verifyProfileDoesNotExist(profile1, organization);
     verifyProfileExists(profile2);
   }
 
@@ -106,7 +106,7 @@ public class DeleteActionTest {
 
     assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
 
-    verifyProfileDoesNotExist(profile1);
+    verifyProfileDoesNotExist(profile1, organization);
     verifyProfileExists(profile2);
   }
 
@@ -127,7 +127,7 @@ public class DeleteActionTest {
       .execute();
     assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
 
-    verifyProfileDoesNotExist(profile1);
+    verifyProfileDoesNotExist(profile1, organization);
     verifyProfileExists(profile2);
   }
 
@@ -274,9 +274,9 @@ public class DeleteActionTest {
       .addPermission(ADMINISTER_QUALITY_PROFILES, organization);
   }
 
-  private void verifyProfileDoesNotExist(QualityProfileDto profile) {
+  private void verifyProfileDoesNotExist(QualityProfileDto profile, OrganizationDto organization) {
     assertThat(dbClient.qualityProfileDao().selectByKey(session, profile.getKey())).isNull();
-    assertThat(dbClient.qualityProfileDao().selectSelectedProjects(profile.getKey(), null, session)).isEmpty();
+    assertThat(dbClient.qualityProfileDao().selectSelectedProjects(organization, profile.getKey(), null, session)).isEmpty();
   }
 
   private void verifyProfileExists(QualityProfileDto profile) {

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/ProjectsActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/ProjectsActionTest.java
@@ -34,6 +34,7 @@ import org.sonar.db.qualityprofile.QualityProfileDto;
 import org.sonar.db.user.UserDto;
 import org.sonar.db.user.UserTesting;
 import org.sonar.server.exceptions.NotFoundException;
+import org.sonar.server.organization.TestDefaultOrganizationProvider;
 import org.sonar.server.qualityprofile.QProfileTesting;
 import org.sonar.server.tester.UserSessionRule;
 import org.sonar.server.ws.WsTester;
@@ -59,7 +60,7 @@ public class ProjectsActionTest {
   private ComponentDto project4;
 
   private WsTester wsTester = new WsTester(new QProfilesWs(
-    new ProjectsAction(dbClient, userSessionRule)));
+    new ProjectsAction(dbClient, userSessionRule, new QProfileWsSupport(dbClient, userSessionRule, TestDefaultOrganizationProvider.from(db)))));
 
   @Before
   public void setUp() {
@@ -197,8 +198,8 @@ public class ProjectsActionTest {
   }
 
   private void createProfiles() {
-    xooP1 = QProfileTesting.newXooP1("org-123");
-    xooP2 = QProfileTesting.newXooP2("org-123");
+    xooP1 = QProfileTesting.newXooP1(organizationDto);
+    xooP2 = QProfileTesting.newXooP2(organizationDto);
     dbClient.qualityProfileDao().insert(dbSession, xooP1, xooP2);
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/QProfilesWsTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/QProfilesWsTest.java
@@ -62,7 +62,7 @@ public class QProfilesWsTest {
       new ImportersAction(importers),
       new SearchAction(null, languages, dbClient, wsSupport),
       new SetDefaultAction(languages, null, null, wsSupport),
-      new ProjectsAction(null, userSessionRule),
+      new ProjectsAction(null, userSessionRule, wsSupport),
       new ChangelogAction(null, wsSupport, languages, dbClient),
       new ChangeParentAction(dbClient, null, languages, wsSupport, userSessionRule),
       new CompareAction(null, null, languages),


### PR DESCRIPTION
When searching for not yet associated projects of a quality profile, only projects of the same organization may be returned.