### PR TITLE
upgrade xstream version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <h2.version>1.3.176</h2.version>
     <jetty.version>8.1.12.v20130726</jetty.version>
     <logback.version>1.2.3</logback.version>
-    <xstream.version>1.4.10<xstream.version>
+    <xstream.version>1.4.10</xstream.version>
     <slf4j.version>1.7.25</slf4j.version>
 
     <!-- Be aware that Log4j is used by Elasticsearch client -->

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <h2.version>1.3.176</h2.version>
     <jetty.version>8.1.12.v20130726</jetty.version>
     <logback.version>1.2.3</logback.version>
+    <xstream.version>1.4.10<xstream.version>
     <slf4j.version>1.7.25</slf4j.version>
 
     <!-- Be aware that Log4j is used by Elasticsearch client -->
@@ -649,6 +650,7 @@
           <exclusion>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
+            <version>${xstream.version}</version>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
     <h2.version>1.3.176</h2.version>
     <jetty.version>8.1.12.v20130726</jetty.version>
     <logback.version>1.2.3</logback.version>
-    <xstream.version>1.4.10</xstream.version>
     <slf4j.version>1.7.25</slf4j.version>
 
     <!-- Be aware that Log4j is used by Elasticsearch client -->
@@ -315,6 +314,7 @@
                   <message>commons-beanutils:commons-beanutils should be used instead</message>
                   <excludes>
                     <exclude>commons-beanutils:commons-beanutils-core</exclude>
+                    <exclude>com.thoughtworks.xstream:xstream:[0.0,1.4.9)</exclude>
                   </excludes>
                   <searchTransitive>true</searchTransitive>
                 </bannedDependencies>
@@ -650,7 +650,6 @@
           <exclusion>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>${xstream.version}</version>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Without specifying the version of xstream in the pom.xml, by default it installs xstream version 1.3.1. There is security vulnerability with this version and the CVS score is 7.5 [https://nvd.nist.gov/vuln/detail/CVE-2017-7957](url). To remove this vulnerability, xstream package needs to be upgraded to 1.4.10. I have updated the pom.xml with the fix. 