### PR TITLE
use POST instead GET in order to get settings values.

### DIFF
--- a/server/sonar-web/src/main/js/api/settings.js
+++ b/server/sonar-web/src/main/js/api/settings.js
@@ -36,7 +36,7 @@ export function getValues(keys, componentKey) {
   if (componentKey) {
     data.component = componentKey;
   }
-  return getJSON(url, data).then(r => r.settings);
+  return postJSON(url, data).then(r => r.settings);
 }
 
 export function setSettingValue(definition, value, componentKey) {


### PR DESCRIPTION
This is still RESTFull since the api endpoint is using filters which are defined by the user in order to obtain specific information.

Allow usage of proxy without issue related to URI length limit.
(ie: specific IIS reverse SSL Proxy setup https://blogs.msdn.microsoft.com/visualstudioalmrangers/2016/06/04/running-sonarqube-behind-an-iis-reversed-proxy/)