### PR TITLE
Skip compiling Test classes

### DIFF
--- a/quick-build.sh
+++ b/quick-build.sh
@@ -41,4 +41,4 @@ $$$$"""$$$$$$$$$$uuu   uu$$$$$$$$$"""$$$"
 EOF
 
 ./stop.sh
-mvn clean install -B -e -V -DskipTests=true -Dmaven.source.skip=true -Pdev,skipSanityChecks $*
+mvn clean install -B -e -V -Dmaven.test.skip -Dmaven.source.skip=true -Pdev,skipSanityChecks $*


### PR DESCRIPTION
-DskipTests just skips the test execution: the tests are still compiled. Where as-Dmaven.test.skip will skip both compilation and execution of the tests.