### PR TITLE
Do not break if navigator.language == undefined

### DIFF
--- a/server/sonar-web/src/main/js/helpers/l10n.js
+++ b/server/sonar-web/src/main/js/helpers/l10n.js
@@ -79,12 +79,12 @@ export function requestMessages() {
 
   if (browserLocale) {
     params.locale = browserLocale;
-  }
 
-  if (browserLocale.startsWith(cachedLocale)) {
-    const bundleTimestamp = localStorage.getItem('l10n.timestamp');
-    if (bundleTimestamp !== null && checkCachedBundle()) {
-      params.ts = bundleTimestamp;
+    if (browserLocale.startsWith(cachedLocale)) {
+      const bundleTimestamp = localStorage.getItem('l10n.timestamp');
+      if (bundleTimestamp !== null && checkCachedBundle()) {
+        params.ts = bundleTimestamp;
+      }
     }
   }
 


### PR DESCRIPTION
(Note this is actually not tested, so I don't know whether it fixes the issue completely)

Related to #1151