### PR TITLE
Deprecate parameter “ps” in api/rules/tags

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/rule/ws/TagsAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/rule/ws/TagsAction.java
@@ -65,7 +65,8 @@ public class TagsAction implements RulesWsAction {
     action.createParam("ps")
       .setDescription("The size of the list to return, 0 for all tags")
       .setExampleValue("25")
-      .setDefaultValue("0");
+      .setDefaultValue("0")
+      .setDeprecatedSince("6.4");
     action.createParam(PARAM_ORGANIZATION)
       .setDescription("Organization key")
       .setRequired(false)

--- a/server/sonar-server/src/test/java/org/sonar/server/rule/ws/TagsActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/rule/ws/TagsActionTest.java
@@ -86,6 +86,7 @@ public class TagsActionTest {
     assertThat(pageSize.defaultValue()).isEqualTo("0");
     assertThat(pageSize.description()).isNotEmpty();
     assertThat(pageSize.exampleValue()).isNotEmpty();
+    assertThat(pageSize.deprecatedSince()).isEqualTo("6.4");
 
     WebService.Param organization = action.param("organization");
     assertThat(organization).isNotNull();


### PR DESCRIPTION
The page size parameter probably has not been used much, because the results were not ordered and there is no corresponding parameter "p".