### PR TITLE
fix build logback verbosity

### DIFF
--- a/server/sonar-db-core/pom.xml
+++ b/server/sonar-db-core/pom.xml
@@ -134,6 +134,11 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <excludes>
+                <exclude>logback-test.xml</exclude>
+              </excludes>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/server/sonar-db-core/src/test/java/org/sonar/db/CoreTestDb.java
+++ b/server/sonar-db-core/src/test/java/org/sonar/db/CoreTestDb.java
@@ -94,7 +94,7 @@ class CoreTestDb {
         }
       }
       isDefault = (schemaPath == null);
-      LOG.info("Test Database: " + db);
+      LOG.debug("Test Database: " + db);
 
       commands = DatabaseCommands.forDialect(db.getDialect());
       tester = new DataSourceDatabaseTester(db.getDataSource(), commands.useLoginAsSchema() ? login : null);

--- a/server/sonar-db-dao/pom.xml
+++ b/server/sonar-db-dao/pom.xml
@@ -93,6 +93,11 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <excludes>
+                <exclude>logback-test.xml</exclude>
+              </excludes>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/server/sonar-db-dao/src/test/resources/logback-test.xml
+++ b/server/sonar-db-dao/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<configuration>
+
+  <appender name="STDOUT"
+            class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>
+        %d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.dbunit">
+    <level value="WARN"/>
+  </logger>
+
+  <!-- set to level DEBUG to log SQL requests executed by MyBatis -->
+  <logger name="java.sql">
+    <level value="WARN"/>
+  </logger>
+
+  <!-- required for DryRunDatabaseFactoryTest -->
+  <logger name="org.elasticsearch">
+    <level value="WARN"/>
+  </logger>
+
+  <root>
+    <level value="INFO"/>
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>

--- a/server/sonar-process/src/test/java/org/sonar/process/LoggingRule.java
+++ b/server/sonar-process/src/test/java/org/sonar/process/LoggingRule.java
@@ -21,6 +21,7 @@ package org.sonar.process;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.joran.spi.JoranException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.rules.ExternalResource;
@@ -47,6 +48,11 @@ public class LoggingRule extends ExternalResource {
   protected void after() {
     TestLogbackAppender.events.clear();
     setLevel(Level.INFO);
+    try {
+      new LogbackHelper().resetFromXml("/logback-test.xml");
+    } catch (JoranException e) {
+      e.printStackTrace();
+    }
   }
 
   public LoggingRule setLevel(Level level) {

--- a/server/sonar-process/src/test/java/org/sonar/process/LoggingRule.java
+++ b/server/sonar-process/src/test/java/org/sonar/process/LoggingRule.java
@@ -58,6 +58,7 @@ public class LoggingRule extends ExternalResource {
 
   public List<String> getLogs() {
     return TestLogbackAppender.events.stream()
+      .filter(e -> e.getLoggerName().equals(loggerClass.getName()))
       .map(LoggingEvent::getFormattedMessage)
       .collect(Collectors.toList());
   }
@@ -72,12 +73,14 @@ public class LoggingRule extends ExternalResource {
 
   public boolean hasLog(Level level, String message) {
     return TestLogbackAppender.events.stream()
+      .filter(e -> e.getLoggerName().equals(loggerClass.getName()))
       .filter(e -> e.getLevel().levelStr.equals(level.name()))
       .anyMatch(e -> e.getFormattedMessage().equals(message));
   }
 
   public boolean hasLog(String message) {
     return TestLogbackAppender.events.stream()
+      .filter(e -> e.getLoggerName().equals(loggerClass.getName()))
       .anyMatch(e -> e.getFormattedMessage().equals(message));
   }
 }

--- a/server/sonar-process/src/test/resources/logback-test.xml
+++ b/server/sonar-process/src/test/resources/logback-test.xml
@@ -11,16 +11,11 @@
   </appender>
 
   <root>
-    <!-- Don't set to DEBUG or it will show the dev licenses into the console!!!! -->
     <level value="INFO"/>
     <appender-ref ref="CONSOLE"/>
   </root>
 
   <logger name="ch.qos.logback">
-    <level value="WARN"/>
-  </logger>
-
-  <logger name="okhttp3.mockwebserver">
     <level value="WARN"/>
   </logger>
 

--- a/server/sonar-process/src/test/resources/org/sonar/process/logback-test.xml
+++ b/server/sonar-process/src/test/resources/org/sonar/process/logback-test.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<configuration debug="true">
+<configuration debug="false">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} %-5level - %msg%n</pattern>
     </encoder>
@@ -13,8 +14,13 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUD" />
+  <root>
+    <level value="INFO"/>
+    <appender-ref ref="CONSOLE" />
     <appender-ref ref="TESTING" />
   </root>
+
+  <logger name="ch.qos.logback">
+    <level value="WARN"/>
+  </logger>
 </configuration>

--- a/server/sonar-server/pom.xml
+++ b/server/sonar-server/pom.xml
@@ -303,6 +303,11 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <excludes>
+                <exclude>logback-test.xml</exclude>
+              </excludes>
+            </configuration>
           </execution>
         </executions>
         <configuration>

--- a/server/sonar-server/src/test/resources/logback-test.xml
+++ b/server/sonar-server/src/test/resources/logback-test.xml
@@ -11,7 +11,6 @@
   </appender>
 
   <root>
-    <!-- Don't set to DEBUG or it will show the dev licenses into the console!!!! -->
     <level value="INFO"/>
     <appender-ref ref="CONSOLE"/>
   </root>

--- a/sonar-plugin-api/pom.xml
+++ b/sonar-plugin-api/pom.xml
@@ -227,6 +227,11 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <excludes>
+                <exclude>logback-test.xml</exclude>
+              </excludes>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/sonar-plugin-api/src/test/resources/logback-test.xml
+++ b/sonar-plugin-api/src/test/resources/logback-test.xml
@@ -11,16 +11,11 @@
   </appender>
 
   <root>
-    <!-- Don't set to DEBUG or it will show the dev licenses into the console!!!! -->
     <level value="INFO"/>
     <appender-ref ref="CONSOLE"/>
   </root>
 
   <logger name="ch.qos.logback">
-    <level value="WARN"/>
-  </logger>
-
-  <logger name="okhttp3.mockwebserver">
     <level value="WARN"/>
   </logger>
 

--- a/sonar-scanner-engine/src/test/resources/logback-test.xml
+++ b/sonar-scanner-engine/src/test/resources/logback-test.xml
@@ -33,6 +33,9 @@
   <logger name="PERSISTIT">
     <level value="WARN"/>
   </logger>
+  <logger name="ch.qos.logback">
+    <level value="WARN"/>
+  </logger>
 
   <root>
     <level value="INFO"/>


### PR DESCRIPTION
basically remove 300Kb of lines starting with "|-" spit by logback at INFO level but which are really debug information (operations performed by logback)

also fix unstable test `SharedHealthStateImplTest`