### PR TITLE
implement an easy/non check https client on demand, secure per default

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/bootstrap/ScannerWsClientProvider.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/bootstrap/ScannerWsClientProvider.java
@@ -68,7 +68,7 @@ public class ScannerWsClientProvider extends ProviderAdapter {
       if (!proxyUser.isEmpty()) {
         connectorBuilder.proxyCredentials(proxyUser, System.getProperty("http.proxyPassword"));
       }
-      if(Boolean.valueOf( System.getProperty( "sonar.http.ssl.insecure", "false" ) )) {
+      if(Boolean.getBoolean("sonar.http.ssl.insecure")) {
         try {
           // Create a trust manager that does not validate certificate chains
           X509TrustManager easyTrust =
@@ -100,7 +100,7 @@ public class ScannerWsClientProvider extends ProviderAdapter {
           throw new RuntimeException( e.getMessage(), e );
         }
       }
-      if(Boolean.valueOf( System.getProperty( "sonar.http.ssl.allowall", "false" ) )) {
+      if(Boolean.getBoolean("sonar.http.ssl.allowall")) {
         connectorBuilder.hostnameVerifier( ( s, sslSession ) -> true );
       }
       wsClient = new ScannerWsClient(WsClientFactories.getDefault().newClient(connectorBuilder.build()), login != null, globalMode);

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/bootstrap/ScannerWsClientProvider.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/bootstrap/ScannerWsClientProvider.java
@@ -72,25 +72,22 @@ public class ScannerWsClientProvider extends ProviderAdapter {
         try {
           // Create a trust manager that does not validate certificate chains
           X509TrustManager easyTrust =
-              new X509TrustManager() {
-                @Override
-                public void checkClientTrusted(X509Certificate[] chain, String authType)
-                    throws CertificateException
-                {
-                  // no op
-                }
+            new X509TrustManager() {
+              @Override
+              public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                // no op
+              }
 
-                @Override
-                public void checkServerTrusted(X509Certificate[] chain, String authType)
-                    throws CertificateException {
-                  // no op
-                }
+              @Override
+              public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                // no op
+              }
 
-                @Override
-                public X509Certificate[] getAcceptedIssuers() {
-                  return new X509Certificate[0];
-                }
-              };
+              @Override
+              public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+              }
+            };
 
           // Init the ezy trusting trust manager
           SSLContext sslContext = SSLContext.getInstance( "SSL");

--- a/sonar-ws/src/main/java/org/sonarqube/ws/client/HttpConnector.java
+++ b/sonar-ws/src/main/java/org/sonarqube/ws/client/HttpConnector.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.Proxy;
 import java.util.Map;
 import javax.annotation.Nullable;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Call;
@@ -81,6 +82,9 @@ public class HttpConnector implements WsConnector {
     okHttpClientBuilder.setReadTimeoutMs(builder.readTimeoutMs);
     okHttpClientBuilder.setSSLSocketFactory(builder.sslSocketFactory);
     okHttpClientBuilder.setTrustManager(builder.sslTrustManager);
+    if(builder.hostnameVerifier!=null) {
+      okHttpClientBuilder.set( builder.hostnameVerifier );
+    }
     this.okHttpClient = okHttpClientBuilder.build();
   }
 
@@ -196,6 +200,7 @@ public class HttpConnector implements WsConnector {
     private int readTimeoutMs = DEFAULT_READ_TIMEOUT_MILLISECONDS;
     private SSLSocketFactory sslSocketFactory = null;
     private X509TrustManager sslTrustManager = null;
+    private HostnameVerifier hostnameVerifier;
 
     /**
      * Private since 5.5.
@@ -282,6 +287,11 @@ public class HttpConnector implements WsConnector {
     public Builder proxyCredentials(@Nullable String proxyLogin, @Nullable String proxyPassword) {
       this.proxyLogin = proxyLogin;
       this.proxyPassword = proxyPassword;
+      return this;
+    }
+
+    public Builder hostnameVerifier(HostnameVerifier hostnameVerifier) {
+      this.hostnameVerifier = hostnameVerifier;
       return this;
     }
 

--- a/sonar-ws/src/main/java/org/sonarqube/ws/client/OkHttpClientBuilder.java
+++ b/sonar-ws/src/main/java/org/sonarqube/ws/client/OkHttpClientBuilder.java
@@ -33,6 +33,7 @@ import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -69,6 +70,7 @@ public class OkHttpClientBuilder {
   private long readTimeoutMs = -1;
   private SSLSocketFactory sslSocketFactory = null;
   private X509TrustManager sslTrustManager = null;
+  private HostnameVerifier hostnameVerifier = null;
 
   /**
    * Optional User-Agent. If set, then all the requests sent by the
@@ -149,6 +151,18 @@ public class OkHttpClientBuilder {
     return this;
   }
 
+  /**
+   * Optional SSL trust manager used to validate certificates.
+   * If not set, a default system trust manager will be used, based on the JVM's default truststore.
+   */
+  public OkHttpClientBuilder set( HostnameVerifier hostnameVerifier) {
+    if (hostnameVerifier == null){
+      throw new IllegalArgumentException("HostnameVerifier cannot be null");
+    }
+    this.hostnameVerifier = hostnameVerifier;
+    return this;
+  }
+
   public OkHttpClient build() {
     OkHttpClient.Builder builder = new OkHttpClient.Builder();
     builder.proxy(proxy);
@@ -183,6 +197,9 @@ public class OkHttpClientBuilder {
     X509TrustManager trustManager = sslTrustManager != null ? sslTrustManager : systemDefaultTrustManager();
     SSLSocketFactory sslFactory = sslSocketFactory != null ? sslSocketFactory : systemDefaultSslSocketFactory(trustManager);
     builder.sslSocketFactory(sslFactory, trustManager);
+    if(this.hostnameVerifier!=null) {
+      builder.hostnameVerifier( this.hostnameVerifier );
+    }
 
     return builder.build();
   }


### PR DESCRIPTION
Using system properties to enable an non secure mode.
So users are be able to use self signed certificates. 
see https://github.com/SonarSource/sonar-scanner-api/pull/45
NOTE same sys properties are used. 
Not sure if you guys have any plan to have a common shared library to handle http call.
I can see some duplicate code with org.sonarsource.scanner.api.internal.OkHttpClientFactory and org.sonarqube.ws.client.OkHttpClientBuilder just saying :P 