### PR TITLE
dropped marvel property

### DIFF
--- a/server/sonar-process/src/main/java/org/sonar/process/ProcessProperties.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/ProcessProperties.java
@@ -57,7 +57,6 @@ public class ProcessProperties {
   public static final String SEARCH_REPLICAS = "sonar.search.replicas";
   public static final String SEARCH_MINIMUM_MASTER_NODES = "sonar.search.minimumMasterNodes";
   public static final String SEARCH_INITIAL_STATE_TIMEOUT = "sonar.search.initialStateTimeout";
-  public static final String SEARCH_MARVEL_HOSTS = "sonar.search.marvelHosts";
 
   public static final String WEB_JAVA_OPTS = "sonar.web.javaOpts";
   public static final String WEB_JAVA_ADDITIONAL_OPTS = "sonar.web.javaAdditionalOpts";

--- a/server/sonar-process/src/main/java/org/sonar/process/es/EsSettings.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/es/EsSettings.java
@@ -21,13 +21,9 @@ package org.sonar.process.es;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.UUID;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.process.ProcessProperties;
@@ -39,7 +35,6 @@ import static org.sonar.cluster.ClusterProperties.CLUSTER_ENABLED;
 import static org.sonar.cluster.ClusterProperties.CLUSTER_NAME;
 import static org.sonar.cluster.ClusterProperties.CLUSTER_NODE_NAME;
 import static org.sonar.cluster.ClusterProperties.CLUSTER_SEARCH_HOSTS;
-import static org.sonar.process.ProcessProperties.SEARCH_MARVEL_HOSTS;
 
 public class EsSettings {
 
@@ -76,7 +71,6 @@ public class EsSettings {
     configureFileSystem(builder);
     configureNetwork(builder);
     configureCluster(builder);
-    configureMarvel(builder);
     configureAction(builder);
     return builder;
   }
@@ -146,18 +140,6 @@ public class EsSettings {
     builder.put("node.name", nodeName);
     builder.put("node.data", valueOf(true));
     builder.put("node.master", valueOf(true));
-  }
-
-  private void configureMarvel(Map<String, String> builder) {
-    Set<String> marvels = new TreeSet<>();
-    marvels.addAll(Arrays.asList(StringUtils.split(props.value(SEARCH_MARVEL_HOSTS, ""), ",")));
-
-    // If we're collecting indexing data send them to the Marvel host(s)
-    if (!marvels.isEmpty()) {
-      String hosts = StringUtils.join(marvels, ",");
-      LOGGER.info("Elasticsearch Marvel is enabled for %s", hosts);
-      builder.put("marvel.agent.exporter.es.hosts", hosts);
-    }
   }
 
   private static void configureAction(Map<String, String> builder) {

--- a/server/sonar-process/src/test/java/org/sonar/process/es/EsSettingsTest.java
+++ b/server/sonar-process/src/test/java/org/sonar/process/es/EsSettingsTest.java
@@ -269,15 +269,6 @@ public class EsSettingsTest {
   }
 
   @Test
-  public void enable_marvel() throws Exception {
-    Props props = minProps(CLUSTER_DISABLED);
-    props.set("sonar.search.marvelHosts", "127.0.0.2,127.0.0.3");
-    Map<String, String> settings = new EsSettings(props, new EsFileSystem(props), System2.INSTANCE).build();
-
-    assertThat(settings.get("marvel.agent.exporter.es.hosts")).isEqualTo("127.0.0.2,127.0.0.3");
-  }
-
-  @Test
   public void enable_http_connector() throws Exception {
     Props props = minProps(CLUSTER_DISABLED);
     props.set(ProcessProperties.SEARCH_HTTP_PORT, "9010");


### PR DESCRIPTION
"sonar.search.marvelHosts" was an internal property, used to enable marvel managing of the embedded Elasticsearch process.