### PR TITLE
Correct the thread safety of logOnce()

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/sensor/DefaultSensorStorage.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/sensor/DefaultSensorStorage.java
@@ -22,6 +22,7 @@ package org.sonar.scanner.sensor;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -149,7 +150,7 @@ public class DefaultSensorStorage implements SensorStorage {
   private final Map<Metric<?>, Metric<?>> deprecatedCoverageMetricMapping = new HashMap<>();
   private final Set<Metric<?>> coverageMetrics = new HashSet<>();
   private final Set<Metric<?>> byLineMetrics = new HashSet<>();
-  private final Set<String> alreadyLogged = new HashSet<>();
+  private final Set<String> alreadyLogged = Collections.synchronizedSet(new HashSet<>());
 
   public DefaultSensorStorage(MetricFinder metricFinder, ModuleIssues moduleIssues, Configuration settings,
     ReportPublisher reportPublisher, MeasureCache measureCache, SonarCpdBlockIndex index,


### PR DESCRIPTION
[logOnce()](https://github.com/SonarSource/sonarqube/blob/6810d4b43783fe4dcbfd7d2361fe5584f261dc89/sonar-scanner-engine/src/main/java/org/sonar/scanner/sensor/DefaultSensorStorage.java#L211) is documented as thread safe; however, it calls Set\<E>.add(E) on the `alreadyLogged` member. This mutates the set and therefore is not thread safe.

To fix, wrap `alreadyLogged` as a synchronized set.