### PR TITLE
Fix some logger calls

### DIFF
--- a/server/sonar-ce/src/main/java/org/sonar/ce/logging/ChangeLogLevelHttpAction.java
+++ b/server/sonar-ce/src/main/java/org/sonar/ce/logging/ChangeLogLevelHttpAction.java
@@ -63,7 +63,7 @@ public class ChangeLogLevelHttpAction implements HttpAction {
       logging.changeLevel(level);
       return newFixedLengthResponse(OK, MIME_PLAINTEXT, null);
     } catch (IllegalArgumentException e) {
-      Loggers.get(ChangeLogLevelHttpAction.class).debug("Value '{}' for parameter '{}' is invalid", levelStr, PARAM_LEVEL, e);
+      Loggers.get(ChangeLogLevelHttpAction.class).debug("Value '{}' for parameter '" + PARAM_LEVEL + "' is invalid: {}", levelStr, e);
       return newFixedLengthResponse(BAD_REQUEST, MIME_PLAINTEXT, format("Value '%s' for parameter '%s' is invalid", levelStr, PARAM_LEVEL));
     }
   }

--- a/server/sonar-ce/src/main/java/org/sonar/ce/taskprocessor/CeProcessingSchedulerImpl.java
+++ b/server/sonar-ce/src/main/java/org/sonar/ce/taskprocessor/CeProcessingSchedulerImpl.java
@@ -87,7 +87,7 @@ public class CeProcessingSchedulerImpl implements CeProcessingScheduler {
       try {
         Thread.sleep(200L);
       } catch (InterruptedException e) {
-        LOG.debug("Graceful stop period has been interrupted", e);
+        LOG.debug("Graceful stop period has been interrupted: {}", e);
         Thread.currentThread().interrupt();
         break;
       }

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/DBSessionsImpl.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/DBSessionsImpl.java
@@ -69,7 +69,7 @@ public class DBSessionsImpl implements DBSessions {
         checkState(!((boolean) f.get(sqlSession)), "Autocommit must be false");
       }
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      LOG.debug("Failed to check the autocommit status of SqlSession", e);
+      LOG.debug("Failed to check the autocommit status of SqlSession: {}", e);
     }
   }
 

--- a/server/sonar-server/src/main/java/org/sonar/server/health/DbConnectionNodeCheck.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/health/DbConnectionNodeCheck.java
@@ -52,7 +52,7 @@ public class DbConnectionNodeCheck implements NodeHealthCheck {
     try (DbSession dbSession = dbClient.openSession(false)) {
       return dbSession.getMapper(IsAliveMapper.class).isAlive() == IsAliveMapper.IS_ALIVE_RETURNED_VALUE;
     } catch (RuntimeException e) {
-      LOGGER.trace("DB connection is down", e);
+      LOGGER.trace("DB connection is down: {}", e);
       return false;
     }
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/notification/email/EmailNotificationChannel.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/notification/email/EmailNotificationChannel.java
@@ -217,7 +217,7 @@ public class EmailNotificationChannel extends NotificationChannel {
       emailMessage.setMessage(message);
       send(emailMessage);
     } catch (EmailException e) {
-      LOG.debug("Fail to send test email to: " + toAddress, e);
+      LOG.debug("Fail to send test email to {}: {}", toAddress, e);
       throw e;
     }
   }

--- a/server/sonar-server/src/main/java/org/sonar/server/plugins/PluginDownloader.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/plugins/PluginDownloader.java
@@ -132,7 +132,7 @@ public class PluginDownloader implements Startable {
         } catch (Exception e) {
           String message = String.format("Fail to download the plugin (%s, version %s) from %s (error is : %s)",
             release.getArtifact().getKey(), release.getVersion().getName(), release.getDownloadUrl(), e.getMessage());
-          LOG.debug(message, e);
+          LOG.debug(message);
           throw new SonarException(message, e);
         }
       }

--- a/server/sonar-server/src/main/java/org/sonar/server/plugins/StaticResourcesServlet.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/plugins/StaticResourcesServlet.java
@@ -69,7 +69,7 @@ public class StaticResourcesServlet extends HttpServlet {
         silentlySendError(response, SC_NOT_FOUND);
       }
     } catch (ClientAbortException e) {
-      LOG.trace(format("Client canceled loading resource [%s] from plugin [%s]", resource, pluginKey), e);
+      LOG.trace("Client canceled loading resource [{}] from plugin [{}]: {}", resource, pluginKey, e);
     } catch (Exception e) {
       LOG.error(format("Unable to load resource [%s] from plugin [%s]", resource, pluginKey), e);
       silentlySendError(response, SC_INTERNAL_SERVER_ERROR);
@@ -92,7 +92,7 @@ public class StaticResourcesServlet extends HttpServlet {
     try {
       response.sendError(error);
     } catch (IOException e) {
-      LOG.trace(format("Failed to send error code %s", error), e);
+      LOG.trace("Failed to send error code {}: {}", error, e);
     }
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/plugins/StaticResourcesServletTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/plugins/StaticResourcesServletTest.java
@@ -106,7 +106,7 @@ public class StaticResourcesServletTest {
     underTest.doGet(request, response);
 
     assertThat(logTester.logs(LoggerLevel.ERROR)).isEmpty();
-    assertThat(logTester.logs(LoggerLevel.TRACE)).containsOnly("Failed to send error code 404");
+    assertThat(logTester.logs(LoggerLevel.TRACE)).containsOnly("Failed to send error code 404: java.io.IOException: Simulating sendError throwing IOException");
   }
 
   private void mockPluginForResourceDoesNotExist() {
@@ -135,7 +135,7 @@ public class StaticResourcesServletTest {
     underTest.doGet(request, response);
 
     assertThat(logTester.logs(LoggerLevel.ERROR)).isEmpty();
-    assertThat(logTester.logs(LoggerLevel.TRACE)).containsOnly("Failed to send error code 404");
+    assertThat(logTester.logs(LoggerLevel.TRACE)).containsOnly("Failed to send error code 404: java.io.IOException: Simulating sendError throwing IOException");
   }
 
   private void mockPluginExistsButNoResource() {
@@ -158,7 +158,7 @@ public class StaticResourcesServletTest {
     underTest.doGet(request, response);
 
     assertThat(logTester.logs(LoggerLevel.ERROR)).isEmpty();
-    assertThat(logTester.logs(LoggerLevel.TRACE)).containsOnly("Client canceled loading resource [static/foo.txt] from plugin [myplugin]");
+    assertThat(logTester.logs(LoggerLevel.TRACE)).containsOnly("Client canceled loading resource [static/foo.txt] from plugin [myplugin]: org.apache.catalina.connector.ClientAbortException: Simulating ClientAbortException");
     verify(response, times(0)).sendError(anyInt());
   }
 


### PR DESCRIPTION
The `org.sonar.api.utils.log.Logger` interface supports logging instances of exception/throwable directly at the warn and error levels, but not at the trace, debug, or info levels. Instead, at the trace, debug, or info levels, the exception/throwable must be formatted as a regular format arg (Object).