### PR TITLE
make quality gate ITs more reliable, by unsetting default qg

### DIFF
--- a/tests/src/test/java/org/sonarqube/tests/projectAdministration/ProjectQualityGatePageTest.java
+++ b/tests/src/test/java/org/sonarqube/tests/projectAdministration/ProjectQualityGatePageTest.java
@@ -66,10 +66,15 @@ public class ProjectQualityGatePageTest {
     QualityGate customQualityGate = createCustomQualityGate("should_display_default");
     qualityGateClient().setDefault(customQualityGate.id());
 
-    ProjectQualityGatePage page = openPage();
-    SelenideElement selectedQualityGate = page.getSelectedQualityGate();
-    selectedQualityGate.should(Condition.hasText("Default"));
-    selectedQualityGate.should(Condition.hasText(customQualityGate.name()));
+    try {
+      ProjectQualityGatePage page = openPage();
+      SelenideElement selectedQualityGate = page.getSelectedQualityGate();
+      selectedQualityGate.should(Condition.hasText("Default"));
+      selectedQualityGate.should(Condition.hasText(customQualityGate.name()));
+    } finally {
+      qualityGateClient().unsetDefault();
+      qualityGateClient().destroy(customQualityGate.id());
+    }
   }
 
   @Test
@@ -107,12 +112,17 @@ public class ProjectQualityGatePageTest {
     QualityGate customQualityGate = createCustomQualityGate("should_set_default");
     qualityGateClient().setDefault(customQualityGate.id());
 
-    ProjectQualityGatePage page = openPage();
-    page.setQualityGate(customQualityGate.name());
+    try {
+      ProjectQualityGatePage page = openPage();
+      page.setQualityGate(customQualityGate.name());
 
-    SelenideElement selectedQualityGate = page.getSelectedQualityGate();
-    selectedQualityGate.should(Condition.hasText("Default"));
-    selectedQualityGate.should(Condition.hasText(customQualityGate.name()));
+      SelenideElement selectedQualityGate = page.getSelectedQualityGate();
+      selectedQualityGate.should(Condition.hasText("Default"));
+      selectedQualityGate.should(Condition.hasText(customQualityGate.name()));
+    } finally {
+      qualityGateClient().unsetDefault();
+      qualityGateClient().destroy(customQualityGate.id());
+    }
   }
 
   @Test


### PR DESCRIPTION
This tries to fix false positives on QualityGateTest::does_not_fail_when_condition_is_on_removed_metric