### PR TITLE
SONAR-9217 if two component suggestions have the same relevancy, prefer A over Z

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/component/index/ComponentIndex.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/component/index/ComponentIndex.java
@@ -37,6 +37,8 @@ import org.elasticsearch.search.aggregations.bucket.filters.InternalFilters.Buck
 import org.elasticsearch.search.aggregations.metrics.tophits.InternalTopHits;
 import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsBuilder;
 import org.elasticsearch.search.highlight.HighlightBuilder;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.ScoreSortBuilder;
 import org.sonar.server.es.EsClient;
 import org.sonar.server.es.textsearch.ComponentTextSearchFeature;
 import org.sonar.server.es.textsearch.ComponentTextSearchFeatureRepertoire;
@@ -116,7 +118,9 @@ public class ComponentIndex {
       .setHighlighterPostTags("</mark>")
       .addHighlightedField(createHighlighter())
       .setFrom(query.getSkip())
-      .setSize(query.getLimit());
+      .setSize(query.getLimit())
+      .addSort(new ScoreSortBuilder())
+      .addSort(new FieldSortBuilder(ComponentIndexDefinition.FIELD_NAME));
     return sub.setFetchSource(false);
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexScoreTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexScoreTest.java
@@ -146,6 +146,13 @@ public class ComponentIndexScoreTest extends ComponentIndexTest {
   }
 
   @Test
+  public void rank_a_higher_then_b() {
+    assertResultOrder("sonarqube",
+      "sonarqubeA",
+      "sonarqubeB");
+  }
+
+  @Test
   public void scoring_test_DbTester() {
     features.set(ComponentTextSearchFeatureRepertoire.PARTIAL);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexScoreTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/component/index/ComponentIndexScoreTest.java
@@ -146,7 +146,7 @@ public class ComponentIndexScoreTest extends ComponentIndexTest {
   }
 
   @Test
-  public void rank_a_higher_then_b() {
+  public void if_relevancy_is_equal_fall_back_to_alphabetical_ordering() {
     assertResultOrder("sonarqube",
       "sonarqubeA",
       "sonarqubeB");


### PR DESCRIPTION
api/components/suggestions used to only use "relevance" (score) in sorting results. If two suggestions have exactly the same relevance (this is a rare case), then we will now also take alphabetical order into account.