### PR TITLE
SONAR-9005 disable custom rules for custom orgs

### DIFF
--- a/server/sonar-web/src/main/js/apps/coding-rules/components/CodingRulesAppContainer.js
+++ b/server/sonar-web/src/main/js/apps/coding-rules/components/CodingRulesAppContainer.js
@@ -49,7 +49,11 @@ class CodingRulesAppContainer extends React.PureComponent {
           window.location.hash
       );
     } else {
-      this.stop = init(this.refs.container, this.props.params.organizationKey);
+      this.stop = init(
+        this.refs.container,
+        this.props.params.organizationKey,
+        this.props.params.organizationKey === this.props.appState.defaultOrganization
+      );
     }
   }
 

--- a/server/sonar-web/src/main/js/apps/coding-rules/models/state.js
+++ b/server/sonar-web/src/main/js/apps/coding-rules/models/state.js
@@ -25,21 +25,6 @@ export default State.extend({
     maxResultsReached: false,
     query: {},
     facets: ['types', 'languages'],
-    allFacets: [
-      'q',
-      'rule_key',
-      'languages',
-      'types',
-      'tags',
-      'repositories',
-      'severities',
-      'statuses',
-      'available_since',
-      'is_template',
-      'qprofile',
-      'inheritance',
-      'active_severities'
-    ],
     facetsFromServer: [
       'languages',
       'repositories',

--- a/server/sonar-web/src/main/js/apps/coding-rules/rule-details-view.js
+++ b/server/sonar-web/src/main/js/apps/coding-rules/rule-details-view.js
@@ -171,7 +171,7 @@ export default Marionette.LayoutView.extend({
 
   serializeData() {
     const isCustom = this.model.has('templateKey');
-    const isEditable = this.options.app.canCustomizeRule && isCustom;
+    const isEditable = this.options.app.canWrite && this.options.app.customRules && isCustom;
     let qualityProfilesVisible = true;
 
     if (this.model.get('isTemplate')) {

--- a/server/sonar-web/src/main/js/apps/coding-rules/rule/custom-rule-view.js
+++ b/server/sonar-web/src/main/js/apps/coding-rules/rule/custom-rule-view.js
@@ -47,7 +47,7 @@ export default Marionette.ItemView.extend({
   serializeData() {
     return {
       ...Marionette.ItemView.prototype.serializeData.apply(this, arguments),
-      canDeleteCustomRule: this.options.app.canCreateCustomRule,
+      canDeleteCustomRule: this.options.app.customRules && this.options.app.canWrite,
       templateRule: this.options.templateRule,
       permalink: window.baseUrl + '/coding_rules/#rule_key=' + encodeURIComponent(this.model.id)
     };

--- a/server/sonar-web/src/main/js/apps/coding-rules/rule/custom-rules-view.js
+++ b/server/sonar-web/src/main/js/apps/coding-rules/rule/custom-rules-view.js
@@ -56,7 +56,7 @@ export default Marionette.CompositeView.extend({
   serializeData() {
     return {
       ...Marionette.ItemView.prototype.serializeData.apply(this, arguments),
-      canCreateCustomRule: this.options.app.canCreateCustomRule
+      canCreateCustomRule: this.options.app.customRules && this.options.app.canWrite
     };
   }
 });

--- a/server/sonar-web/src/main/js/apps/coding-rules/rule/rule-description-view.js
+++ b/server/sonar-web/src/main/js/apps/coding-rules/rule/rule-description-view.js
@@ -97,7 +97,7 @@ export default Marionette.ItemView.extend({
     return {
       ...Marionette.ItemView.prototype.serializeData.apply(this, arguments),
       isCustom: this.model.get('isCustom'),
-      canCustomizeRule: this.options.app.canCustomizeRule
+      canCustomizeRule: this.options.app.canWrite && this.options.app.customRules
     };
   }
 });

--- a/server/sonar-web/src/main/js/apps/coding-rules/rule/rule-meta-view.js
+++ b/server/sonar-web/src/main/js/apps/coding-rules/rule/rule-meta-view.js
@@ -112,7 +112,7 @@ export default Marionette.ItemView.extend(RuleFilterMixin).extend({
 
     return {
       ...Marionette.ItemView.prototype.serializeData.apply(this, arguments),
-      canCustomizeRule: this.options.app.canCustomizeRule,
+      canCustomizeRule: this.options.app.canWrite && this.options.app.customRules,
       allTags: union(this.model.get('sysTags'), this.model.get('tags')),
       permalink: window.baseUrl + permalinkPath + '#rule_key=' + encodeURIComponent(this.model.id)
     };


### PR DESCRIPTION
Custom rules and rule customizations must be available only for the default organization (or when organizations are disabled, i.e. on premise).