### PR TITLE
SONAR-9168 do not fail when indexing measure with unexpected text value

### DIFF
--- a/server/sonar-db-dao/src/main/java/org/sonar/db/measure/ProjectMeasuresIndexerIterator.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/measure/ProjectMeasuresIndexerIterator.java
@@ -220,9 +220,7 @@ public class ProjectMeasuresIndexerIterator extends CloseableIterator<ProjectMea
     }
     if (NCLOC_LANGUAGE_DISTRIBUTION_KEY.equals(metricKey)) {
       readTextValue(rs, measures::setLanguages);
-      return;
     }
-    throw new IllegalArgumentException("Measure has no value");
   }
 
   private static void readTextValue(ResultSet rs, Consumer<String> action) throws SQLException {


### PR DESCRIPTION
Contrary to what's suggested in ticket, this PR simply ignores numeric measures that don't have any numeric value