### PR TITLE
SONAR-10215 dont fail in migration 1642 when perm template is missing

### DIFF
--- a/server/sonar-db-migration/src/main/java/org/sonar/server/platform/db/migration/version/v64/SupportPrivateProjectInDefaultPermissionTemplate.java
+++ b/server/sonar-db-migration/src/main/java/org/sonar/server/platform/db/migration/version/v64/SupportPrivateProjectInDefaultPermissionTemplate.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.db.Database;
 import org.sonar.server.platform.db.migration.step.DataChange;
 import org.sonar.server.platform.db.migration.step.Select;
@@ -98,10 +99,12 @@ public class SupportPrivateProjectInDefaultPermissionTemplate extends DataChange
     checkState(rawProperties.defaultGroupId != null, "No default group id is defined for default organization (uuid=%s)", defaultOrganizationUuid);
     checkState(rawProperties.projectUuid != null || rawProperties.viewUuid == null,
       "Inconsistent state for default organization (uuid=%s): no project default template is defined but view default template is", defaultOrganizationUuid);
+    Integer projectTemplateId = getPermTemplateId(context, rawProperties.projectUuid);
+    Integer viewTemplateId = getViewTemplateIdOrClearReference(context, rawProperties.viewUuid, defaultOrganizationUuid);
     return new ResolvedOrganizationProperties(
       rawProperties.defaultGroupId,
-      getPermTemplateId(context, rawProperties.projectUuid),
-      getPermTemplateId(context, rawProperties.viewUuid));
+      projectTemplateId,
+      viewTemplateId);
   }
 
   @CheckForNull
@@ -109,12 +112,40 @@ public class SupportPrivateProjectInDefaultPermissionTemplate extends DataChange
     if (permissionTemplateUuid == null) {
       return null;
     }
-    List<Integer> ids = context.prepareSelect("select id from permission_templates where kee=?")
-      .setString(1, permissionTemplateUuid)
-      .list(row -> row.getInt(1));
+    List<Integer> ids = getTemplateIds(context, permissionTemplateUuid);
     checkState(!ids.isEmpty(), "Permission template with uuid %s not found", permissionTemplateUuid);
     checkState(ids.size() == 1, "Multiple permission templates found with uuid %s", permissionTemplateUuid);
     return ids.iterator().next();
+  }
+
+  @CheckForNull
+  private static Integer getViewTemplateIdOrClearReference(Context context, @Nullable String permissionTemplateUuid,
+    String defaultOrganizationUuid) throws SQLException {
+    if (permissionTemplateUuid == null) {
+      return null;
+    }
+    List<Integer> ids = getTemplateIds(context, permissionTemplateUuid);
+    if (ids.isEmpty()) {
+      clearViewTemplateReference(context, defaultOrganizationUuid);
+      return null;
+    }
+    checkState(ids.size() == 1, "Multiple permission templates found with uuid %s", permissionTemplateUuid);
+    return ids.iterator().next();
+  }
+
+  private static void clearViewTemplateReference(Context context, String defaultOrganizationUuid) throws SQLException {
+    context.prepareUpsert("update organizations set default_perm_template_view = null where uuid=?")
+      .setString(1, defaultOrganizationUuid)
+      .execute()
+      .commit();
+    Loggers.get(SupportPrivateProjectInDefaultPermissionTemplate.class)
+      .info("Permission template with uuid %s referenced as default permission template for view does not exist. Reference cleared.");
+  }
+
+  private static List<Integer> getTemplateIds(Context context, @Nullable String permissionTemplateUuid) throws SQLException {
+    return context.prepareSelect("select id from permission_templates where kee=?")
+      .setString(1, permissionTemplateUuid)
+      .list(row -> row.getInt(1));
   }
 
   private static final class OrganizationProperties {


### PR DESCRIPTION
by not blindling copy the value of property storing the view permission template UUID to the organization table in DB migration 1509