### PR TITLE
Add format rule : react lifecycle methods should be ordered

### DIFF
--- a/server/sonar-web/.eslintrc
+++ b/server/sonar-web/.eslintrc
@@ -163,7 +163,22 @@
     "react/no-unknown-property": 2,
     "react/react-in-jsx-scope": 2,
     "react/require-render-return": 2,
-    "react/self-closing-comp": 2
+    "react/self-closing-comp": 2,
+    "react/sort-comp": [2, {
+      "order": [
+        "type-annotations",
+        "static-methods",
+        "lifecycle",
+        "everything-else",
+        "rendering"
+      ],
+      "groups": {
+        "rendering": [
+          "/^render.+$/",
+          "render"
+        ]
+      }
+    }]
   },
 
   "settings": {

--- a/server/sonar-web/src/main/js/app/components/App.js
+++ b/server/sonar-web/src/main/js/app/components/App.js
@@ -39,12 +39,6 @@ class App extends React.Component {
     loading: true
   };
 
-  finishLoading = () => {
-    if (this.mounted) {
-      this.setState({ loading: false });
-    }
-  };
-
   componentDidMount() {
     this.mounted = true;
 
@@ -62,6 +56,12 @@ class App extends React.Component {
   componentWillUnmount() {
     this.mounted = false;
   }
+
+  finishLoading = () => {
+    if (this.mounted) {
+      this.setState({ loading: false });
+    }
+  };
 
   render() {
     if (this.state.loading) {

--- a/server/sonar-web/src/main/js/app/components/LocalizationContainer.js
+++ b/server/sonar-web/src/main/js/app/components/LocalizationContainer.js
@@ -28,12 +28,6 @@ export default class LocalizationContainer extends React.Component {
     loading: true
   };
 
-  finishLoading = () => {
-    if (this.mounted) {
-      this.setState({ loading: false });
-    }
-  };
-
   componentDidMount() {
     this.mounted = true;
     requestMessages().then(this.finishLoading, this.finishLoading);
@@ -42,6 +36,12 @@ export default class LocalizationContainer extends React.Component {
   componentWillUnmount() {
     this.mounted = false;
   }
+
+  finishLoading = () => {
+    if (this.mounted) {
+      this.setState({ loading: false });
+    }
+  };
 
   render() {
     return this.state.loading ? null : this.props.children;

--- a/server/sonar-web/src/main/js/app/components/nav/global/GlobalNavSearch.js
+++ b/server/sonar-web/src/main/js/app/components/nav/global/GlobalNavSearch.js
@@ -62,15 +62,6 @@ class GlobalNavSearch extends React.Component {
     this.setState({ open: false });
   };
 
-  renderSearchView = () => {
-    const searchContainer = this.refs.container;
-    this.searchView = new SearchView({
-      model: new Backbone.Model(this.props),
-      hide: this.closeSearch
-    });
-    this.searchView.render().$el.appendTo(searchContainer);
-  };
-
   resetSearchView = () => {
     if (this.searchView) {
       this.searchView.destroy();
@@ -90,6 +81,15 @@ class GlobalNavSearch extends React.Component {
     if (!contains(this.refs.dropdown, e.target)) {
       this.closeSearch();
     }
+  };
+
+  renderSearchView = () => {
+    const searchContainer = this.refs.container;
+    this.searchView = new SearchView({
+      model: new Backbone.Model(this.props),
+      hide: this.closeSearch
+    });
+    this.searchView.render().$el.appendTo(searchContainer);
   };
 
   render() {

--- a/server/sonar-web/src/main/js/apps/account/components/Tokens.js
+++ b/server/sonar-web/src/main/js/apps/account/components/Tokens.js
@@ -30,6 +30,12 @@ export default class Tokens extends Component {
     this.destroyView();
   }
 
+  destroyView() {
+    if (this.destroyView) {
+      this.tokensView.destroy();
+    }
+  }
+
   renderView() {
     const account = new Backbone.Model({
       id: this.props.user.login
@@ -39,12 +45,6 @@ export default class Tokens extends Component {
       el: this.refs.container,
       model: account
     }).render();
-  }
-
-  destroyView() {
-    if (this.destroyView) {
-      this.tokensView.destroy();
-    }
   }
 
   render() {

--- a/server/sonar-web/src/main/js/apps/account/notifications/Projects.js
+++ b/server/sonar-web/src/main/js/apps/account/notifications/Projects.js
@@ -62,14 +62,6 @@ class Projects extends React.Component {
     }
   }
 
-  renderOption = option => {
-    return (
-      <span>
-        <Organization organizationKey={option.organization} link={false} />
-        <strong>{option.label}</strong>
-      </span>
-    );
-  };
   loadOptions = (query, cb) => {
     if (query.length < 2) {
       cb(null, { options: [] });
@@ -101,6 +93,15 @@ class Projects extends React.Component {
     this.setState({
       addedProjects: [...this.state.addedProjects, project]
     });
+  };
+
+  renderOption = option => {
+    return (
+      <span>
+        <Organization organizationKey={option.organization} link={false} />
+        <strong>{option.label}</strong>
+      </span>
+    );
   };
 
   render() {

--- a/server/sonar-web/src/main/js/apps/account/organizations/CreateOrganizationForm.js
+++ b/server/sonar-web/src/main/js/apps/account/organizations/CreateOrganizationForm.js
@@ -38,24 +38,23 @@ type State = {
 
 class CreateOrganizationForm extends React.Component {
   mounted: boolean;
-
+  state: State;
   props: {
     createOrganization: () => Promise<*>,
     router: { push: (string) => void }
   };
 
-  state: State = {
-    loading: false,
-    avatar: '',
-    avatarImage: '',
-    description: '',
-    key: '',
-    name: '',
-    url: ''
-  };
-
   constructor(props) {
     super(props);
+    this.state = {
+      loading: false,
+      avatar: '',
+      avatarImage: '',
+      description: '',
+      key: '',
+      name: '',
+      url: ''
+    };
     this.changeAvatarImage = debounce(this.changeAvatarImage, 500);
   }
 

--- a/server/sonar-web/src/main/js/apps/projects-admin/search.js
+++ b/server/sonar-web/src/main/js/apps/projects-admin/search.js
@@ -55,6 +55,20 @@ export default React.createClass({
     return sortBy(options, option => QUALIFIERS_ORDER.indexOf(option.value));
   },
 
+  onCheck(checked) {
+    if (checked) {
+      this.props.onAllSelected();
+    } else {
+      this.props.onAllDeselected();
+    }
+  },
+
+  deleteProjects() {
+    new DeleteView({
+      deleteProjects: this.props.deleteProjects
+    }).render();
+  },
+
   renderCheckbox() {
     const isAllChecked = this.props.projects.length > 0 &&
       this.props.selection.length === this.props.projects.length;
@@ -63,18 +77,6 @@ export default React.createClass({
       this.props.selection.length < this.props.projects.length;
     const checked = isAllChecked || thirdState;
     return <Checkbox checked={checked} thirdState={thirdState} onCheck={this.onCheck} />;
-  },
-
-  renderSpinner() {
-    return <i className="spinner" />;
-  },
-
-  onCheck(checked) {
-    if (checked) {
-      this.props.onAllSelected();
-    } else {
-      this.props.onAllDeselected();
-    }
   },
 
   renderGhostsDescription() {
@@ -86,12 +88,6 @@ export default React.createClass({
         {translate('bulk_deletion.ghosts.description')}
       </div>
     );
-  },
-
-  deleteProjects() {
-    new DeleteView({
-      deleteProjects: this.props.deleteProjects
-    }).render();
   },
 
   renderQualifierFilter() {
@@ -109,6 +105,10 @@ export default React.createClass({
         />
       </td>
     );
+  },
+
+  renderSpinner() {
+    return <i className="spinner" />;
   },
 
   render() {

--- a/server/sonar-web/src/main/js/apps/projects/components/ProjectTagsSelectorContainer.js
+++ b/server/sonar-web/src/main/js/apps/projects/components/ProjectTagsSelectorContainer.js
@@ -41,12 +41,11 @@ const LIST_SIZE = 10;
 
 class ProjectTagsSelectorContainer extends React.PureComponent {
   props: Props;
-  state: State = {
-    searchResult: []
-  };
+  state: State;
 
   constructor(props: Props) {
     super(props);
+    this.state = { searchResult: [] };
     this.onSearch = debounce(this.onSearch, 250);
   }
 

--- a/server/sonar-web/src/main/js/apps/projects/filters/CoverageFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/CoverageFilter.js
@@ -33,6 +33,11 @@ export default class CoverageFilter extends React.PureComponent {
 
   property = 'coverage';
 
+  getFacetValueForOption(facet, option) {
+    const map = ['80.0-*', '70.0-80.0', '50.0-70.0', '30.0-50.0', '*-30.0'];
+    return facet[map[option - 1]];
+  }
+
   renderOption(option, selected) {
     return (
       <span>
@@ -46,11 +51,6 @@ export default class CoverageFilter extends React.PureComponent {
         </span>
       </span>
     );
-  }
-
-  getFacetValueForOption(facet, option) {
-    const map = ['80.0-*', '70.0-80.0', '50.0-70.0', '30.0-50.0', '*-30.0'];
-    return facet[map[option - 1]];
   }
 
   render() {

--- a/server/sonar-web/src/main/js/apps/projects/filters/DuplicationsFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/DuplicationsFilter.js
@@ -36,6 +36,11 @@ export default class DuplicationsFilter extends React.PureComponent {
 
   property = 'duplications';
 
+  getFacetValueForOption(facet, option) {
+    const map = ['*-3.0', '3.0-5.0', '5.0-10.0', '10.0-20.0', '20.0-*'];
+    return facet[map[option - 1]];
+  }
+
   renderOption(option, selected) {
     return (
       <span>
@@ -49,11 +54,6 @@ export default class DuplicationsFilter extends React.PureComponent {
         </span>
       </span>
     );
-  }
-
-  getFacetValueForOption(facet, option) {
-    const map = ['*-3.0', '3.0-5.0', '5.0-10.0', '10.0-20.0', '20.0-*'];
-    return facet[map[option - 1]];
   }
 
   render() {

--- a/server/sonar-web/src/main/js/apps/projects/filters/IssuesFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/IssuesFilter.js
@@ -32,6 +32,10 @@ export default class IssuesFilter extends React.PureComponent {
     organization: React.PropTypes.object
   };
 
+  getFacetValueForOption(facet, option) {
+    return facet[option];
+  }
+
   renderOption(option, selected) {
     return (
       <span>
@@ -39,10 +43,6 @@ export default class IssuesFilter extends React.PureComponent {
         {option > 1 && option < 5 && <span className="note spacer-left">and worse</span>}
       </span>
     );
-  }
-
-  getFacetValueForOption(facet, option) {
-    return facet[option];
   }
 
   render() {

--- a/server/sonar-web/src/main/js/apps/projects/filters/LanguagesFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/LanguagesFilter.js
@@ -44,13 +44,6 @@ export default class LanguagesFilter extends React.PureComponent {
   props: Props;
   property = 'languages';
 
-  renderOption = (option: string) => (
-    <SearchableFilterOption
-      optionKey={option}
-      option={getLanguageByKey(this.props.languages, option)}
-    />
-  );
-
   getSearchOptions(facet: {}, languages: {}) {
     let languageKeys = Object.keys(languages);
     if (facet) {
@@ -66,6 +59,13 @@ export default class LanguagesFilter extends React.PureComponent {
   }
 
   getFacetValueForOption = (facet: {} = {}, option: string) => facet[option];
+
+  renderOption = (option: string) => (
+    <SearchableFilterOption
+      optionKey={option}
+      option={getLanguageByKey(this.props.languages, option)}
+    />
+  );
 
   render() {
     return (

--- a/server/sonar-web/src/main/js/apps/projects/filters/QualityGateFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/QualityGateFilter.js
@@ -29,12 +29,12 @@ export default class QualityGateFilter extends React.PureComponent {
     organization: React.PropTypes.object
   };
 
-  renderOption(option, selected) {
-    return <Level level={option} small={true} muted={!selected} />;
-  }
-
   getFacetValueForOption(facet, option) {
     return facet[option];
+  }
+
+  renderOption(option, selected) {
+    return <Level level={option} small={true} muted={!selected} />;
   }
 
   render() {

--- a/server/sonar-web/src/main/js/apps/projects/filters/SizeFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/SizeFilter.js
@@ -34,6 +34,17 @@ export default class SizeFilter extends React.PureComponent {
 
   property = 'size';
 
+  getFacetValueForOption(facet, option) {
+    const map = [
+      '*-1000.0',
+      '1000.0-10000.0',
+      '10000.0-100000.0',
+      '100000.0-500000.0',
+      '500000.0-*'
+    ];
+    return facet[map[option - 1]];
+  }
+
   renderOption(option, selected) {
     return (
       <span>
@@ -57,17 +68,6 @@ export default class SizeFilter extends React.PureComponent {
       />
     );
   };
-
-  getFacetValueForOption(facet, option) {
-    const map = [
-      '*-1000.0',
-      '1000.0-10000.0',
-      '10000.0-100000.0',
-      '100000.0-500000.0',
-      '500000.0-*'
-    ];
-    return facet[map[option - 1]];
-  }
 
   render() {
     return (

--- a/server/sonar-web/src/main/js/apps/projects/filters/TagsFilter.js
+++ b/server/sonar-web/src/main/js/apps/projects/filters/TagsFilter.js
@@ -47,19 +47,19 @@ const LIST_SIZE = 10;
 export default class TagsFilter extends React.PureComponent {
   getSearchOptions: () => [{ label: string, value: string }];
   props: Props;
-  state: State = {
-    isLoading: false,
-    search: '',
-    tags: []
-  };
-  property = 'tags';
+  state: State;
+  property: string;
 
   constructor(props: Props) {
     super(props);
+    this.state = {
+      isLoading: false,
+      search: '',
+      tags: []
+    };
+    this.property = 'tags';
     this.handleSearch = debounce(this.handleSearch.bind(this), 250);
   }
-
-  renderOption = (option: string) => <SearchableFilterOption optionKey={option} />;
 
   getSearchOptions(facet: {}, tags: Array<string>) {
     let tagsCopy = [...tags];
@@ -87,6 +87,8 @@ export default class TagsFilter extends React.PureComponent {
   }
 
   getFacetValueForOption = (facet: {}, option: string) => facet[option];
+
+  renderOption = (option: string) => <SearchableFilterOption optionKey={option} />;
 
   render() {
     return (

--- a/server/sonar-web/src/main/js/apps/quality-gates/components/Projects.js
+++ b/server/sonar-web/src/main/js/apps/quality-gates/components/Projects.js
@@ -37,6 +37,12 @@ export default class Projects extends Component {
     this.destroyView();
   }
 
+  destroyView() {
+    if (this.projectsView) {
+      this.projectsView.destroy();
+    }
+  }
+
   renderView() {
     const { qualityGate, edit } = this.props;
 
@@ -46,12 +52,6 @@ export default class Projects extends Component {
       container: this.refs.container
     });
     this.projectsView.render();
-  }
-
-  destroyView() {
-    if (this.projectsView) {
-      this.projectsView.destroy();
-    }
   }
 
   render() {

--- a/server/sonar-web/src/main/js/apps/quality-profiles/details/ProfileRules.js
+++ b/server/sonar-web/src/main/js/apps/quality-profiles/details/ProfileRules.js
@@ -101,6 +101,12 @@ export default class ProfileRules extends React.Component {
     );
   }
 
+  getTooltipForType(type) {
+    const { count } = this.state.activatedByType[type];
+    const total = this.state.allByType[type].count;
+    return this.getTooltip(count, total);
+  }
+
   renderActiveTitle() {
     return (
       <strong>
@@ -149,12 +155,6 @@ export default class ProfileRules extends React.Component {
         </strong>
       </Link>
     );
-  }
-
-  getTooltipForType(type) {
-    const { count } = this.state.activatedByType[type];
-    const total = this.state.allByType[type].count;
-    return this.getTooltip(count, total);
   }
 
   renderTitleForType(type) {

--- a/server/sonar-web/src/main/js/apps/users/components/UsersSearch.js
+++ b/server/sonar-web/src/main/js/apps/users/components/UsersSearch.js
@@ -34,12 +34,13 @@ type State = {
 
 export default class UsersSearch extends React.PureComponent {
   props: Props;
-  state: State = {
-    query: ''
-  };
+  state: State;
 
   constructor(props: Props) {
     super(props);
+    this.state = {
+      query: ''
+    };
     this.handleSearch = debounce(this.handleSearch, 250);
   }
 

--- a/server/sonar-web/src/main/js/components/SourceViewer/SourceViewerIssueLocations.js
+++ b/server/sonar-web/src/main/js/components/SourceViewer/SourceViewerIssueLocations.js
@@ -43,7 +43,7 @@ type State = {
 
 export default class SourceViewerIssueLocations extends React.Component {
   fixedNode: HTMLElement;
-  locations: { [string]: HTMLElement } = {};
+  locations: { [string]: HTMLElement };
   node: HTMLElement;
   props: Props;
   rootNode: HTMLElement;
@@ -52,6 +52,7 @@ export default class SourceViewerIssueLocations extends React.Component {
   constructor(props: Props) {
     super(props);
     this.state = { fixed: true, locationBlink: false };
+    this.locations = {};
     this.handleScroll = throttle(this.handleScroll, 50);
   }
 

--- a/server/sonar-web/src/main/js/components/common/MultiSelect.js
+++ b/server/sonar-web/src/main/js/components/common/MultiSelect.js
@@ -44,17 +44,22 @@ export default class MultiSelect extends React.PureComponent {
   container: HTMLElement;
   searchInput: HTMLInputElement;
   props: Props;
-  state: State = {
-    query: '',
-    selectedElements: [],
-    unselectedElements: [],
-    activeIdx: 0
-  };
+  state: State;
 
   static defaultProps = {
     listSize: 10,
     validateSearchInput: (value: string) => value
   };
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      query: '',
+      selectedElements: [],
+      unselectedElements: [],
+      activeIdx: 0
+    };
+  }
 
   componentDidMount() {
     this.updateSelectedElements(this.props);

--- a/server/sonar-web/src/main/js/components/issue/Issue.js
+++ b/server/sonar-web/src/main/js/components/issue/Issue.js
@@ -116,6 +116,10 @@ class Issue extends React.PureComponent {
     }
   };
 
+  destroyIssueView() {
+    this.issueView.destroy();
+  }
+
   renderIssueView() {
     const model = this.props.issue.toJSON ? this.props.issue : new IssueModel(this.props.issue);
     this.issueView = new IssueView({
@@ -130,10 +134,6 @@ class Issue extends React.PureComponent {
     if (this.props.selected) {
       this.issueView.select();
     }
-  }
-
-  destroyIssueView() {
-    this.issueView.destroy();
   }
 
   render() {


### PR DESCRIPTION
With this we should order our components methods like this : 

1. type annotations
2. static methods
3. lifecycle stuff : 
    1. propTypes and ci
    2. constructor
    3. lifecycle methods in right order
4. our custom methods
5. renderXYZ methods
6. render method

We can tweak this order as we want in the `sort-comp` rule if needed.