### PR TITLE
CVE-2017-9801 (commons-email)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -744,7 +744,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-email</artifactId>
-        <version>1.3.2</version>
+        <version>1.5</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
When a call-site passes a subject for an email that contains line-breaks in Apache Commons Email 1.0 through 1.4, the caller can add arbitrary SMTP headers.	

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9801