### PR TITLE
SONAR-9079 let favorites not be found as suggestion, if they don’t match

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/component/index/ComponentIndex.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/component/index/ComponentIndex.java
@@ -39,6 +39,7 @@ import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsBuilder;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.sonar.server.es.EsClient;
 import org.sonar.server.es.textsearch.ComponentTextSearchFeature;
+import org.sonar.server.es.textsearch.ComponentTextSearchFeatureRepertoire;
 import org.sonar.server.es.textsearch.ComponentTextSearchQueryFactory;
 import org.sonar.server.es.textsearch.ComponentTextSearchQueryFactory.ComponentTextSearchQuery;
 import org.sonar.server.permission.index.AuthorizationTypeSupport;
@@ -78,7 +79,7 @@ public class ComponentIndex {
   }
 
   public ComponentIndexResults search(ComponentIndexQuery query) {
-    return search(query, ComponentTextSearchFeature.values());
+    return search(query, ComponentTextSearchFeatureRepertoire.values());
   }
 
   @VisibleForTesting

--- a/server/sonar-server/src/main/java/org/sonar/server/component/ws/SuggestionsAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/component/ws/SuggestionsAction.java
@@ -41,7 +41,7 @@ import org.sonar.server.component.index.ComponentHitsPerQualifier;
 import org.sonar.server.component.index.ComponentIndex;
 import org.sonar.server.component.index.ComponentIndexQuery;
 import org.sonar.server.component.index.ComponentIndexResults;
-import org.sonar.server.es.textsearch.ComponentTextSearchFeature;
+import org.sonar.server.es.textsearch.ComponentTextSearchFeatureRepertoire;
 import org.sonar.server.favorite.FavoriteFinder;
 import org.sonarqube.ws.WsComponents.SuggestionsWsResponse;
 import org.sonarqube.ws.WsComponents.SuggestionsWsResponse.Category;
@@ -144,7 +144,7 @@ public class SuggestionsAction implements ComponentsWsAction {
   }
 
   private static String getWarning(String query) {
-    List<String> tokens = ComponentTextSearchFeature.split(query).collect(Collectors.toList());
+    List<String> tokens = ComponentTextSearchFeatureRepertoire.split(query).collect(Collectors.toList());
     if (tokens.stream().anyMatch(token -> token.length() < MINIMUM_NGRAM_LENGTH)) {
       return SHORT_INPUT_WARNING;
     }

--- a/server/sonar-server/src/main/java/org/sonar/server/es/textsearch/ComponentTextSearchFeature.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/es/textsearch/ComponentTextSearchFeature.java
@@ -17,127 +17,26 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+
 package org.sonar.server.es.textsearch;
 
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
-import org.apache.commons.lang.StringUtils;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.sonar.server.es.DefaultIndexSettings;
-import org.sonar.server.es.DefaultIndexSettingsElement;
 import org.sonar.server.es.textsearch.ComponentTextSearchQueryFactory.ComponentTextSearchQuery;
 
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
-import static org.sonar.server.es.DefaultIndexSettingsElement.SEARCH_GRAMS_ANALYZER;
-import static org.sonar.server.es.DefaultIndexSettingsElement.SEARCH_PREFIX_ANALYZER;
-import static org.sonar.server.es.DefaultIndexSettingsElement.SEARCH_PREFIX_CASE_INSENSITIVE_ANALYZER;
-import static org.sonar.server.es.DefaultIndexSettingsElement.SORTABLE_ANALYZER;
+public interface ComponentTextSearchFeature {
 
-public enum ComponentTextSearchFeature {
+  enum UseCase {
+    GENERATE_RESULTS, CHANGE_ORDER_OF_RESULTS;
+  }
 
-  EXACT_IGNORE_CASE {
-    @Override
-    public QueryBuilder getQuery(ComponentTextSearchQuery query) {
-      return matchQuery(SORTABLE_ANALYZER.subField(query.getFieldName()), query.getQueryText())
-        .boost(2.5f);
-    }
-  },
-  PREFIX {
-    @Override
-    public QueryBuilder getQuery(ComponentTextSearchQuery query) {
-      return prefixAndPartialQuery(query.getQueryText(), query.getFieldName(), SEARCH_PREFIX_ANALYZER)
-        .boost(3f);
-    }
-  },
-  PREFIX_IGNORE_CASE {
-    @Override
-    public QueryBuilder getQuery(ComponentTextSearchQuery query) {
-      String lowerCaseQueryText = query.getQueryText().toLowerCase(Locale.getDefault());
-      return prefixAndPartialQuery(lowerCaseQueryText, query.getFieldName(), SEARCH_PREFIX_CASE_INSENSITIVE_ANALYZER)
-        .boost(2f);
-    }
-  },
-  PARTIAL {
-    @Override
-    public QueryBuilder getQuery(ComponentTextSearchQuery query) {
-      BoolQueryBuilder queryBuilder = boolQuery();
-      split(query.getQueryText())
-        .map(text -> tokenQuery(text, query.getFieldName(), SEARCH_GRAMS_ANALYZER))
-        .forEach(queryBuilder::must);
-      return queryBuilder
-        .boost(0.5f);
-    }
-  },
-  KEY {
-    @Override
-    public QueryBuilder getQuery(ComponentTextSearchQuery query) {
-      return matchQuery(SORTABLE_ANALYZER.subField(query.getFieldKey()), query.getQueryText())
-        .boost(50f);
-    }
-  },
-  RECENTLY_BROWSED {
-    @Override
-    public Stream<QueryBuilder> getQueries(ComponentTextSearchQuery query) {
-      Set<String> recentlyBrowsedKeys = query.getRecentlyBrowsedKeys();
-      if (recentlyBrowsedKeys.isEmpty()) {
-        return Stream.empty();
-      }
-      return Stream.of(termsQuery(query.getFieldKey(), recentlyBrowsedKeys).boost(100f));
-    }
-  },
-  FAVORITE {
-    @Override
-    public Stream<QueryBuilder> getQueries(ComponentTextSearchQuery query) {
-      Set<String> favoriteKeys = query.getFavoriteKeys();
-      if (favoriteKeys.isEmpty()) {
-        return Stream.empty();
-      }
-      return Stream.of(termsQuery(query.getFieldKey(), favoriteKeys).boost(1000f));
-    }
-  };
+  default UseCase getUseCase() {
+    return UseCase.GENERATE_RESULTS;
+  }
 
-  public Stream<QueryBuilder> getQueries(ComponentTextSearchQuery query) {
+  default Stream<QueryBuilder> getQueries(ComponentTextSearchQuery query) {
     return Stream.of(getQuery(query));
   }
 
-  public QueryBuilder getQuery(ComponentTextSearchQuery query) {
-    throw new UnsupportedOperationException();
-  }
-
-  public static Stream<String> split(String queryText) {
-    return Arrays.stream(
-      queryText.split(DefaultIndexSettings.SEARCH_TERM_TOKENIZER_PATTERN))
-      .filter(StringUtils::isNotEmpty);
-  }
-
-  protected BoolQueryBuilder prefixAndPartialQuery(String queryText, String originalFieldName, DefaultIndexSettingsElement analyzer) {
-    BoolQueryBuilder queryBuilder = boolQuery();
-
-    AtomicBoolean first = new AtomicBoolean(true);
-    split(queryText)
-      .map(queryTerm -> {
-
-        if (first.getAndSet(false)) {
-          return tokenQuery(queryTerm, originalFieldName, analyzer);
-        }
-
-        return tokenQuery(queryTerm, originalFieldName, SEARCH_GRAMS_ANALYZER);
-      })
-      .forEach(queryBuilder::must);
-    return queryBuilder;
-  }
-
-  protected MatchQueryBuilder tokenQuery(String queryTerm, String fieldName, DefaultIndexSettingsElement analyzer) {
-    // We will truncate the search to the maximum length of nGrams in the index.
-    // Otherwise the search would for sure not find any results.
-    String truncatedQuery = StringUtils.left(queryTerm, DefaultIndexSettings.MAXIMUM_NGRAM_LENGTH);
-    return matchQuery(analyzer.subField(fieldName), truncatedQuery);
-  }
+  QueryBuilder getQuery(ComponentTextSearchQuery query);
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/es/textsearch/ComponentTextSearchFeatureRepertoire.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/es/textsearch/ComponentTextSearchFeatureRepertoire.java
@@ -1,0 +1,153 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.es.textsearch;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.sonar.server.es.DefaultIndexSettings;
+import org.sonar.server.es.DefaultIndexSettingsElement;
+import org.sonar.server.es.textsearch.ComponentTextSearchQueryFactory.ComponentTextSearchQuery;
+
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
+import static org.sonar.server.es.DefaultIndexSettingsElement.SEARCH_GRAMS_ANALYZER;
+import static org.sonar.server.es.DefaultIndexSettingsElement.SEARCH_PREFIX_ANALYZER;
+import static org.sonar.server.es.DefaultIndexSettingsElement.SEARCH_PREFIX_CASE_INSENSITIVE_ANALYZER;
+import static org.sonar.server.es.DefaultIndexSettingsElement.SORTABLE_ANALYZER;
+import static org.sonar.server.es.textsearch.ComponentTextSearchFeature.UseCase.CHANGE_ORDER_OF_RESULTS;
+import static org.sonar.server.es.textsearch.ComponentTextSearchFeature.UseCase.GENERATE_RESULTS;
+
+public enum ComponentTextSearchFeatureRepertoire implements ComponentTextSearchFeature {
+
+  EXACT_IGNORE_CASE(CHANGE_ORDER_OF_RESULTS) {
+    @Override
+    public QueryBuilder getQuery(ComponentTextSearchQuery query) {
+      return matchQuery(SORTABLE_ANALYZER.subField(query.getFieldName()), query.getQueryText())
+        .boost(2.5f);
+    }
+  },
+  PREFIX(CHANGE_ORDER_OF_RESULTS) {
+    @Override
+    public QueryBuilder getQuery(ComponentTextSearchQuery query) {
+      return prefixAndPartialQuery(query.getQueryText(), query.getFieldName(), SEARCH_PREFIX_ANALYZER)
+        .boost(3f);
+    }
+  },
+  PREFIX_IGNORE_CASE(GENERATE_RESULTS) {
+    @Override
+    public QueryBuilder getQuery(ComponentTextSearchQuery query) {
+      String lowerCaseQueryText = query.getQueryText().toLowerCase(Locale.getDefault());
+      return prefixAndPartialQuery(lowerCaseQueryText, query.getFieldName(), SEARCH_PREFIX_CASE_INSENSITIVE_ANALYZER)
+        .boost(2f);
+    }
+  },
+  PARTIAL(GENERATE_RESULTS) {
+    @Override
+    public QueryBuilder getQuery(ComponentTextSearchQuery query) {
+      BoolQueryBuilder queryBuilder = boolQuery();
+      split(query.getQueryText())
+        .map(text -> tokenQuery(text, query.getFieldName(), SEARCH_GRAMS_ANALYZER))
+        .forEach(queryBuilder::must);
+      return queryBuilder
+        .boost(0.5f);
+    }
+  },
+  KEY(GENERATE_RESULTS) {
+    @Override
+    public QueryBuilder getQuery(ComponentTextSearchQuery query) {
+      return matchQuery(SORTABLE_ANALYZER.subField(query.getFieldKey()), query.getQueryText())
+        .boost(50f);
+    }
+  },
+  RECENTLY_BROWSED(CHANGE_ORDER_OF_RESULTS) {
+    @Override
+    public Stream<QueryBuilder> getQueries(ComponentTextSearchQuery query) {
+      Set<String> recentlyBrowsedKeys = query.getRecentlyBrowsedKeys();
+      if (recentlyBrowsedKeys.isEmpty()) {
+        return Stream.empty();
+      }
+      return Stream.of(termsQuery(query.getFieldKey(), recentlyBrowsedKeys).boost(100f));
+    }
+  },
+  FAVORITE(CHANGE_ORDER_OF_RESULTS) {
+    @Override
+    public Stream<QueryBuilder> getQueries(ComponentTextSearchQuery query) {
+      Set<String> favoriteKeys = query.getFavoriteKeys();
+      if (favoriteKeys.isEmpty()) {
+        return Stream.empty();
+      }
+      return Stream.of(termsQuery(query.getFieldKey(), favoriteKeys).boost(1000f));
+    }
+  };
+
+  private final UseCase useCase;
+
+  ComponentTextSearchFeatureRepertoire(UseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @Override
+  public QueryBuilder getQuery(ComponentTextSearchQuery query) {
+    throw new UnsupportedOperationException();
+  }
+
+  public static Stream<String> split(String queryText) {
+    return Arrays.stream(
+      queryText.split(DefaultIndexSettings.SEARCH_TERM_TOKENIZER_PATTERN))
+      .filter(StringUtils::isNotEmpty);
+  }
+
+  protected BoolQueryBuilder prefixAndPartialQuery(String queryText, String originalFieldName, DefaultIndexSettingsElement analyzer) {
+    BoolQueryBuilder queryBuilder = boolQuery();
+
+    AtomicBoolean first = new AtomicBoolean(true);
+    split(queryText)
+      .map(queryTerm -> {
+
+        if (first.getAndSet(false)) {
+          return tokenQuery(queryTerm, originalFieldName, analyzer);
+        }
+
+        return tokenQuery(queryTerm, originalFieldName, SEARCH_GRAMS_ANALYZER);
+      })
+      .forEach(queryBuilder::must);
+    return queryBuilder;
+  }
+
+  protected MatchQueryBuilder tokenQuery(String queryTerm, String fieldName, DefaultIndexSettingsElement analyzer) {
+    // We will truncate the search to the maximum length of nGrams in the index.
+    // Otherwise the search would for sure not find any results.
+    String truncatedQuery = StringUtils.left(queryTerm, DefaultIndexSettings.MAXIMUM_NGRAM_LENGTH);
+    return matchQuery(analyzer.subField(fieldName), truncatedQuery);
+  }
+
+  @Override
+  public UseCase getUseCase() {
+    return useCase;
+  }
+}

--- a/server/sonar-server/src/main/java/org/sonar/server/measure/index/ProjectMeasuresIndex.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/measure/index/ProjectMeasuresIndex.java
@@ -47,7 +47,7 @@ import org.sonar.server.es.EsClient;
 import org.sonar.server.es.SearchIdResult;
 import org.sonar.server.es.SearchOptions;
 import org.sonar.server.es.StickyFacetBuilder;
-import org.sonar.server.es.textsearch.ComponentTextSearchFeature;
+import org.sonar.server.es.textsearch.ComponentTextSearchFeatureRepertoire;
 import org.sonar.server.es.textsearch.ComponentTextSearchQueryFactory;
 import org.sonar.server.measure.index.ProjectMeasuresQuery.MetricCriterion;
 import org.sonar.server.permission.index.AuthorizationTypeSupport;
@@ -284,7 +284,7 @@ public class ProjectMeasuresIndex {
       .setFieldKey(FIELD_KEY)
       .setFieldName(FIELD_NAME)
       .build();
-    return Optional.of(ComponentTextSearchQueryFactory.createQuery(componentTextSearchQuery, ComponentTextSearchFeature.values()));
+    return Optional.of(ComponentTextSearchQueryFactory.createQuery(componentTextSearchQuery, ComponentTextSearchFeatureRepertoire.values()));
   }
 
   private static QueryBuilder toValueQuery(MetricCriterion criterion) {

--- a/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexFeatureKeyTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexFeatureKeyTest.java
@@ -22,13 +22,13 @@ package org.sonar.server.component.index;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.db.component.ComponentDto;
-import org.sonar.server.es.textsearch.ComponentTextSearchFeature;
+import org.sonar.server.es.textsearch.ComponentTextSearchFeatureRepertoire;
 
 public class ComponentIndexFeatureKeyTest extends ComponentIndexTest {
 
   @Before
   public void before() {
-    features.set(ComponentTextSearchFeature.KEY);
+    features.set(ComponentTextSearchFeatureRepertoire.KEY);
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexFeaturePartialTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexFeaturePartialTest.java
@@ -22,13 +22,13 @@ package org.sonar.server.component.index;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.db.component.ComponentDto;
-import org.sonar.server.es.textsearch.ComponentTextSearchFeature;
+import org.sonar.server.es.textsearch.ComponentTextSearchFeatureRepertoire;
 
 public class ComponentIndexFeaturePartialTest extends ComponentIndexTest {
 
   @Before
   public void before() {
-    features.set(ComponentTextSearchFeature.PARTIAL);
+    features.set(ComponentTextSearchFeatureRepertoire.PARTIAL);
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexFeaturePrefixTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexFeaturePrefixTest.java
@@ -21,13 +21,13 @@ package org.sonar.server.component.index;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.sonar.server.es.textsearch.ComponentTextSearchFeature;
+import org.sonar.server.es.textsearch.ComponentTextSearchFeatureRepertoire;
 
 public class ComponentIndexFeaturePrefixTest extends ComponentIndexTest {
 
   @Before
   public void before() {
-    features.set(ComponentTextSearchFeature.PREFIX, ComponentTextSearchFeature.PREFIX_IGNORE_CASE);
+    features.set(ComponentTextSearchFeatureRepertoire.PREFIX, ComponentTextSearchFeatureRepertoire.PREFIX_IGNORE_CASE);
   }
 
   @Test
@@ -47,14 +47,8 @@ public class ComponentIndexFeaturePrefixTest extends ComponentIndexTest {
 
   @Test
   public void should_be_able_to_ignore_case() {
-    features.set(ComponentTextSearchFeature.PREFIX_IGNORE_CASE);
+    features.set(ComponentTextSearchFeatureRepertoire.PREFIX_IGNORE_CASE);
     assertResultOrder("cOmPoNeNt.Js", "CoMpOnEnT.jS");
-  }
-
-  @Test
-  public void should_be_able_to_match_case() {
-    features.set(ComponentTextSearchFeature.PREFIX);
-    assertNoFileMatches("cOmPoNeNt.Js", "CoMpOnEnT.jS");
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexFeatureRecentlyBrowsedTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexFeatureRecentlyBrowsedTest.java
@@ -24,20 +24,21 @@ import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.db.component.ComponentDto;
-import org.sonar.server.es.textsearch.ComponentTextSearchFeature;
+import org.sonar.server.es.textsearch.ComponentTextSearchFeatureRepertoire;
 
 import static com.google.common.collect.ImmutableSet.of;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.sonar.api.resources.Qualifiers.PROJECT;
 
 public class ComponentIndexFeatureRecentlyBrowsedTest extends ComponentIndexTest {
 
   @Before
   public void before() {
-    features.set(ComponentTextSearchFeature.PREFIX, ComponentTextSearchFeature.RECENTLY_BROWSED);
+    features.set(query -> matchAllQuery(), ComponentTextSearchFeatureRepertoire.RECENTLY_BROWSED);
   }
 
   @Test
-  public void search_projects_by_exact_name() {
+  public void scoring_cares_about_recently_browsed() {
     ComponentDto project1 = indexProject("sonarqube", "SonarQube");
     ComponentDto project2 = indexProject("recent", "SonarQube Recently");
 

--- a/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexMultipleWordsTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexMultipleWordsTest.java
@@ -20,7 +20,7 @@
 package org.sonar.server.component.index;
 
 import org.junit.Test;
-import org.sonar.server.es.textsearch.ComponentTextSearchFeature;
+import org.sonar.server.es.textsearch.ComponentTextSearchFeatureRepertoire;
 
 public class ComponentIndexMultipleWordsTest extends ComponentIndexTest {
 
@@ -32,7 +32,7 @@ public class ComponentIndexMultipleWordsTest extends ComponentIndexTest {
 
   @Test
   public void should_find_partial_match() {
-    features.set(ComponentTextSearchFeature.PARTIAL);
+    features.set(ComponentTextSearchFeatureRepertoire.PARTIAL);
     assertResultOrder("struts java",
       "Xstrutsx.Xjavax");
   }
@@ -87,7 +87,7 @@ public class ComponentIndexMultipleWordsTest extends ComponentIndexTest {
 
   @Test
   public void should_require_all_words_to_match_for_partial() {
-    features.set(ComponentTextSearchFeature.PARTIAL);
+    features.set(ComponentTextSearchFeatureRepertoire.PARTIAL);
     assertNoFileMatches("struts java",
       "Struts");
   }

--- a/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexScoreTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexScoreTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.sonar.db.component.ComponentDto;
 import org.sonar.db.component.ComponentTesting;
-import org.sonar.server.es.textsearch.ComponentTextSearchFeature;
+import org.sonar.server.es.textsearch.ComponentTextSearchFeatureRepertoire;
 
 import static java.util.Arrays.asList;
 import static org.sonar.api.resources.Qualifiers.FILE;
@@ -112,19 +112,25 @@ public class ComponentIndexScoreTest extends ComponentIndexTest {
 
   @Test
   public void should_prefer_favorite_over_recently_browsed() {
-    ComponentDto recentlyBrowsed = db.components().insertPrivateProject(c -> c.setName("File1"));
-    index(recentlyBrowsed);
+    ComponentDto file1 = db.components().insertPrivateProject(c -> c.setName("File1"));
+    index(file1);
 
-    ComponentDto favorite = db.components().insertPrivateProject(c -> c.setName("File2"));
-    index(favorite);
+    ComponentDto file2 = db.components().insertPrivateProject(c -> c.setName("File2"));
+    index(file2);
 
-    ComponentIndexQuery query = ComponentIndexQuery.builder()
-      .setQuery("sonarqube")
+    assertSearch(ComponentIndexQuery.builder()
+      .setQuery("File")
       .setQualifiers(asList(PROJECT, MODULE, FILE))
-      .setRecentlyBrowsedKeys(ImmutableSet.of(recentlyBrowsed.getKey()))
-      .setFavoriteKeys(ImmutableSet.of(favorite.getKey()))
-      .build();
-    assertSearch(query).containsExactly(uuids(favorite, recentlyBrowsed));
+      .setRecentlyBrowsedKeys(ImmutableSet.of(file1.getKey()))
+      .setFavoriteKeys(ImmutableSet.of(file2.getKey()))
+      .build()).containsExactly(uuids(file2, file1));
+
+    assertSearch(ComponentIndexQuery.builder()
+      .setQuery("File")
+      .setQualifiers(asList(PROJECT, MODULE, FILE))
+      .setRecentlyBrowsedKeys(ImmutableSet.of(file2.getKey()))
+      .setFavoriteKeys(ImmutableSet.of(file1.getKey()))
+      .build()).containsExactly(uuids(file1, file2));
   }
 
   @Test
@@ -141,7 +147,7 @@ public class ComponentIndexScoreTest extends ComponentIndexTest {
 
   @Test
   public void scoring_test_DbTester() {
-    features.set(ComponentTextSearchFeature.PARTIAL);
+    features.set(ComponentTextSearchFeatureRepertoire.PARTIAL);
 
     ComponentDto project = indexProject("key-1", "Quality Product");
 

--- a/server/sonar-server/src/test/java/org/sonar/server/es/textsearch/ComponentTextSearchFeatureRule.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/es/textsearch/ComponentTextSearchFeatureRule.java
@@ -27,7 +27,7 @@ public class ComponentTextSearchFeatureRule extends ExternalResource {
 
   @Override
   protected void before() throws Throwable {
-    features = ComponentTextSearchFeature.values();
+    features = ComponentTextSearchFeatureRepertoire.values();
   }
 
   public ComponentTextSearchFeature[] get() {

--- a/server/sonar-server/src/test/java/org/sonar/server/es/textsearch/ComponentTextSearchQueryFactoryTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/es/textsearch/ComponentTextSearchQueryFactoryTest.java
@@ -37,16 +37,20 @@ public class ComponentTextSearchQueryFactoryTest {
   public void create_query() throws Exception {
     QueryBuilder result = createQuery(ComponentTextSearchQuery.builder()
       .setQueryText("SonarQube").setFieldKey("key").setFieldName("name").build(),
-      ComponentTextSearchFeature.KEY);
+      ComponentTextSearchFeatureRepertoire.KEY);
 
     assertJson(result.toString()).isSimilarTo("{" +
       "  \"bool\" : {" +
-      "    \"should\" : {" +
-      "      \"match\" : {" +
-      "        \"key.sortable_analyzer\" : {" +
-      "          \"query\" : \"SonarQube\"," +
-      "          \"type\" : \"boolean\"," +
-      "          \"boost\" : 50.0\n" +
+      "    \"must\" : {" +
+      "      \"bool\" : {" +
+      "        \"should\" : {" +
+      "          \"match\" : {" +
+      "            \"key.sortable_analyzer\" : {" +
+      "              \"query\" : \"SonarQube\"," +
+      "              \"type\" : \"boolean\"," +
+      "              \"boost\" : 50.0\n" +
+      "            }" +
+      "          }" +
       "        }" +
       "      }" +
       "    }" +


### PR DESCRIPTION
The component text query is divided into two parts: one part generates results, the other part boosts certain results for the correct ordering.