### PR TITLE
.level label localazed size css fix

### DIFF
--- a/server/sonar-web/src/main/js/components/ui/Level.css
+++ b/server/sonar-web/src/main/js/components/ui/Level.css
@@ -1,6 +1,9 @@
 .level {
   display: inline-block;
-  width: 80px;
+  width: auto;
+  min-width: 80px;
+  padding-left: 9px;
+  padding-right: 9px;
   height: 24px;
   line-height: 24px;
   border-radius: 24px;
@@ -14,7 +17,10 @@
 }
 
 .level-small {
-  width: 64px;
+  width: auto;
+  min-width: 64px;
+  padding-left: 9px;
+  padding-right: 9px;
   margin-top: -1px;
   margin-bottom: -1px;
   height: 18px;


### PR DESCRIPTION
Fixing problem with localazed string in level label.  

Before:  

![image](https://user-images.githubusercontent.com/15638529/30230351-92d3f032-94ee-11e7-8ad3-a6199d79d5ab.png)  

After:   

![image](https://user-images.githubusercontent.com/15638529/30230451-067beb02-94ef-11e7-900c-7d1b5a3c54b1.png)

In En local size is not changed:

![image](https://user-images.githubusercontent.com/15638529/30230529-61a80e70-94ef-11e7-8df9-19249e67e00d.png)

