### PR TITLE
ban xstream less than 1.4.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,7 @@
                   <message>commons-beanutils:commons-beanutils should be used instead</message>
                   <excludes>
                     <exclude>commons-beanutils:commons-beanutils-core</exclude>
+                    <exclude>com.thoughtworks.xstream:xstream:[0.0,1.4.9)</exclude>
                   </excludes>
                   <searchTransitive>true</searchTransitive>
                 </bannedDependencies>


### PR DESCRIPTION
Without specifying the version of xstream in the pom.xml, by default it installs xstream version 1.3.1. There is security vulnerability with this version and the CVS score is 7.5 https://nvd.nist.gov/vuln/detail/CVE-2017-7957. To remove this vulnerability, xstream package needs to be upgraded to 1.4.10. I have updated the pom.xml with the fix.