### PR TITLE
SONAR-4824 support branches when filtering recipients on their perms

### DIFF
--- a/server/sonar-db-dao/src/main/java/org/sonar/db/permission/AuthorizationDao.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/permission/AuthorizationDao.java
@@ -177,10 +177,10 @@ public class AuthorizationDao implements Dao {
     return mapper(dbSession).selectLoginsWithGlobalPermission(ADMINISTER.getKey());
   }
 
-  public Set<String> keepAuthorizedLoginsOnProject(DbSession dbSession, Set<String> logins, String projectUuid, String permission) {
+  public Set<String> keepAuthorizedLoginsOnProject(DbSession dbSession, Set<String> logins, String projectKey, String permission) {
     return executeLargeInputsIntoSet(
       logins,
-      partitionOfLogins -> mapper(dbSession).keepAuthorizedLoginsOnProject(partitionOfLogins, projectUuid, permission),
+      partitionOfLogins -> mapper(dbSession).keepAuthorizedLoginsOnProject(partitionOfLogins, projectKey, permission),
       partitionSize -> partitionSize / 3);
   }
 

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/permission/AuthorizationMapper.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/permission/AuthorizationMapper.java
@@ -63,7 +63,7 @@ public interface AuthorizationMapper {
 
   List<String> selectQualityProfileAdministratorLogins(@Param("permission") String permission);
 
-  Set<String> keepAuthorizedLoginsOnProject(@Param("logins") List<String> logins, @Param("projectUuid") String projectUuid, @Param("permission") String permission);
+  Set<String> keepAuthorizedLoginsOnProject(@Param("logins") List<String> logins, @Param("projectKey") String projectKey, @Param("permission") String permission);
 
   List<String> selectLoginsWithGlobalPermission(@Param("permission") String permission);
 }

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/property/PropertiesDao.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/property/PropertiesDao.java
@@ -66,9 +66,9 @@ public class PropertiesDao implements Dao {
    *
    * @return the list of Subscriber (maybe be empty - obviously)
    */
-  public Set<Subscriber> findUsersForNotification(String notificationDispatcherKey, String notificationChannelKey, @Nullable String projectUuid) {
+  public Set<Subscriber> findUsersForNotification(String notificationDispatcherKey, String notificationChannelKey, @Nullable String projectKey) {
     try (DbSession session = mybatis.openSession(false)) {
-      return getMapper(session).findUsersForNotification(NOTIFICATION_PREFIX + notificationDispatcherKey + "." + notificationChannelKey, projectUuid);
+      return getMapper(session).findUsersForNotification(NOTIFICATION_PREFIX + notificationDispatcherKey + "." + notificationChannelKey, projectKey);
     }
   }
 

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/property/PropertiesMapper.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/property/PropertiesMapper.java
@@ -26,7 +26,7 @@ import org.apache.ibatis.annotations.Param;
 
 public interface PropertiesMapper {
 
-  Set<Subscriber> findUsersForNotification(@Param("notifKey") String notificationKey, @Nullable @Param("projectUuid") String projectUuid);
+  Set<Subscriber> findUsersForNotification(@Param("notifKey") String notificationKey, @Nullable @Param("projectKey") String projectKey);
 
   List<PropertyDto> selectGlobalProperties();
 

--- a/server/sonar-db-dao/src/main/resources/org/sonar/db/permission/AuthorizationMapper.xml
+++ b/server/sonar-db-dao/src/main/resources/org/sonar/db/permission/AuthorizationMapper.xml
@@ -401,7 +401,7 @@
       SELECT u.login
       FROM users u
       INNER JOIN user_roles ur ON ur.user_id = u.id
-      INNER JOIN projects p ON p.uuid = #{projectUuid,jdbcType=VARCHAR}
+      INNER JOIN projects p ON p.kee = #{projectKey,jdbcType=VARCHAR}
       WHERE
         ur.organization_uuid = p.organization_uuid
         AND ur.resource_id = p.id
@@ -412,7 +412,7 @@
 
       SELECT u.login
       FROM users u
-      INNER JOIN projects p ON p.uuid = #{projectUuid,jdbcType=VARCHAR}
+      INNER JOIN projects p ON p.kee = #{projectKey,jdbcType=VARCHAR}
       INNER JOIN group_roles gr ON gr.organization_uuid = p.organization_uuid
       INNER JOIN groups_users gu ON gr.group_id = gu.group_id
       WHERE
@@ -425,7 +425,7 @@
 
       SELECT u.login
       FROM users u
-      INNER JOIN projects p ON p.uuid = #{projectUuid,jdbcType=VARCHAR}
+      INNER JOIN projects p ON p.kee = #{projectKey,jdbcType=VARCHAR}
       WHERE
         p.private = ${_false}
         AND u.login IN <foreach collection="logins" open="(" close=")" item="login" separator=",">#{login}</foreach>

--- a/server/sonar-db-dao/src/main/resources/org/sonar/db/property/PropertiesMapper.xml
+++ b/server/sonar-db-dao/src/main/resources/org/sonar/db/property/PropertiesMapper.xml
@@ -22,7 +22,7 @@
       ${_false} as "global"
     FROM
       users u
-    INNER JOIN projects c on c.uuid = #{projectUuid,jdbcType=VARCHAR}
+    INNER JOIN projects c on c.kee = #{projectKey,jdbcType=VARCHAR}
     INNER JOIN properties p ON p.user_id = u.id
     WHERE
       p.prop_key = #{notifKey,jdbcType=VARCHAR}

--- a/server/sonar-db-dao/src/test/java/org/sonar/db/permission/AuthorizationDaoTest.java
+++ b/server/sonar-db-dao/src/test/java/org/sonar/db/permission/AuthorizationDaoTest.java
@@ -35,6 +35,7 @@ import org.sonar.core.permission.ProjectPermissions;
 import org.sonar.core.util.stream.MoreCollectors;
 import org.sonar.db.DbSession;
 import org.sonar.db.DbTester;
+import org.sonar.db.component.BranchType;
 import org.sonar.db.component.ComponentDto;
 import org.sonar.db.organization.OrganizationDto;
 import org.sonar.db.user.GroupDto;
@@ -61,6 +62,7 @@ public class AuthorizationDaoTest {
   @Rule
   public DbTester db = DbTester.create(System2.INSTANCE);
 
+  private final Random random = new Random();
   private DbSession dbSession = db.getSession();
   private AuthorizationDao underTest = new AuthorizationDao();
   private OrganizationDto organization;
@@ -70,7 +72,7 @@ public class AuthorizationDaoTest {
   private Set<Long> randomPublicProjectIds;
   private Set<Long> randomPrivateProjectIds;
   private Set<Integer> randomExistingUserIds;
-  private String randomPermission = "p" + new Random().nextInt();
+  private String randomPermission = "p" + random.nextInt();
 
   @Before
   public void setUp() throws Exception {
@@ -78,15 +80,15 @@ public class AuthorizationDaoTest {
     user = db.users().insertUser();
     group1 = db.users().insertGroup(organization, "group1");
     group2 = db.users().insertGroup(organization, "group2");
-    randomExistingUserIds = IntStream.range(0, 1 + Math.abs(new Random().nextInt(5)))
+    randomExistingUserIds = IntStream.range(0, 1 + Math.abs(random.nextInt(5)))
       .map(i -> db.users().insertUser().getId())
       .boxed()
       .collect(MoreCollectors.toSet());
-    randomPublicProjectIds = IntStream.range(0, 1 + Math.abs(new Random().nextInt(5)))
+    randomPublicProjectIds = IntStream.range(0, 1 + Math.abs(random.nextInt(5)))
       .mapToLong(i -> db.components().insertPublicProject(organization).getId())
       .boxed()
       .collect(MoreCollectors.toSet());
-    randomPrivateProjectIds = IntStream.range(0, 1 + Math.abs(new Random().nextInt(5)))
+    randomPrivateProjectIds = IntStream.range(0, 1 + Math.abs(random.nextInt(5)))
       .mapToLong(i -> db.components().insertPrivateProject(organization).getId())
       .boxed()
       .collect(MoreCollectors.toSet());
@@ -239,7 +241,7 @@ public class AuthorizationDaoTest {
 
   @Test
   public void keepAuthorizedProjectIds_returns_empty_for_group_AnyOne_for_non_existent_projects() {
-    Set<Long> randomNonProjectsSet = IntStream.range(0, 1 + Math.abs(new Random().nextInt(5)))
+    Set<Long> randomNonProjectsSet = IntStream.range(0, 1 + Math.abs(random.nextInt(5)))
       .mapToLong(i -> 3_562 + i)
       .boxed()
       .collect(MoreCollectors.toSet());
@@ -250,7 +252,7 @@ public class AuthorizationDaoTest {
 
   @Test
   public void keepAuthorizedProjectIds_returns_empty_for_user_for_non_existent_projects() {
-    Set<Long> randomNonProjectsSet = IntStream.range(0, 1 + Math.abs(new Random().nextInt(5)))
+    Set<Long> randomNonProjectsSet = IntStream.range(0, 1 + Math.abs(random.nextInt(5)))
       .mapToLong(i -> 9_666 + i)
       .boxed()
       .collect(MoreCollectors.toSet());
@@ -513,8 +515,8 @@ public class AuthorizationDaoTest {
 
   @Test
   public void keepAuthorizedUsersForRoleAndProject_returns_empty_for_non_existent_users() {
-    ComponentDto project = new Random().nextBoolean() ? db.components().insertPublicProject(organization) : db.components().insertPrivateProject(organization);
-    Set<Integer> randomNonExistingUserIdsSet = IntStream.range(0, 1 + Math.abs(new Random().nextInt(5)))
+    ComponentDto project = random.nextBoolean() ? db.components().insertPublicProject(organization) : db.components().insertPrivateProject(organization);
+    Set<Integer> randomNonExistingUserIdsSet = IntStream.range(0, 1 + Math.abs(random.nextInt(5)))
       .map(i -> i + 1_990)
       .boxed()
       .collect(MoreCollectors.toSet());
@@ -1044,11 +1046,11 @@ public class AuthorizationDaoTest {
     db.users().insertMember(adminGroup, admin2);
     db.users().insertProjectPermissionOnGroup(adminGroup, UserRole.ADMIN, project);
 
-    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(user1.getLogin()), project.uuid(), UserRole.USER))
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(user1.getLogin()), project.getKey(), UserRole.USER))
       .containsOnly(user1.getLogin());
-    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(user1.getLogin(), admin1.getLogin(), admin2.getLogin()), project.uuid(), UserRole.USER))
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(user1.getLogin(), admin1.getLogin(), admin2.getLogin()), project.getKey(), UserRole.USER))
       .containsOnly(user1.getLogin(), admin1.getLogin(), admin2.getLogin());
-    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(user1.getLogin(), admin1.getLogin(), admin2.getLogin()), project.uuid(), UserRole.ADMIN))
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(user1.getLogin(), admin1.getLogin(), admin2.getLogin()), project.getKey(), UserRole.ADMIN))
       .containsOnly(admin1.getLogin(), admin2.getLogin());
   }
 
@@ -1080,17 +1082,60 @@ public class AuthorizationDaoTest {
     // user without role
     UserDto userWithNoRole = db.users().insertUser();
 
-    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(userWithNoRole.getLogin()), project.uuid(), UserRole.USER))
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(userWithNoRole.getLogin()), project.getKey(), UserRole.USER))
       .isEmpty();
-    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(user1.getLogin()), project.uuid(), UserRole.USER))
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(user1.getLogin()), project.getKey(), UserRole.USER))
       .containsOnly(user1.getLogin());
 
     Set<String> allLogins = newHashSet(admin1.getLogin(), admin2.getLogin(), user1.getLogin(), user2.getLogin(), userWithNoRole.getLogin());
 
     // Admin does not have the USER permission set
-    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, allLogins, project.uuid(), UserRole.USER))
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, allLogins, project.getKey(), UserRole.USER))
       .containsOnly(user1.getLogin(), user2.getLogin());
-    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, allLogins, project.uuid(), UserRole.ADMIN))
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, allLogins, project.getKey(), UserRole.ADMIN))
+      .containsOnly(admin1.getLogin(), admin2.getLogin());
+  }
+
+  @Test
+  public void keepAuthorizedLoginsOnProject_return_correct_users_on_branch() {
+    ComponentDto project = db.components().insertPrivateProject(organization);
+    ComponentDto branch = db.components().insertProjectBranch(project, c -> c.setBranchType(random.nextBoolean() ? BranchType.SHORT : BranchType.LONG));
+
+    GroupDto userGroup = db.users().insertGroup(organization, "USERS");
+    GroupDto adminGroup = db.users().insertGroup(organization, "ADMIN");
+    db.users().insertProjectPermissionOnGroup(userGroup, UserRole.USER, project);
+    db.users().insertProjectPermissionOnGroup(adminGroup, UserRole.ADMIN, project);
+
+    // admin with "direct" ADMIN role
+    UserDto admin1 = db.users().insertUser();
+    db.users().insertProjectPermissionOnUser(admin1, UserRole.ADMIN, project);
+
+    // admin2 with ADMIN role through group
+    UserDto admin2 = db.users().insertUser();
+    db.users().insertMember(adminGroup, admin2);
+
+    // user1 with "direct" USER role
+    UserDto user1 = db.users().insertUser();
+    db.users().insertProjectPermissionOnUser(user1, UserRole.USER, project);
+
+    // user2 with USER role through group
+    UserDto user2 = db.users().insertUser();
+    db.users().insertMember(userGroup, user2);
+
+    // user without role
+    UserDto userWithNoRole = db.users().insertUser();
+
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(userWithNoRole.getLogin()), branch.getKey(), UserRole.USER))
+      .isEmpty();
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, newHashSet(user1.getLogin()), branch.getKey(), UserRole.USER))
+      .containsOnly(user1.getLogin());
+
+    Set<String> allLogins = newHashSet(admin1.getLogin(), admin2.getLogin(), user1.getLogin(), user2.getLogin(), userWithNoRole.getLogin());
+
+    // Admin does not have the USER permission set
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, allLogins, branch.getKey(), UserRole.USER))
+      .containsOnly(user1.getLogin(), user2.getLogin());
+    assertThat(underTest.keepAuthorizedLoginsOnProject(dbSession, allLogins, branch.getKey(), UserRole.ADMIN))
       .containsOnly(admin1.getLogin(), admin2.getLogin());
   }
 }

--- a/server/sonar-db-dao/src/test/java/org/sonar/db/property/PropertiesDaoTest.java
+++ b/server/sonar-db-dao/src/test/java/org/sonar/db/property/PropertiesDaoTest.java
@@ -101,10 +101,10 @@ public class PropertiesDaoTest {
     assertThat(underTest.findUsersForNotification("NewViolations", "Email", "uuid_78"))
       .isEmpty();
 
-    assertThat(underTest.findUsersForNotification("NewViolations", "Email", project1.uuid()))
+    assertThat(underTest.findUsersForNotification("NewViolations", "Email", project1.getKey()))
       .containsOnly(new Subscriber("user2", false));
 
-    assertThat(underTest.findUsersForNotification("NewViolations", "Email", project2.uuid()))
+    assertThat(underTest.findUsersForNotification("NewViolations", "Email", project2.getKey()))
       .isEmpty();
 
     assertThat(underTest.findUsersForNotification("NewViolations", "Twitter", null))
@@ -113,10 +113,10 @@ public class PropertiesDaoTest {
     assertThat(underTest.findUsersForNotification("NewViolations", "Twitter", "uuid_78"))
       .containsOnly(new Subscriber("user3", true));
 
-    assertThat(underTest.findUsersForNotification("NewViolations", "Twitter", project1.uuid()))
+    assertThat(underTest.findUsersForNotification("NewViolations", "Twitter", project1.getKey()))
       .containsOnly(new Subscriber("user2", false), new Subscriber("user3", true));
 
-    assertThat(underTest.findUsersForNotification("NewViolations", "Twitter", project2.uuid()))
+    assertThat(underTest.findUsersForNotification("NewViolations", "Twitter", project2.getKey()))
       .containsOnly(new Subscriber("user1", false), new Subscriber("user3", true), new Subscriber("user3", false));
   }
 

--- a/server/sonar-server/src/main/java/org/sonar/ce/notification/ReportAnalysisFailureNotificationDispatcher.java
+++ b/server/sonar-server/src/main/java/org/sonar/ce/notification/ReportAnalysisFailureNotificationDispatcher.java
@@ -55,9 +55,9 @@ public class ReportAnalysisFailureNotificationDispatcher extends NotificationDis
 
   @Override
   public void dispatch(Notification notification, Context context) {
-    String projectUuid = notification.getFieldValue("project.uuid");
-    Multimap<String, NotificationChannel> subscribedRecipients = manager.findSubscribedRecipientsForDispatcher(
-      this, projectUuid, REQUIRED_SUBSCRIBER_PERMISSIONS);
+    String projectKey = notification.getFieldValue("project.key");
+    Multimap<String, NotificationChannel> subscribedRecipients = manager
+      .findSubscribedRecipientsForDispatcher(this, projectKey, REQUIRED_SUBSCRIBER_PERMISSIONS);
 
     for (Map.Entry<String, Collection<NotificationChannel>> channelsByRecipients : subscribedRecipients.asMap().entrySet()) {
       String userLogin = channelsByRecipients.getKey();

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/step/QualityGateEventsStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/step/QualityGateEventsStep.java
@@ -127,7 +127,6 @@ public class QualityGateEventsStep implements ComputationStep {
       .setDefaultMessage(String.format("Alert on %s: %s", project.getName(), label))
       .setFieldValue("projectName", project.getName())
       .setFieldValue("projectKey", project.getPublicKey())
-      .setFieldValue("projectUuid", project.getUuid())
       .setFieldValue("projectVersion", project.getReportAttributes().getVersion())
       .setFieldValue("alertName", label)
       .setFieldValue("alertText", rawStatus.getText())

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/step/SendIssueNotificationsStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/step/SendIssueNotificationsStep.java
@@ -127,7 +127,7 @@ public class SendIssueNotificationsStep implements ComputationStep {
     IssueChangeNotification changeNotification = new IssueChangeNotification();
     changeNotification.setRuleName(rules.getByKey(issue.ruleKey()).getName());
     changeNotification.setIssue(issue);
-    changeNotification.setProject(project.getPublicKey(), project.getName(), getBranchName(), project.getUuid());
+    changeNotification.setProject(project.getPublicKey(), project.getName(), getBranchName());
     getComponentKey(issue).ifPresent(c -> changeNotification.setComponent(c.getPublicKey(), c.getName()));
     service.deliver(changeNotification);
   }
@@ -136,7 +136,7 @@ public class SendIssueNotificationsStep implements ComputationStep {
     NewIssuesStatistics.Stats globalStatistics = statistics.globalStatistics();
     NewIssuesNotification notification = newIssuesNotificationFactory
       .newNewIssuesNotication()
-      .setProject(project.getPublicKey(), project.getUuid(), project.getName(), getBranchName())
+      .setProject(project.getPublicKey(), project.getName(), getBranchName())
       .setProjectVersion(project.getReportAttributes().getVersion())
       .setAnalysisDate(new Date(analysisDate))
       .setStatistics(project.getName(), globalStatistics)
@@ -155,7 +155,7 @@ public class SendIssueNotificationsStep implements ComputationStep {
           .newMyNewIssuesNotification()
           .setAssignee(assignee);
         myNewIssuesNotification
-          .setProject(project.getPublicKey(), project.getUuid(), project.getName(), getBranchName())
+          .setProject(project.getPublicKey(), project.getName(), getBranchName())
           .setProjectVersion(project.getReportAttributes().getVersion())
           .setAnalysisDate(new Date(analysisDate))
           .setStatistics(project.getName(), assigneeStatistics)

--- a/server/sonar-server/src/main/java/org/sonar/server/event/NewAlerts.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/event/NewAlerts.java
@@ -58,10 +58,10 @@ public class NewAlerts extends NotificationDispatcher {
 
   @Override
   public void dispatch(Notification notification, Context context) {
-    String projectUuid = notification.getFieldValue("projectUuid");
-    if (projectUuid != null) {
-      Multimap<String, NotificationChannel> subscribedRecipients = notifications.findSubscribedRecipientsForDispatcher(
-        this, projectUuid, ALL_MUST_HAVE_ROLE_USER);
+    String projectKey = notification.getFieldValue("projectKey");
+    if (projectKey != null) {
+      Multimap<String, NotificationChannel> subscribedRecipients = notifications
+          .findSubscribedRecipientsForDispatcher(this, projectKey, ALL_MUST_HAVE_ROLE_USER);
 
       for (Map.Entry<String, Collection<NotificationChannel>> channelsByRecipients : subscribedRecipients.asMap().entrySet()) {
         String userLogin = channelsByRecipients.getKey();

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/notification/AbstractNewIssuesEmailTemplate.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/notification/AbstractNewIssuesEmailTemplate.java
@@ -51,7 +51,6 @@ public abstract class AbstractNewIssuesEmailTemplate extends EmailTemplate {
   static final String FIELD_PROJECT_NAME = "projectName";
   static final String FIELD_PROJECT_KEY = "projectKey";
   static final String FIELD_PROJECT_DATE = "projectDate";
-  static final String FIELD_PROJECT_UUID = "projectUuid";
   static final String FIELD_PROJECT_VERSION = "projectVersion";
   static final String FIELD_ASSIGNEE = "assignee";
   static final String FIELD_BRANCH = "branch";

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/notification/ChangesOnMyIssueNotificationDispatcher.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/notification/ChangesOnMyIssueNotificationDispatcher.java
@@ -59,9 +59,9 @@ public class ChangesOnMyIssueNotificationDispatcher extends NotificationDispatch
 
   @Override
   public void dispatch(Notification notification, Context context) {
-    String projectUuid = notification.getFieldValue("projectUuid");
-    Multimap<String, NotificationChannel> subscribedRecipients = notificationManager.findSubscribedRecipientsForDispatcher(
-      this, projectUuid, ALL_MUST_HAVE_ROLE_USER);
+    String projectKey = notification.getFieldValue("projectKey");
+    Multimap<String, NotificationChannel> subscribedRecipients = notificationManager
+      .findSubscribedRecipientsForDispatcher(this, projectKey, ALL_MUST_HAVE_ROLE_USER);
 
     // See available fields in the class IssueNotifications.
 

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/notification/DoNotFixNotificationDispatcher.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/notification/DoNotFixNotificationDispatcher.java
@@ -62,9 +62,9 @@ public class DoNotFixNotificationDispatcher extends NotificationDispatcher {
     String newResolution = notification.getFieldValue("new.resolution");
     if (Objects.equals(newResolution, Issue.RESOLUTION_FALSE_POSITIVE) || Objects.equals(newResolution, Issue.RESOLUTION_WONT_FIX)) {
       String author = notification.getFieldValue("changeAuthor");
-      String projectUuid = notification.getFieldValue("projectUuid");
-      Multimap<String, NotificationChannel> subscribedRecipients = notifications.findSubscribedRecipientsForDispatcher(
-        this, projectUuid, ALL_MUST_HAVE_ROLE_USER);
+      String projectKey = notification.getFieldValue("projectKey");
+      Multimap<String, NotificationChannel> subscribedRecipients = notifications
+        .findSubscribedRecipientsForDispatcher(this, projectKey, ALL_MUST_HAVE_ROLE_USER);
       notify(author, context, subscribedRecipients);
     }
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/notification/IssueChangeNotification.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/notification/IssueChangeNotification.java
@@ -54,12 +54,11 @@ public class IssueChangeNotification extends Notification {
   }
 
   public IssueChangeNotification setProject(ComponentDto project) {
-    return setProject(project.getKey(), project.name(), project.getBranch(), project.uuid());
+    return setProject(project.getKey(), project.name(), project.getBranch());
   }
 
-  public IssueChangeNotification setProject(String projectKey, String projectName, @Nullable String branch, String projectUuid) {
+  public IssueChangeNotification setProject(String projectKey, String projectName, @Nullable String branch) {
     setFieldValue("projectName", projectName);
-    setFieldValue("projectUuid", projectUuid);
     setFieldValue("projectKey", projectKey);
     if (branch != null) {
       setFieldValue("branch", branch);

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/notification/MyNewIssuesNotificationDispatcher.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/notification/MyNewIssuesNotificationDispatcher.java
@@ -55,10 +55,10 @@ public class MyNewIssuesNotificationDispatcher extends NotificationDispatcher {
 
   @Override
   public void dispatch(Notification notification, Context context) {
-    String projectUuid = notification.getFieldValue("projectUuid");
+    String projectKey = notification.getFieldValue("projectKey");
     String assignee = notification.getFieldValue("assignee");
-    Multimap<String, NotificationChannel> subscribedRecipients = manager.findSubscribedRecipientsForDispatcher(
-        this, projectUuid, ALL_MUST_HAVE_ROLE_USER);
+    Multimap<String, NotificationChannel> subscribedRecipients = manager
+        .findSubscribedRecipientsForDispatcher(this, projectKey, ALL_MUST_HAVE_ROLE_USER);
 
     Collection<NotificationChannel> channels = subscribedRecipients.get(assignee);
     for (NotificationChannel channel : channels) {

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/notification/NewIssuesNotification.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/notification/NewIssuesNotification.java
@@ -49,7 +49,6 @@ import static org.sonar.server.issue.notification.AbstractNewIssuesEmailTemplate
 import static org.sonar.server.issue.notification.NewIssuesEmailTemplate.FIELD_PROJECT_DATE;
 import static org.sonar.server.issue.notification.NewIssuesEmailTemplate.FIELD_PROJECT_KEY;
 import static org.sonar.server.issue.notification.NewIssuesEmailTemplate.FIELD_PROJECT_NAME;
-import static org.sonar.server.issue.notification.NewIssuesEmailTemplate.FIELD_PROJECT_UUID;
 import static org.sonar.server.issue.notification.NewIssuesStatistics.Metric.RULE_TYPE;
 
 public class NewIssuesNotification extends Notification {
@@ -80,10 +79,9 @@ public class NewIssuesNotification extends Notification {
     return this;
   }
 
-  public NewIssuesNotification setProject(String projectKey, String projectUuid, String projectName, @Nullable String branchName) {
+  public NewIssuesNotification setProject(String projectKey, String projectName, @Nullable String branchName) {
     setFieldValue(FIELD_PROJECT_NAME, projectName);
     setFieldValue(FIELD_PROJECT_KEY, projectKey);
-    setFieldValue(FIELD_PROJECT_UUID, projectUuid);
     if (branchName != null) {
       setFieldValue(FIELD_BRANCH, branchName);
     }

--- a/server/sonar-server/src/main/java/org/sonar/server/issue/notification/NewIssuesNotificationDispatcher.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/issue/notification/NewIssuesNotificationDispatcher.java
@@ -56,9 +56,9 @@ public class NewIssuesNotificationDispatcher extends NotificationDispatcher {
 
   @Override
   public void dispatch(Notification notification, Context context) {
-    String projectUuid = notification.getFieldValue("projectUuid");
-    Multimap<String, NotificationChannel> subscribedRecipients = manager.findSubscribedRecipientsForDispatcher(
-      this, projectUuid, ALL_MUST_HAVE_ROLE_USER);
+    String projectKey = notification.getFieldValue("projectKey");
+    Multimap<String, NotificationChannel> subscribedRecipients = manager
+      .findSubscribedRecipientsForDispatcher(this, projectKey, ALL_MUST_HAVE_ROLE_USER);
 
     for (Map.Entry<String, Collection<NotificationChannel>> channelsByRecipients : subscribedRecipients.asMap().entrySet()) {
       String userLogin = channelsByRecipients.getKey();

--- a/server/sonar-server/src/test/java/org/sonar/ce/notification/ReportAnalysisFailureNotificationDispatcherTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/ce/notification/ReportAnalysisFailureNotificationDispatcherTest.java
@@ -78,8 +78,8 @@ public class ReportAnalysisFailureNotificationDispatcherTest {
   @Test
   public void performDispatch_adds_user_for_each_recipient_and_channel_for_the_component_uuid_in_the_notification() {
     when(notificationMock.getType()).thenReturn(ReportAnalysisFailureNotification.TYPE);
-    String projectUuid = randomAlphanumeric(9);
-    when(notificationMock.getFieldValue("project.uuid")).thenReturn(projectUuid);
+    String projectKey = randomAlphanumeric(9);
+    when(notificationMock.getFieldValue("project.key")).thenReturn(projectKey);
     HashMultimap<String, NotificationChannel> multimap = HashMultimap.create();
     String login1 = randomAlphanumeric(3);
     String login2 = randomAlphanumeric(3);
@@ -90,7 +90,7 @@ public class ReportAnalysisFailureNotificationDispatcherTest {
     multimap.put(login1, channel2);
     multimap.put(login2, channel2);
     multimap.put(login2, channel3);
-    when(notificationManager.findSubscribedRecipientsForDispatcher(underTest, projectUuid, new SubscriberPermissionsOnProject(UserRole.ADMIN, UserRole.USER)))
+    when(notificationManager.findSubscribedRecipientsForDispatcher(underTest, projectKey, new SubscriberPermissionsOnProject(UserRole.ADMIN, UserRole.USER)))
       .thenReturn(multimap);
 
     underTest.performDispatch(notificationMock, contextMock);
@@ -105,10 +105,10 @@ public class ReportAnalysisFailureNotificationDispatcherTest {
   @Test
   public void performDispatch_adds_no_user_if_notification_manager_returns_none() {
     when(notificationMock.getType()).thenReturn(ReportAnalysisFailureNotification.TYPE);
-    String projectUuid = randomAlphanumeric(9);
-    when(notificationMock.getFieldValue("project.uuid")).thenReturn(projectUuid);
+    String projectKey = randomAlphanumeric(9);
+    when(notificationMock.getFieldValue("project.key")).thenReturn(projectKey);
     HashMultimap<String, NotificationChannel> multimap = HashMultimap.create();
-    when(notificationManager.findSubscribedRecipientsForDispatcher(underTest, projectUuid, new SubscriberPermissionsOnProject(UserRole.ADMIN, UserRole.USER)))
+    when(notificationManager.findSubscribedRecipientsForDispatcher(underTest, projectKey, new SubscriberPermissionsOnProject(UserRole.ADMIN, UserRole.USER)))
       .thenReturn(multimap);
 
     underTest.performDispatch(notificationMock, contextMock);

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/QualityGateEventsStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/QualityGateEventsStepTest.java
@@ -188,7 +188,6 @@ public class QualityGateEventsStepTest {
     Notification notification = notificationArgumentCaptor.getValue();
     assertThat(notification.getType()).isEqualTo("alerts");
     assertThat(notification.getFieldValue("projectKey")).isEqualTo(PROJECT_COMPONENT.getPublicKey());
-    assertThat(notification.getFieldValue("projectUuid")).isEqualTo(PROJECT_COMPONENT.getUuid());
     assertThat(notification.getFieldValue("projectName")).isEqualTo(PROJECT_COMPONENT.getName());
     assertThat(notification.getFieldValue("projectVersion")).isEqualTo(PROJECT_COMPONENT.getReportAttributes().getVersion());
     assertThat(notification.getFieldValue("branch")).isNull();
@@ -241,7 +240,6 @@ public class QualityGateEventsStepTest {
     Notification notification = notificationArgumentCaptor.getValue();
     assertThat(notification.getType()).isEqualTo("alerts");
     assertThat(notification.getFieldValue("projectKey")).isEqualTo(PROJECT_COMPONENT.getPublicKey());
-    assertThat(notification.getFieldValue("projectUuid")).isEqualTo(PROJECT_COMPONENT.getUuid());
     assertThat(notification.getFieldValue("projectName")).isEqualTo(PROJECT_COMPONENT.getName());
     assertThat(notification.getFieldValue("projectVersion")).isEqualTo(PROJECT_COMPONENT.getReportAttributes().getVersion());
     assertThat(notification.getFieldValue("branch")).isNull();
@@ -271,7 +269,6 @@ public class QualityGateEventsStepTest {
     Notification notification = notificationArgumentCaptor.getValue();
     assertThat(notification.getType()).isEqualTo("alerts");
     assertThat(notification.getFieldValue("projectKey")).isEqualTo(PROJECT_COMPONENT.getPublicKey());
-    assertThat(notification.getFieldValue("projectUuid")).isEqualTo(PROJECT_COMPONENT.getUuid());
     assertThat(notification.getFieldValue("projectName")).isEqualTo(PROJECT_COMPONENT.getName());
     assertThat(notification.getFieldValue("projectVersion")).isEqualTo(PROJECT_COMPONENT.getReportAttributes().getVersion());
     assertThat(notification.getFieldValue("branch")).isEqualTo(branchName);
@@ -293,7 +290,6 @@ public class QualityGateEventsStepTest {
     Notification notification = notificationArgumentCaptor.getValue();
     assertThat(notification.getType()).isEqualTo("alerts");
     assertThat(notification.getFieldValue("projectKey")).isEqualTo(PROJECT_COMPONENT.getPublicKey());
-    assertThat(notification.getFieldValue("projectUuid")).isEqualTo(PROJECT_COMPONENT.getUuid());
     assertThat(notification.getFieldValue("projectName")).isEqualTo(PROJECT_COMPONENT.getName());
     assertThat(notification.getFieldValue("projectVersion")).isEqualTo(PROJECT_COMPONENT.getReportAttributes().getVersion());
     assertThat(notification.getFieldValue("branch")).isEqualTo(null);

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/SendIssueNotificationsStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/SendIssueNotificationsStepTest.java
@@ -144,7 +144,7 @@ public class SendIssueNotificationsStepTest extends BaseStepTest {
     underTest.execute();
 
     verify(notificationService).deliver(newIssuesNotificationMock);
-    verify(newIssuesNotificationMock).setProject(PROJECT.getPublicKey(), PROJECT.getUuid(), PROJECT.getName(), null);
+    verify(newIssuesNotificationMock).setProject(PROJECT.getPublicKey(), PROJECT.getName(), null);
     verify(newIssuesNotificationMock).setAnalysisDate(new Date(ANALYSE_DATE));
     verify(newIssuesNotificationMock).setStatistics(eq(PROJECT.getName()), any(NewIssuesStatistics.Stats.class));
     verify(newIssuesNotificationMock).setDebt(ISSUE_DURATION);
@@ -207,7 +207,7 @@ public class SendIssueNotificationsStepTest extends BaseStepTest {
     underTest.execute();
 
     verify(notificationService).deliver(newIssuesNotificationMock);
-    verify(newIssuesNotificationMock).setProject(branch.getKey(), branch.uuid(), branch.longName(), BRANCH_NAME);
+    verify(newIssuesNotificationMock).setProject(branch.getKey(), branch.longName(), BRANCH_NAME);
     verify(newIssuesNotificationMock).setAnalysisDate(new Date(ANALYSE_DATE));
     verify(newIssuesNotificationMock).setStatistics(eq(branch.longName()), any(NewIssuesStatistics.Stats.class));
     verify(newIssuesNotificationMock).setDebt(ISSUE_DURATION);
@@ -239,7 +239,7 @@ public class SendIssueNotificationsStepTest extends BaseStepTest {
     verify(notificationService).deliver(newIssuesNotificationMock);
     verify(notificationService).deliver(myNewIssuesNotificationMock);
     verify(myNewIssuesNotificationMock).setAssignee(ISSUE_ASSIGNEE);
-    verify(myNewIssuesNotificationMock).setProject(PROJECT.getPublicKey(), PROJECT.getUuid(), PROJECT.getName(), null);
+    verify(myNewIssuesNotificationMock).setProject(PROJECT.getPublicKey(), PROJECT.getName(), null);
     verify(myNewIssuesNotificationMock).setAnalysisDate(new Date(ANALYSE_DATE));
     verify(myNewIssuesNotificationMock).setStatistics(eq(PROJECT.getName()), any(NewIssuesStatistics.Stats.class));
     verify(myNewIssuesNotificationMock).setDebt(ISSUE_DURATION);
@@ -425,7 +425,7 @@ public class SendIssueNotificationsStepTest extends BaseStepTest {
 
   private NewIssuesNotification createNewIssuesNotificationMock() {
     NewIssuesNotification notification = mock(NewIssuesNotification.class);
-    when(notification.setProject(anyString(), anyString(), anyString(), anyString())).thenReturn(notification);
+    when(notification.setProject(anyString(), anyString(), anyString())).thenReturn(notification);
     when(notification.setProjectVersion(anyString())).thenReturn(notification);
     when(notification.setAnalysisDate(any(Date.class))).thenReturn(notification);
     when(notification.setStatistics(anyString(), any(NewIssuesStatistics.Stats.class))).thenReturn(notification);
@@ -436,7 +436,7 @@ public class SendIssueNotificationsStepTest extends BaseStepTest {
   private MyNewIssuesNotification createMyNewIssuesNotificationMock() {
     MyNewIssuesNotification notification = mock(MyNewIssuesNotification.class);
     when(notification.setAssignee(anyString())).thenReturn(notification);
-    when(notification.setProject(anyString(), anyString(), anyString(), anyString())).thenReturn(notification);
+    when(notification.setProject(anyString(), anyString(), anyString())).thenReturn(notification);
     when(notification.setProjectVersion(anyString())).thenReturn(notification);
     when(notification.setAnalysisDate(any(Date.class))).thenReturn(notification);
     when(notification.setStatistics(anyString(), any(NewIssuesStatistics.Stats.class))).thenReturn(notification);

--- a/server/sonar-server/src/test/java/org/sonar/server/event/NewAlertsTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/event/NewAlertsTest.java
@@ -28,15 +28,20 @@ import org.sonar.api.web.UserRole;
 import org.sonar.server.notification.NotificationDispatcher;
 import org.sonar.server.notification.NotificationManager;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class NewAlertsTest {
 
-  NotificationManager notificationManager = mock(NotificationManager.class);
-  NotificationDispatcher.Context context = mock(NotificationDispatcher.Context.class);
-  NotificationChannel emailChannel = mock(NotificationChannel.class);
-  NotificationChannel twitterChannel = mock(NotificationChannel.class);
-  NewAlerts dispatcher = new NewAlerts(notificationManager);
+  private NotificationManager notificationManager = mock(NotificationManager.class);
+  private NotificationDispatcher.Context context = mock(NotificationDispatcher.Context.class);
+  private NotificationChannel emailChannel = mock(NotificationChannel.class);
+  private NotificationChannel twitterChannel = mock(NotificationChannel.class);
+  private NewAlerts dispatcher = new NewAlerts(notificationManager);
 
   @Test
   public void should_not_dispatch_if_not_alerts_notification() {
@@ -51,9 +56,11 @@ public class NewAlertsTest {
     Multimap<String, NotificationChannel> recipients = HashMultimap.create();
     recipients.put("user1", emailChannel);
     recipients.put("user2", twitterChannel);
-    when(notificationManager.findSubscribedRecipientsForDispatcher(dispatcher, "uuid_34", new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER))).thenReturn(recipients);
+    when(notificationManager.findSubscribedRecipientsForDispatcher(dispatcher, "key_34", new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER)))
+      .thenReturn(recipients);
 
-    Notification notification = new Notification("alerts").setFieldValue("projectUuid", "uuid_34");
+    Notification notification = new Notification("alerts")
+      .setFieldValue("projectKey", "key_34");
     dispatcher.performDispatch(notification, context);
 
     verify(context).addUser("user1", emailChannel);
@@ -62,11 +69,12 @@ public class NewAlertsTest {
   }
 
   @Test
-  public void should_not_dispatch_if_missing_project_id() {
+  public void should_not_dispatch_if_missing_project_key() {
     Multimap<String, NotificationChannel> recipients = HashMultimap.create();
     recipients.put("user1", emailChannel);
     recipients.put("user2", twitterChannel);
-    when(notificationManager.findSubscribedRecipientsForDispatcher(dispatcher, "uuid_34", new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER))).thenReturn(recipients);
+    when(notificationManager.findSubscribedRecipientsForDispatcher(dispatcher, "key_34", new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER)))
+      .thenReturn(recipients);
 
     Notification notification = new Notification("alerts");
     dispatcher.performDispatch(notification, context);

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/IssueUpdaterTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/IssueUpdaterTest.java
@@ -117,7 +117,6 @@ public class IssueUpdaterTest {
     assertThat(issueChangeNotification.getFieldValue("componentKey")).isEqualTo(file.getDbKey());
     assertThat(issueChangeNotification.getFieldValue("componentName")).isEqualTo(file.longName());
     assertThat(issueChangeNotification.getFieldValue("projectKey")).isEqualTo(project.getDbKey());
-    assertThat(issueChangeNotification.getFieldValue("projectUuid")).isEqualTo(project.uuid());
     assertThat(issueChangeNotification.getFieldValue("projectName")).isEqualTo(project.name());
     assertThat(issueChangeNotification.getFieldValue("ruleName")).isEqualTo(rule.getName());
     assertThat(issueChangeNotification.getFieldValue("changeAuthor")).isEqualTo("john");

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/notification/ChangesOnMyIssueNotificationDispatcherTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/notification/ChangesOnMyIssueNotificationDispatcherTest.java
@@ -84,12 +84,11 @@ public class ChangesOnMyIssueNotificationDispatcherTest {
     recipients.put("simon", emailChannel);
     recipients.put("freddy", twitterChannel);
     recipients.put("godin", twitterChannel);
-    when(notifications.findSubscribedRecipientsForDispatcher(dispatcher, "uuid1",
-        new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER))).thenReturn(recipients);
+    when(notifications.findSubscribedRecipientsForDispatcher(dispatcher, "struts",
+      new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER))).thenReturn(recipients);
 
     Notification notification = new IssueChangeNotification()
       .setFieldValue("projectKey", "struts")
-      .setFieldValue("projectUuid", "uuid1")
       .setFieldValue("changeAuthor", "olivier")
       .setFieldValue("assignee", "freddy");
     dispatcher.performDispatch(notification, context);
@@ -113,7 +112,8 @@ public class ChangesOnMyIssueNotificationDispatcherTest {
         .setFieldValue("projectKey", "struts")
         .setFieldValue("projectUuid", "uuid1")
         .setFieldValue("changeAuthor", "simon")
-        .setFieldValue("assignee", "simon"), context);
+        .setFieldValue("assignee", "simon"),
+      context);
 
     // no change author
     dispatcher.performDispatch(new IssueChangeNotification().setFieldValue("projectKey", "struts")

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/notification/DoNotFixNotificationDispatcherTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/notification/DoNotFixNotificationDispatcherTest.java
@@ -31,7 +31,13 @@ import org.sonar.server.notification.NotificationDispatcherMetadata;
 import org.sonar.server.notification.NotificationManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 public class DoNotFixNotificationDispatcherTest {
   NotificationManager notifications = mock(NotificationManager.class);
@@ -62,10 +68,10 @@ public class DoNotFixNotificationDispatcherTest {
     recipients.put("simon", emailChannel);
     recipients.put("freddy", twitterChannel);
     recipients.put("godin", twitterChannel);
-    when(notifications.findSubscribedRecipientsForDispatcher(underTest, "uuid1", new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER))).thenReturn(recipients);
+    when(notifications.findSubscribedRecipientsForDispatcher(underTest, "struts", new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER))).thenReturn(recipients);
 
-    Notification fpNotif = new IssueChangeNotification().setFieldValue("projectKey", "struts")
-      .setFieldValue("projectUuid", "uuid1")
+    Notification fpNotif = new IssueChangeNotification()
+      .setFieldValue("projectKey", "struts")
       .setFieldValue("changeAuthor", "godin")
       .setFieldValue("new.resolution", Issue.RESOLUTION_FALSE_POSITIVE)
       .setFieldValue("assignee", "freddy");

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/notification/IssueChangeNotificationTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/notification/IssueChangeNotificationTest.java
@@ -84,18 +84,16 @@ public class IssueChangeNotificationTest {
 
   @Test
   public void set_project_without_branch() {
-    IssueChangeNotification result = notification.setProject("MyService", "My Service", null, "uuid1");
+    IssueChangeNotification result = notification.setProject("MyService", "My Service", null);
     assertThat(result.getFieldValue("projectKey")).isEqualTo("MyService");
-    assertThat(result.getFieldValue("projectUuid")).isEqualTo("uuid1");
     assertThat(result.getFieldValue("projectName")).isEqualTo("My Service");
     assertThat(result.getFieldValue("branch")).isNull();
   }
 
   @Test
   public void set_project_with_branch() {
-    IssueChangeNotification result = notification.setProject("MyService", "My Service", "feature1", "uuid2");
+    IssueChangeNotification result = notification.setProject("MyService", "My Service", "feature1");
     assertThat(result.getFieldValue("projectKey")).isEqualTo("MyService");
-    assertThat(result.getFieldValue("projectUuid")).isEqualTo("uuid2");
     assertThat(result.getFieldValue("projectName")).isEqualTo("My Service");
     assertThat(result.getFieldValue("branch")).isEqualTo("feature1");
   }

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/notification/IssueChangesEmailTemplateTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/notification/IssueChangesEmailTemplateTest.java
@@ -170,7 +170,7 @@ public class IssueChangesEmailTemplateTest {
 
     Notification notification = new IssueChangeNotification()
       .setChangeAuthorLogin("simon")
-      .setProject("Struts", "org.apache:struts", null, "");
+      .setProject("Struts", "org.apache:struts", null);
 
     EmailMessage message = underTest.format(notification);
     assertThat(message.getFrom()).isEqualTo("Simon");
@@ -182,7 +182,7 @@ public class IssueChangesEmailTemplateTest {
 
     Notification notification = new IssueChangeNotification()
       .setChangeAuthorLogin("simon")
-      .setProject("Struts", "org.apache:struts", null, "");
+      .setProject("Struts", "org.apache:struts", null);
 
     EmailMessage message = underTest.format(notification);
     assertThat(message.getFrom()).isEqualTo("simon");

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/notification/MyNewIssuesEmailTemplateTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/notification/MyNewIssuesEmailTemplateTest.java
@@ -224,7 +224,6 @@ public class MyNewIssuesEmailTemplateTest {
     return new Notification(MyNewIssuesNotification.MY_NEW_ISSUES_NOTIF_TYPE)
       .setFieldValue("projectName", "Struts")
       .setFieldValue("projectKey", "org.apache:struts")
-      .setFieldValue("projectUuid", "ABCDE")
       .setFieldValue("projectDate", "2010-05-18T14:50:45+0000")
       .setFieldValue("assignee", "lo.gin")
       .setFieldValue(EFFORT + ".count", "1d3h")

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/notification/MyNewIssuesNotificationDispatcherTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/notification/MyNewIssuesNotificationDispatcherTest.java
@@ -59,11 +59,10 @@ public class MyNewIssuesNotificationDispatcherTest {
     Multimap<String, NotificationChannel> recipients = HashMultimap.create();
     recipients.put("user1", emailChannel);
     recipients.put("user2", twitterChannel);
-    when(notificationManager.findSubscribedRecipientsForDispatcher(underTest, "uuid1", new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER))).thenReturn(recipients);
+    when(notificationManager.findSubscribedRecipientsForDispatcher(underTest, "struts", new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER))).thenReturn(recipients);
 
     Notification notification = new Notification(MyNewIssuesNotification.MY_NEW_ISSUES_NOTIF_TYPE)
       .setFieldValue("projectKey", "struts")
-      .setFieldValue("projectUuid", "uuid1")
       .setFieldValue("assignee", "user1");
     underTest.performDispatch(notification, context);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/notification/NewIssuesEmailTemplateTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/notification/NewIssuesEmailTemplateTest.java
@@ -228,7 +228,6 @@ public class NewIssuesEmailTemplateTest {
     return new Notification(NewIssuesNotification.TYPE)
       .setFieldValue("projectName", "Struts")
       .setFieldValue("projectKey", "org.apache:struts")
-      .setFieldValue("projectUuid", "ABCDE")
       .setFieldValue("projectDate", "2010-05-18T14:50:45+0000")
       .setFieldValue(EFFORT + ".count", "1d3h")
       .setFieldValue(RULE_TYPE + ".count", String.valueOf(count))

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/notification/NewIssuesNotificationDispatcherTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/notification/NewIssuesNotificationDispatcherTest.java
@@ -57,11 +57,10 @@ public class NewIssuesNotificationDispatcherTest {
     Multimap<String, NotificationChannel> recipients = HashMultimap.create();
     recipients.put("user1", emailChannel);
     recipients.put("user2", twitterChannel);
-    when(notifications.findSubscribedRecipientsForDispatcher(dispatcher, "uuid1", new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER))).thenReturn(recipients);
+    when(notifications.findSubscribedRecipientsForDispatcher(dispatcher, "struts", new NotificationManager.SubscriberPermissionsOnProject(UserRole.USER))).thenReturn(recipients);
 
     Notification notification = new Notification(NewIssuesNotification.TYPE)
-      .setFieldValue("projectKey", "struts")
-      .setFieldValue("projectUuid", "uuid1");
+      .setFieldValue("projectKey", "struts");
     dispatcher.performDispatch(notification, context);
 
     verify(context).addUser("user1", emailChannel);

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/notification/NewIssuesNotificationTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/notification/NewIssuesNotificationTest.java
@@ -83,20 +83,18 @@ public class NewIssuesNotificationTest {
 
   @Test
   public void set_project_without_branch() {
-    underTest.setProject("project-key", "project-uuid", "project-long-name", null);
+    underTest.setProject("project-key", "project-long-name", null);
 
     assertThat(underTest.getFieldValue(NewIssuesEmailTemplate.FIELD_PROJECT_NAME)).isEqualTo("project-long-name");
-    assertThat(underTest.getFieldValue(NewIssuesEmailTemplate.FIELD_PROJECT_UUID)).isEqualTo("project-uuid");
     assertThat(underTest.getFieldValue(NewIssuesEmailTemplate.FIELD_PROJECT_KEY)).isEqualTo("project-key");
     assertThat(underTest.getFieldValue(NewIssuesEmailTemplate.FIELD_BRANCH)).isNull();
   }
 
   @Test
   public void set_project_with_branch() {
-    underTest.setProject("project-key", "project-uuid", "project-long-name", "feature");
+    underTest.setProject("project-key", "project-long-name", "feature");
 
     assertThat(underTest.getFieldValue(NewIssuesEmailTemplate.FIELD_PROJECT_NAME)).isEqualTo("project-long-name");
-    assertThat(underTest.getFieldValue(NewIssuesEmailTemplate.FIELD_PROJECT_UUID)).isEqualTo("project-uuid");
     assertThat(underTest.getFieldValue(NewIssuesEmailTemplate.FIELD_PROJECT_KEY)).isEqualTo("project-key");
     assertThat(underTest.getFieldValue(NewIssuesEmailTemplate.FIELD_BRANCH)).isEqualTo("feature");
   }


### PR DESCRIPTION
by querying permissions in DB with component key rather than component uuid
as computing the target branch's key from the branch's key is easy