### PR TITLE
SONAR-9685 Better handle when a plugin returns null from Metrics::getMetrics

### DIFF
--- a/sonar-core/src/main/java/org/sonar/core/metric/ScannerMetrics.java
+++ b/sonar-core/src/main/java/org/sonar/core/metric/ScannerMetrics.java
@@ -22,6 +22,7 @@ package org.sonar.core.metric;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -137,6 +138,7 @@ public class ScannerMetrics {
   private static Stream<Metric> getPluginMetrics(Metrics[] metricsRepositories) {
     return Arrays.stream(metricsRepositories)
       .map(Metrics::getMetrics)
+      .filter(Objects::nonNull)
       .flatMap(List::stream);
   }
 }

--- a/sonar-core/src/test/java/org/sonar/core/metric/ScannerMetricsTest.java
+++ b/sonar-core/src/test/java/org/sonar/core/metric/ScannerMetricsTest.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.core.metric;
 
-import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +41,7 @@ public class ScannerMetricsTest {
   @Test
   public void check_metrics_from_plugin() throws Exception {
     List<Metric> metrics = metrics(new FakeMetrics());
-    Iterables.removeAll(metrics, SENSOR_METRICS_WITHOUT_METRIC_PLUGIN);
+    metrics.removeAll(SENSOR_METRICS_WITHOUT_METRIC_PLUGIN);
     assertThat(metrics).hasSize(2);
   }
 
@@ -52,7 +51,7 @@ public class ScannerMetricsTest {
     Metrics okMetrics = new FakeMetrics();
 
     List<Metric> metrics = metrics(okMetrics, faultyMetrics);
-    Iterables.removeAll(metrics, SENSOR_METRICS_WITHOUT_METRIC_PLUGIN);
+    metrics.removeAll(SENSOR_METRICS_WITHOUT_METRIC_PLUGIN);
 
     assertThat(metrics).isEqualTo(okMetrics.getMetrics());
   }

--- a/sonar-core/src/test/java/org/sonar/core/metric/ScannerMetricsTest.java
+++ b/sonar-core/src/test/java/org/sonar/core/metric/ScannerMetricsTest.java
@@ -19,30 +19,30 @@
  */
 package org.sonar.core.metric;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.sonar.api.measures.Metric;
 import org.sonar.api.measures.Metrics;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ScannerMetricsTest {
 
-  static final ScannerMetrics SENSOR_METRICS_WITHOUT_METRIC_PLUGIN = new ScannerMetrics(new Metrics[] {});
-  static final ScannerMetrics SENSOR_METRICS_WITH_PLUGIN = new ScannerMetrics(new Metrics[] {new FakeMetrics()});
+  // metrics that are always added, regardless of plugins
+  private static final List<Metric> SENSOR_METRICS_WITHOUT_METRIC_PLUGIN = metrics();
 
   @Test
   public void check_number_of_allowed_core_metrics() throws Exception {
-    assertThat(SENSOR_METRICS_WITHOUT_METRIC_PLUGIN.getMetrics()).hasSize(34);
+    assertThat(SENSOR_METRICS_WITHOUT_METRIC_PLUGIN).hasSize(34);
   }
 
   @Test
   public void check_metrics_from_plugin() throws Exception {
-    List<Metric> metrics = newArrayList(SENSOR_METRICS_WITH_PLUGIN.getMetrics());
-    Iterables.removeAll(metrics, SENSOR_METRICS_WITHOUT_METRIC_PLUGIN.getMetrics());
+    List<Metric> metrics = metrics(new FakeMetrics());
+    Iterables.removeAll(metrics, SENSOR_METRICS_WITHOUT_METRIC_PLUGIN);
     assertThat(metrics).hasSize(2);
   }
 
@@ -51,16 +51,20 @@ public class ScannerMetricsTest {
     Metrics faultyMetrics = () -> null;
     Metrics okMetrics = new FakeMetrics();
 
-    List<Metric> metrics = newArrayList(new ScannerMetrics(new Metrics[] {okMetrics, faultyMetrics}).getMetrics());
-    Iterables.removeAll(metrics, SENSOR_METRICS_WITHOUT_METRIC_PLUGIN.getMetrics());
+    List<Metric> metrics = metrics(okMetrics, faultyMetrics);
+    Iterables.removeAll(metrics, SENSOR_METRICS_WITHOUT_METRIC_PLUGIN);
 
     assertThat(metrics).isEqualTo(okMetrics.getMetrics());
+  }
+
+  private static List<Metric> metrics(Metrics... metrics) {
+    return new ArrayList<>(new ScannerMetrics(metrics).getMetrics());
   }
 
   private static class FakeMetrics implements Metrics {
     @Override
     public List<Metric> getMetrics() {
-      return ImmutableList.<Metric>of(
+      return Arrays.asList(
         new Metric.Builder("key1", "name1", Metric.ValueType.INT).create(),
         new Metric.Builder("key2", "name2", Metric.ValueType.FLOAT).create());
     }

--- a/sonar-core/src/test/java/org/sonar/core/metric/ScannerMetricsTest.java
+++ b/sonar-core/src/test/java/org/sonar/core/metric/ScannerMetricsTest.java
@@ -46,8 +46,18 @@ public class ScannerMetricsTest {
     assertThat(metrics).hasSize(2);
   }
 
-  private static class FakeMetrics implements Metrics {
+  @Test
+  public void should_not_crash_on_null_metrics_from_faulty_plugins() {
+    Metrics faultyMetrics = () -> null;
+    Metrics okMetrics = new FakeMetrics();
 
+    List<Metric> metrics = newArrayList(new ScannerMetrics(new Metrics[] {okMetrics, faultyMetrics}).getMetrics());
+    Iterables.removeAll(metrics, SENSOR_METRICS_WITHOUT_METRIC_PLUGIN.getMetrics());
+
+    assertThat(metrics).isEqualTo(okMetrics.getMetrics());
+  }
+
+  private static class FakeMetrics implements Metrics {
     @Override
     public List<Metric> getMetrics() {
       return ImmutableList.<Metric>of(


### PR DESCRIPTION
I did not add logging, because I just don't see the point. If somebody is expecting metrics from a plugin, they had better check that it actually provides some. Logging would require either that I add a side effect while mapping the stream of metrics providers, or an extra iteration over all providers. Neither is great, and I think it would be unnecessary ugliness just for the sake of faulty plugins that should have been better implemented and tested.