### PR TITLE
SONAR-10074 Add QP actions "delete" and "associateProjects"

### DIFF
--- a/server/sonar-qa-util/src/main/java/org/sonarqube/qa/util/pageobjects/QualityProfilePage.java
+++ b/server/sonar-qa-util/src/main/java/org/sonarqube/qa/util/pageobjects/QualityProfilePage.java
@@ -48,7 +48,19 @@ public class QualityProfilePage {
 
   public QualityProfilePage shouldAllowToChangeProjects() {
     Selenide.$(".js-change-projects").shouldBe(Condition.visible).click();
-    Selenide.$("#profile-projects .select-list-list").shouldBe(Condition.visible);
+    Selenide.$("#profile-projects .select-list-list-container").shouldBe(Condition.visible);
+    return this;
+  }
+
+  public QualityProfilePage shouldNotAllowToChangeProjects() {
+    Selenide.$(".js-change-projects").shouldNot(Condition.exist);
+    return this;
+  }
+
+  public QualityProfilePage shouldNotAllowToEdit() {
+    Selenide.$("button.dropdown-toggle").should(Condition.exist).click();
+    Selenide.$("#quality-profile-rename").shouldNot(Condition.exist);
+    Selenide.$("#quality-profile-activate-more-rules").shouldNot(Condition.exist);
     return this;
   }
 }

--- a/server/sonar-server/src/main/java/org/sonar/server/qualityprofile/ws/SearchData.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/qualityprofile/ws/SearchData.java
@@ -39,7 +39,6 @@ class SearchData {
   private Map<String, Long> projectCountByProfileKey;
   private Set<String> defaultProfileKeys;
   private Set<String> editableProfileKeys;
-  private boolean isGlobalQProfileAdmin;
 
   SearchData setOrganization(OrganizationDto organization) {
     this.organization = organization;
@@ -96,7 +95,7 @@ class SearchData {
   }
 
   boolean isEditable(QProfileDto profile) {
-    return !profile.isBuiltIn() && (isGlobalQProfileAdmin || editableProfileKeys.contains(profile.getKee()));
+    return editableProfileKeys.contains(profile.getKee());
   }
 
   SearchData setEditableProfileKeys(List<String> editableProfileKeys) {
@@ -104,12 +103,4 @@ class SearchData {
     return this;
   }
 
-  boolean isGlobalQProfileAdmin() {
-    return isGlobalQProfileAdmin;
-  }
-
-  SearchData setGlobalQProfileAdmin(boolean globalQProfileAdmin) {
-    isGlobalQProfileAdmin = globalQProfileAdmin;
-    return this;
-  }
 }

--- a/server/sonar-server/src/main/resources/org/sonar/server/qualityprofile/ws/search-example.json
+++ b/server/sonar-server/src/main/resources/org/sonar/server/qualityprofile/ws/search-example.json
@@ -15,7 +15,9 @@
       "actions": {
         "edit": false,
         "setAsDefault": false,
-        "copy": false
+        "copy": false,
+        "delete": false,
+        "associateProjects": false
       }
     },
     {
@@ -37,7 +39,9 @@
       "actions": {
         "edit": true,
         "setAsDefault": false,
-        "copy": false
+        "copy": false,
+        "delete": true,
+        "associateProjects": true
       }
     },
     {
@@ -55,7 +59,9 @@
       "actions": {
         "edit": true,
         "setAsDefault": false,
-        "copy": false
+        "copy": false,
+        "delete": false,
+        "associateProjects": false
       }
     },
     {
@@ -72,7 +78,9 @@
       "actions": {
         "edit": false,
         "setAsDefault": false,
-        "copy": false
+        "copy": false,
+        "delete": false,
+        "associateProjects": false
       }
     }
   ],

--- a/server/sonar-web/src/main/js/api/quality-profiles.ts
+++ b/server/sonar-web/src/main/js/api/quality-profiles.ts
@@ -30,7 +30,9 @@ import { Paging } from '../app/types';
 import throwGlobalError from '../app/utils/throwGlobalError';
 
 export interface ProfileActions {
+  associateProjects?: boolean;
   copy?: boolean;
+  delete?: boolean;
   edit?: boolean;
   setAsDefault?: boolean;
 }
@@ -104,7 +106,7 @@ export function restoreQualityProfile(data: RequestData): Promise<any> {
 }
 
 export function getProfileProjects(data: RequestData): Promise<any> {
-  return getJSON('/api/qualityprofiles/projects', data);
+  return getJSON('/api/qualityprofiles/projects', data).catch(throwGlobalError);
 }
 
 export function getProfileInheritance(profileKey: string): Promise<any> {

--- a/server/sonar-web/src/main/js/apps/quality-profiles/components/BuiltInQualityProfileBadge.tsx
+++ b/server/sonar-web/src/main/js/apps/quality-profiles/components/BuiltInQualityProfileBadge.tsx
@@ -41,5 +41,11 @@ export default function BuiltInQualityProfileBadge({ className, tooltip = true }
     </span>
   );
 
-  return tooltip ? <Tooltip overlay={overlay}>{badge}</Tooltip> : badge;
+  return tooltip ? (
+    <Tooltip overlay={overlay} placement="right">
+      {badge}
+    </Tooltip>
+  ) : (
+    badge
+  );
 }

--- a/server/sonar-web/src/main/js/apps/quality-profiles/components/ProfileActions.tsx
+++ b/server/sonar-web/src/main/js/apps/quality-profiles/components/ProfileActions.tsx
@@ -137,15 +137,10 @@ export default class ProfileActions extends React.PureComponent<Props, State> {
       this.props.organization
     );
 
-    const canActivateRules = actions.edit && !profile.isBuiltIn;
-    const canRename = actions.edit && !profile.isBuiltIn;
-    const canSetAsDefault = actions.setAsDefault && !profile.isDefault;
-    const canDelete = actions.edit && !profile.isDefault && !profile.isBuiltIn;
-
     return (
       <ActionsDropdown className={this.props.className}>
-        {canActivateRules && (
-          <ActionsDropdownItem to={activateMoreUrl}>
+        {actions.edit && (
+          <ActionsDropdownItem to={activateMoreUrl} id="quality-profile-activate-more-rules">
             {translate('quality_profiles.activate_more_rules')}
           </ActionsDropdownItem>
         )}
@@ -171,13 +166,13 @@ export default class ProfileActions extends React.PureComponent<Props, State> {
           </ActionsDropdownItem>
         )}
 
-        {canRename && (
+        {actions.edit && (
           <ActionsDropdownItem id="quality-profile-rename" onClick={this.handleRenameClick}>
             {translate('rename')}
           </ActionsDropdownItem>
         )}
 
-        {canSetAsDefault && (
+        {actions.setAsDefault && (
           <ActionsDropdownItem
             id="quality-profile-set-as-default"
             onClick={this.handleSetDefaultClick}>
@@ -185,9 +180,9 @@ export default class ProfileActions extends React.PureComponent<Props, State> {
           </ActionsDropdownItem>
         )}
 
-        {canDelete && <ActionsDropdownDivider />}
+        {actions.delete && <ActionsDropdownDivider />}
 
-        {canDelete && (
+        {actions.delete && (
           <ActionsDropdownItem
             destructive={true}
             id="quality-profile-delete"

--- a/server/sonar-web/src/main/js/apps/quality-profiles/components/__tests__/ProfileActions-test.tsx
+++ b/server/sonar-web/src/main/js/apps/quality-profiles/components/__tests__/ProfileActions-test.tsx
@@ -50,7 +50,7 @@ it('renders with no permissions', () => {
   ).toMatchSnapshot();
 });
 
-it('renders with permission to edit', () => {
+it('renders with permission to edit only', () => {
   expect(
     shallow(
       <ProfileActions
@@ -69,7 +69,16 @@ it('renders with all permissions', () => {
       <ProfileActions
         onRequestFail={jest.fn()}
         organization="org"
-        profile={{ ...PROFILE, actions: { copy: true, edit: true, setAsDefault: true } }}
+        profile={{
+          ...PROFILE,
+          actions: {
+            copy: true,
+            edit: true,
+            delete: true,
+            setAsDefault: true,
+            associateProjects: true
+          }
+        }}
         updateProfiles={jest.fn()}
       />
     )

--- a/server/sonar-web/src/main/js/apps/quality-profiles/components/__tests__/__snapshots__/ProfileActions-test.tsx.snap
+++ b/server/sonar-web/src/main/js/apps/quality-profiles/components/__tests__/__snapshots__/ProfileActions-test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`renders with all permissions 1`] = `
 <ActionsDropdown>
   <ActionsDropdownItem
+    id="quality-profile-activate-more-rules"
     to="/organizations/org/rules#qprofile=foo|activation=false"
   >
     quality_profiles.activate_more_rules
@@ -83,9 +84,10 @@ exports[`renders with no permissions 1`] = `
 </ActionsDropdown>
 `;
 
-exports[`renders with permission to edit 1`] = `
+exports[`renders with permission to edit only 1`] = `
 <ActionsDropdown>
   <ActionsDropdownItem
+    id="quality-profile-activate-more-rules"
     to="/organizations/org/rules#qprofile=foo|activation=false"
   >
     quality_profiles.activate_more_rules
@@ -116,14 +118,6 @@ exports[`renders with permission to edit 1`] = `
     onClick={[Function]}
   >
     rename
-  </ActionsDropdownItem>
-  <ActionsDropdownDivider />
-  <ActionsDropdownItem
-    destructive={true}
-    id="quality-profile-delete"
-    onClick={[Function]}
-  >
-    delete
   </ActionsDropdownItem>
 </ActionsDropdown>
 `;

--- a/server/sonar-web/src/main/js/apps/quality-profiles/details/ProfileProjects.tsx
+++ b/server/sonar-web/src/main/js/apps/quality-profiles/details/ProfileProjects.tsx
@@ -69,15 +69,18 @@ export default class ProfileProjects extends React.PureComponent<Props, State> {
     }
 
     const data = { key: this.props.profile.key };
-    getProfileProjects(data).then((r: any) => {
-      if (this.mounted) {
-        this.setState({
-          projects: r.results,
-          more: r.more,
-          loading: false
-        });
-      }
-    });
+    getProfileProjects(data).then(
+      (r: any) => {
+        if (this.mounted) {
+          this.setState({
+            projects: r.results,
+            more: r.more,
+            loading: false
+          });
+        }
+      },
+      () => {}
+    );
   }
 
   handleChangeClick = (event: React.SyntheticEvent<HTMLElement>) => {
@@ -91,6 +94,10 @@ export default class ProfileProjects extends React.PureComponent<Props, State> {
   };
 
   renderDefault() {
+    if (this.state.loading) {
+      return <i className="spinner" />;
+    }
+
     return (
       <div>
         <span className="badge spacer-right">{translate('default')}</span>
@@ -100,6 +107,10 @@ export default class ProfileProjects extends React.PureComponent<Props, State> {
   }
 
   renderProjects() {
+    if (this.state.loading) {
+      return <i className="spinner" />;
+    }
+
     const { projects } = this.state;
 
     if (projects == null) {
@@ -130,8 +141,7 @@ export default class ProfileProjects extends React.PureComponent<Props, State> {
     return (
       <div className="boxed-group quality-profile-projects">
         {profile.actions &&
-          profile.actions.edit &&
-          !profile.isDefault && (
+          profile.actions.associateProjects && (
             <div className="boxed-group-actions">
               <button className="js-change-projects" onClick={this.handleChangeClick}>
                 {translate('quality_profiles.change_projects')}
@@ -144,13 +154,7 @@ export default class ProfileProjects extends React.PureComponent<Props, State> {
         </header>
 
         <div className="boxed-group-inner">
-          {this.state.loading ? (
-            <i className="spinner" />
-          ) : profile.isDefault ? (
-            this.renderDefault()
-          ) : (
-            this.renderProjects()
-          )}
+          {profile.isDefault ? this.renderDefault() : this.renderProjects()}
         </div>
 
         {this.state.formOpen && (

--- a/sonar-ws/src/main/protobuf/ws-qualityprofiles.proto
+++ b/sonar-ws/src/main/protobuf/ws-qualityprofiles.proto
@@ -54,7 +54,9 @@ message SearchWsResponse {
         optional bool edit = 1;
         optional bool setAsDefault = 2;
         optional bool copy = 3;
-    }
+        optional bool associateProjects = 4;
+        optional bool delete = 5;
+      }
   }
 
   message Actions {

--- a/tests/src/test/java/org/sonarqube/tests/qualityProfile/OrganizationQualityProfilesUiTest.java
+++ b/tests/src/test/java/org/sonarqube/tests/qualityProfile/OrganizationQualityProfilesUiTest.java
@@ -118,6 +118,17 @@ public class OrganizationQualityProfilesUiTest {
   }
 
   @Test
+  public void testBuiltIn() {
+    Navigation nav = tester.openBrowser().logIn().submitCredentials(user.getLogin());
+    nav.openQualityProfile("xoo", "Sonar way", "test-org")
+      .shouldNotAllowToEdit()
+      .shouldAllowToChangeProjects();
+    nav.openQualityProfile("xoo", "Basic", "test-org")
+      .shouldNotAllowToEdit()
+      .shouldNotAllowToChangeProjects();
+  }
+
+  @Test
   public void testCreation() {
     Selenese.runSelenese(orchestrator, "/organization/OrganizationQualityProfilesUiTest/should_create.html");
   }

--- a/tests/src/test/java/org/sonarqube/tests/qualityProfile/QualityProfilesEditTest.java
+++ b/tests/src/test/java/org/sonarqube/tests/qualityProfile/QualityProfilesEditTest.java
@@ -24,8 +24,8 @@ import java.util.function.Predicate;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.sonarqube.tests.Category6Suite;
 import org.sonarqube.qa.util.Tester;
+import org.sonarqube.tests.Category6Suite;
 import org.sonarqube.ws.Common;
 import org.sonarqube.ws.Organizations.Organization;
 import org.sonarqube.ws.Qualityprofiles.CreateWsResponse;
@@ -213,11 +213,12 @@ public class QualityProfilesEditTest {
       .qProfiles().service().search(new SearchRequest().setOrganizationKey(organization.getKey()));
     assertThat(result.getActions().getCreate()).isFalse();
     assertThat(result.getProfilesList())
-      .extracting(SearchWsResponse.QualityProfile::getKey, qp -> qp.getActions().getEdit(), qp -> qp.getActions().getCopy(), qp -> qp.getActions().getSetAsDefault())
+      .extracting(SearchWsResponse.QualityProfile::getKey, qp -> qp.getActions().getEdit(), qp -> qp.getActions().getCopy(), qp -> qp.getActions().getSetAsDefault(),
+        qp -> qp.getActions().getDelete(), qp -> qp.getActions().getAssociateProjects())
       .contains(
-        tuple(xooProfile1.getKey(), true, false, false),
-        tuple(xooProfile2.getKey(), true, false, false),
-        tuple(xooProfile3.getKey(), false, false, false));
+        tuple(xooProfile1.getKey(), true, false, false, true, true),
+        tuple(xooProfile2.getKey(), true, false, false, true, true),
+        tuple(xooProfile3.getKey(), false, false, false, false, false));
   }
 
   @Test
@@ -231,9 +232,10 @@ public class QualityProfilesEditTest {
       .qProfiles().service().search(new SearchRequest().setOrganizationKey(organization.getKey()));
     assertThat(result.getActions().getCreate()).isTrue();
     assertThat(result.getProfilesList())
-      .extracting(SearchWsResponse.QualityProfile::getKey, qp -> qp.getActions().getEdit(), qp -> qp.getActions().getCopy(), qp -> qp.getActions().getSetAsDefault())
+      .extracting(SearchWsResponse.QualityProfile::getKey, qp -> qp.getActions().getEdit(), qp -> qp.getActions().getCopy(), qp -> qp.getActions().getSetAsDefault(),
+        qp -> qp.getActions().getDelete(), qp -> qp.getActions().getAssociateProjects())
       .contains(
-        tuple(xooProfile.getKey(), true, true, true));
+        tuple(xooProfile.getKey(), true, true, true, true, true));
   }
 
   @Test


### PR DESCRIPTION
In api/qualityprofiles/search, the following actions are now availables :
- delete : Available when not built-it, not default, and have either QP admin permission or have rights to edit
- associateProjects : Available when not default and have either QP admin permission or have rights to edit