### PR TITLE
Update profile name parameter

### DIFF
--- a/server/sonar-web/src/main/js/apps/quality-profiles/details/ProfileExporters.tsx
+++ b/server/sonar-web/src/main/js/apps/quality-profiles/details/ProfileExporters.tsx
@@ -36,7 +36,7 @@ export default class ProfileExporters extends React.PureComponent<Props> {
     const parameters = {
       exporterKey: exporter.key,
       language: profile.language,
-      name: profile.name
+      qualityProfile: profile.name
     };
     if (organization) {
       Object.assign(parameters, { organization });


### PR DESCRIPTION
The name of this parameter was updated in this commit, but was never corrected on the UI: https://github.com/SonarSource/sonarqube/commit/184dbe792ce14f192f75b13507c30a4b697d5852

This was encountered on SonarQube version 6.7