### PR TITLE
SONAR-9828 support Java 9 as build environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.1.0</version>
           <configuration>
             <archiverConfig>
               <!-- Workaround for http://jira.codehaus.org/browse/MASSEMBLY-422 -->
@@ -143,7 +143,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.12</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -153,12 +153,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.10</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.4.1</version>
+          <version>3.0.0-M1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -182,7 +182,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
+          <version>3.0.0-M1</version>
           <configuration>
             <author>false</author>
             <linksource>true</linksource>
@@ -201,12 +201,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -216,12 +216,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>2.20.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <!-- not thread safe -->

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
         <plugin>
           <groupId>com.github.genthaler</groupId>
           <artifactId>beanshell-maven-plugin</artifactId>
-          <version>1.2</version>
+          <version>1.4</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -339,6 +339,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <quiet>true</quiet>
               <script>
                 <![CDATA[
                 String[] timezones = new String[] {"GMT-9", "UTC", "GMT+9"};

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <hazelcast.version>3.8.4</hazelcast.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.min.version>3.2</maven.min.version>
+    <maven.min.version>3.3.9</maven.min.version>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <license.title>SonarQube</license.title>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.1.Final</version>
+        <version>1.5.0.Final</version>
       </extension>
     </extensions>
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,10 +104,6 @@
     <artifactsToPublish>${project.groupId}:sonar-application:zip</artifactsToPublish>
   </properties>
 
-  <prerequisites>
-    <maven>3.2</maven>
-  </prerequisites>
-
   <build>
     <extensions>
       <extension>

--- a/sonar-application/assembly.xml
+++ b/sonar-application/assembly.xml
@@ -122,7 +122,7 @@
     <!-- wrapper binaries -->
     <fileSet>
       <directory>src/main/assembly</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>bin/*/lib/*.so</include>
         <include>bin/*/lib/*.jnilib</include>
@@ -137,7 +137,7 @@
     <!-- Configuration Files -->
     <fileSet>
       <directory>src/main/assembly</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>conf/**</include>
       </includes>
@@ -148,7 +148,7 @@
     <!-- Windows Scripts -->
     <fileSet>
       <directory>src/main/assembly</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>**/*.bat</include>
         <include>**/*.cmd</include>
@@ -159,7 +159,7 @@
     <!-- Linux Scripts -->
     <fileSet>
       <directory>src/main/assembly</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>**/*.sh</include>
         <include>**/ant</include>
@@ -171,7 +171,7 @@
     <!-- Other stuff -->
     <fileSet>
       <directory>src/main/assembly</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <excludes>
         <exclude>conf/**</exclude>
         <exclude>**/*.bat</exclude>

--- a/sonar-application/assembly.xml
+++ b/sonar-application/assembly.xml
@@ -64,7 +64,6 @@
       <outputDirectory>lib/bundled-plugins</outputDirectory>
       <useTransitiveDependencies>false</useTransitiveDependencies>
       <includes>
-        <include>org.codehaus.sonar-plugins*:sonar-*-plugin</include>
         <include>org.sonarsource.*:sonar-*-plugin</include>
       </includes>
       <scope>provided</scope>

--- a/travis.sh
+++ b/travis.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # at each build.
 #
 function installJdk8 {
-  echo "Setup JDK 1.8u131"
+  echo "Setup JDK 1.8u144"
   mkdir -p ~/jvm
   pushd ~/jvm > /dev/null
   if [ ! -d "jdk1.8.0_144" ]; then


### PR DESCRIPTION
This pull request does not aim to support Java 9
at runtime (this is the goal of #2633) but at build 
time. Some changes must be done in pom.xml files so
that Maven can successfully build sources with
JDK 9.