### PR TITLE
SONAR-9132 remove redundant "org-enabled" check for custom rule create/delete

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/rule/RuleDeleter.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/rule/RuleDeleter.java
@@ -26,7 +26,6 @@ import org.sonar.api.utils.System2;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.rule.RuleDefinitionDto;
-import org.sonar.server.organization.OrganizationFlags;
 import org.sonar.server.qualityprofile.RuleActivator;
 import org.sonar.server.rule.index.RuleIndexer;
 
@@ -37,20 +36,16 @@ public class RuleDeleter {
   private final RuleIndexer ruleIndexer;
   private final DbClient dbClient;
   private final RuleActivator ruleActivator;
-  private final OrganizationFlags organizationFlags;
 
-  public RuleDeleter(System2 system2, RuleIndexer ruleIndexer, DbClient dbClient, RuleActivator ruleActivator, OrganizationFlags organizationFlags) {
+  public RuleDeleter(System2 system2, RuleIndexer ruleIndexer, DbClient dbClient, RuleActivator ruleActivator) {
     this.system2 = system2;
     this.ruleIndexer = ruleIndexer;
     this.dbClient = dbClient;
     this.ruleActivator = ruleActivator;
-    this.organizationFlags = organizationFlags;
   }
 
   public void delete(RuleKey ruleKey) {
     try (DbSession dbSession = dbClient.openSession(false)) {
-      organizationFlags.checkDisabled(dbSession);
-
       RuleDefinitionDto rule = dbClient.ruleDao().selectOrFailDefinitionByKey(dbSession, ruleKey);
       if (!rule.isCustomRule()) {
         throw new IllegalStateException("Only custom rules can be deleted");

--- a/server/sonar-server/src/main/java/org/sonar/server/rule/ws/CreateAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/rule/ws/CreateAction.java
@@ -35,7 +35,6 @@ import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.rule.RuleDefinitionDto;
 import org.sonar.db.rule.RuleParamDto;
-import org.sonar.server.organization.OrganizationFlags;
 import org.sonar.server.rule.NewCustomRule;
 import org.sonar.server.rule.ReactivationException;
 import org.sonar.server.rule.RuleCreator;
@@ -64,14 +63,12 @@ public class CreateAction implements RulesWsAction {
   private final DbClient dbClient;
   private final RuleCreator ruleCreator;
   private final RuleMapper ruleMapper;
-  private final OrganizationFlags organizationFlags;
   private final RuleWsSupport ruleWsSupport;
 
-  public CreateAction(DbClient dbClient, RuleCreator ruleCreator, RuleMapper ruleMapper, OrganizationFlags organizationFlags, RuleWsSupport ruleWsSupport) {
+  public CreateAction(DbClient dbClient, RuleCreator ruleCreator, RuleMapper ruleMapper, RuleWsSupport ruleWsSupport) {
     this.dbClient = dbClient;
     this.ruleCreator = ruleCreator;
     this.ruleMapper = ruleMapper;
-    this.organizationFlags = organizationFlags;
     this.ruleWsSupport = ruleWsSupport;
   }
 
@@ -83,8 +80,7 @@ public class CreateAction implements RulesWsAction {
         "Requires the 'Administer Quality Profiles' permission")
       .setSince("4.4")
       .setChangelog(
-        new Change("5.5", "Creating manual rule is not more possible"),
-        new Change("6.4", "Creating custom rules are not supported if the organization feature is enabled. In that case, the webservice will fail"))
+        new Change("5.5", "Creating manual rule is not more possible"))
       .setPost(true)
       .setHandler(this);
 
@@ -143,7 +139,6 @@ public class CreateAction implements RulesWsAction {
     ruleWsSupport.checkQProfileAdminPermission();
     String customKey = request.mandatoryParam(PARAM_CUSTOM_KEY);
     try (DbSession dbSession = dbClient.openSession(false)) {
-      organizationFlags.checkDisabled(dbSession);
       try {
         NewCustomRule newRule = NewCustomRule.createForCustomRule(customKey, RuleKey.parse(request.mandatoryParam(PARAM_TEMPLATE_KEY)))
           .setName(request.mandatoryParam(PARAM_NAME))

--- a/server/sonar-server/src/test/java/org/sonar/server/rule/RuleDeleterTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/rule/RuleDeleterTest.java
@@ -27,10 +27,7 @@ import org.sonar.api.utils.System2;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
 import org.sonar.db.DbTester;
-import org.sonar.db.organization.OrganizationDto;
 import org.sonar.db.rule.RuleDefinitionDto;
-import org.sonar.server.organization.OrganizationFlags;
-import org.sonar.server.organization.TestOrganizationFlags;
 import org.sonar.server.qualityprofile.RuleActivator;
 import org.sonar.server.rule.index.RuleIndexer;
 import org.sonar.server.tester.UserSessionRule;
@@ -41,7 +38,7 @@ import static org.mockito.Mockito.mock;
 
 public class RuleDeleterTest {
 
-  static final long PAST = 10000L;
+  private static final long PAST = 10000L;
 
   @org.junit.Rule
   public UserSessionRule userSessionRule = UserSessionRule.standalone();
@@ -53,14 +50,11 @@ public class RuleDeleterTest {
   private DbClient dbClient = dbTester.getDbClient();
   private DbSession dbSession = dbTester.getSession();
   private RuleIndexer ruleIndexer = mock(RuleIndexer.class);
-  private OrganizationFlags organizationFlags = TestOrganizationFlags.standalone();
   private RuleActivator ruleActivator = mock(RuleActivator.class);
-  private RuleDeleter deleter = new RuleDeleter(System2.INSTANCE, ruleIndexer, dbClient, ruleActivator, organizationFlags);
+  private RuleDeleter deleter = new RuleDeleter(System2.INSTANCE, ruleIndexer, dbClient, ruleActivator);
 
   @Test
   public void delete_custom_rule() {
-    OrganizationDto organization = dbTester.organizations().insert();
-
     RuleDefinitionDto templateRule = dbTester.rules().insert(
       r -> r.setIsTemplate(true),
       r -> r.setCreatedAt(PAST),
@@ -93,17 +87,6 @@ public class RuleDeleterTest {
 
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Only custom rules can be deleted");
-
-    deleter.delete(rule.getKey());
-  }
-
-  @Test
-  public void fail_if_organizations_enabled() {
-    RuleDefinitionDto rule = dbTester.rules().insert();
-    organizationFlags.enable(dbSession);
-
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Organization support is enabled");
 
     deleter.delete(rule.getKey());
   }


### PR DESCRIPTION
As of #1949, template rules and custom rules will be removed, when you enable organizations. The checks on api/rules/create and api/rules/delete are now redundant.