### PR TITLE
Force authentication by default

### DIFF
--- a/sonar-plugin-api/src/main/java/org/sonar/api/CoreProperties.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/CoreProperties.java
@@ -182,7 +182,7 @@ public interface CoreProperties {
   /* Sonar Core */
 
   String CORE_FORCE_AUTHENTICATION_PROPERTY = "sonar.forceAuthentication";
-  boolean CORE_FORCE_AUTHENTICATION_DEFAULT_VALUE = false;
+  boolean CORE_FORCE_AUTHENTICATION_DEFAULT_VALUE = true;
 
   /**
    * @deprecated since 6.3. This feature is not supported anymore


### PR DESCRIPTION
When new users initialise their SonarQube instance, it would be better to 
make their system to follow the 'secure-by-default' mantra. 

The current configuration of `sonar.forceAuthentication = false` means that 
as soon as a SonarQube instance is hosted and has scanned a project, there is 
potentially sensitive information exposed to non-authenticated users that could
just connect to the server.

While this is not an issue for more experienced users, for those less-knowledgeable, 
it can expose them to an unnecessary vulnerability.

P.S. I searched here and in JIRA for related issues/PRs and couldn't find anything. I also tried to raise an issue on JIRA but didn't have permission to submit one. Thought the easiest way would be to put a PR in for discussion/merging. Thanks!