### PR TITLE
fix the documentation of the Elasticsearch http port setting

### DIFF
--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -350,6 +350,5 @@
 # of plugins are deployed.
 #sonar.web.dev=false
 
-# Elasticsearch HTTP connector, for example for KOPF:
-# http://lmenezes.com/elasticsearch-kopf/?location=http://localhost:9010
+# Elasticsearch HTTP connector
 #sonar.search.httpPort=-1


### PR DESCRIPTION
in sonar.properties. "Kopf" is not compatible with Elasticsearch 5 and therefore should not be mentioned.