### PR TITLE
Clarify description of CoreProperties.SERVER_BASE_URL

### DIFF
--- a/sonar-core/src/main/java/org/sonar/core/config/CorePropertyDefinitions.java
+++ b/sonar-core/src/main/java/org/sonar/core/config/CorePropertyDefinitions.java
@@ -70,7 +70,7 @@ public class CorePropertyDefinitions {
         .build(),
       PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL)
         .name("Server base URL")
-        .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
+        .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails or by plugins during scanner analysis.")
         .category(CoreProperties.CATEGORY_GENERAL)
         .build(),
 


### PR DESCRIPTION
Added use by plugins for clarity
-> https://github.com/SonarQubeCommunity/sonar-build-breaker/issues/12