### PR TITLE
Validate branch + incremental configuration

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/BranchConfigurationValidator.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/BranchConfigurationValidator.java
@@ -27,5 +27,5 @@ import org.sonar.api.batch.ScannerSide;
 @ScannerSide
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
 public interface BranchConfigurationValidator {
-  void validate(List<String> validationMessages, @Nullable String deprecatedBranchName);
+  void validate(List<String> validationMessages, @Nullable String deprecatedBranchName, boolean incrementalMode);
 }

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/DefaultBranchConfigurationValidator.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/DefaultBranchConfigurationValidator.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 
 public class DefaultBranchConfigurationValidator implements BranchConfigurationValidator {
   @Override
-  public void validate(List<String> validationMessages, @Nullable String deprecatedBranchName) {
+  public void validate(List<String> validationMessages, @Nullable String deprecatedBranchName, boolean incrementalMode) {
     // no-op
   }
 }

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/ProjectReactorValidator.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/ProjectReactorValidator.java
@@ -61,7 +61,7 @@ public class ProjectReactorValidator {
 
     String deprecatedBranchName = reactor.getRoot().getBranch();
 
-    branchConfigurationValidator.validate(validationMessages, deprecatedBranchName);
+    branchConfigurationValidator.validate(validationMessages, deprecatedBranchName, mode.isIncremental());
     validateBranch(validationMessages, deprecatedBranchName);
 
     if (!validationMessages.isEmpty()) {


### PR DESCRIPTION
Notes:

- `ProjectReactorValidator` already had analysis mode param, no need to inject anything more
- Btw: could not drop `DefaultBranchConfigurationValidator` (injected in `ProjectReactorValidator` constructor), because Pico's `@Nullable` is not effective in constructors, only in providers (Pico complains if it cannot find implementation)
- Did not add a medium test, because it seems to me that any user of `ScannerMediumTester` should already reveal injection issues, as it already uses a fake `BranchConfigurationLoader`. 