### PR TITLE
Upgrade orchestrator to version 3.15.0.1213

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <log4j.version>2.8.2</log4j.version>
     <tomcat.version>8.5.16</tomcat.version>
     <elasticsearch.version>5.5.1</elasticsearch.version>
-    <orchestrator.version>3.15.0.1090</orchestrator.version>
+    <orchestrator.version>3.15.0.1213</orchestrator.version>
     <okhttp.version>3.7.0</okhttp.version>
     <jackson.version>2.6.6</jackson.version>
 


### PR DESCRIPTION
Trying to fix stability of Oracle tests. Orphan connections should be better dropped.