### PR TITLE
Add standard badges

### DIFF
--- a/server/sonar-web/src/main/js/api/web-api.ts
+++ b/server/sonar-web/src/main/js/api/web-api.ts
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { getJSON } from '../helpers/request';
+import throwGlobalError from '../app/utils/throwGlobalError';
 
 export interface Changelog {
   description: string;
@@ -65,16 +66,20 @@ export interface Example {
   format: string;
 }
 
-export function fetchWebApi(showInternal: boolean = true): Promise<Array<Domain>> {
-  return getJSON('/api/webservices/list', { include_internals: showInternal }).then(r =>
-    r.webServices.map((domain: any) => {
-      const deprecated = !domain.actions.find((action: any) => !action.deprecatedSince);
-      const internal = !domain.actions.find((action: any) => !action.internal);
-      return { ...domain, deprecated, internal };
-    })
-  );
+export function fetchWebApi(showInternal = true): Promise<Domain[]> {
+  return getJSON('/api/webservices/list', { include_internals: showInternal })
+    .then(r =>
+      r.webServices.map((domain: any) => {
+        const deprecated = !domain.actions.find((action: any) => !action.deprecatedSince);
+        const internal = !domain.actions.find((action: any) => !action.internal);
+        return { ...domain, deprecated, internal };
+      })
+    )
+    .catch(throwGlobalError);
 }
 
 export function fetchResponseExample(domain: string, action: string): Promise<Example> {
-  return getJSON('/api/webservices/response_example', { controller: domain, action });
+  return getJSON('/api/webservices/response_example', { controller: domain, action }).catch(
+    throwGlobalError
+  );
 }

--- a/server/sonar-web/src/main/js/apps/overview/meta/Meta.js
+++ b/server/sonar-web/src/main/js/apps/overview/meta/Meta.js
@@ -89,7 +89,7 @@ const Meta = ({
 
       {hasOrganization && <MetaOrganizationKey component={component} />}
 
-      {onSonarCloud && <StickersModal />}
+      {onSonarCloud && <StickersModal component={component} />}
     </div>
   );
 };

--- a/server/sonar-web/src/main/js/apps/overview/meta/Meta.js
+++ b/server/sonar-web/src/main/js/apps/overview/meta/Meta.js
@@ -89,7 +89,7 @@ const Meta = ({
 
       {hasOrganization && <MetaOrganizationKey component={component} />}
 
-      {onSonarCloud && <StickersModal component={component} />}
+      {onSonarCloud && <StickersModal branch={branch} component={component} />}
     </div>
   );
 };

--- a/server/sonar-web/src/main/js/apps/overview/meta/Meta.js
+++ b/server/sonar-web/src/main/js/apps/overview/meta/Meta.js
@@ -39,9 +39,10 @@ const Meta = ({
   onComponentChange,
   onSonarCloud
 }) => {
-  const { qualifier, description, qualityProfiles, qualityGate } = component;
+  const { qualifier, description, qualityProfiles, qualityGate, visibility } = component;
 
   const isProject = qualifier === 'TRK';
+  const isPrivate = visibility === 'private';
 
   const hasDescription = !!description;
   const hasQualityProfiles = Array.isArray(qualityProfiles) && qualityProfiles.length > 0;
@@ -89,7 +90,7 @@ const Meta = ({
 
       {hasOrganization && <MetaOrganizationKey component={component} />}
 
-      {onSonarCloud && <StickersModal branch={branch} component={component} />}
+      {onSonarCloud && !isPrivate && <StickersModal branch={branch} component={component} />}
     </div>
   );
 };

--- a/server/sonar-web/src/main/js/apps/overview/meta/Meta.js
+++ b/server/sonar-web/src/main/js/apps/overview/meta/Meta.js
@@ -29,6 +29,7 @@ import MetaSize from './MetaSize';
 import MetaTags from './MetaTags';
 import StickersModal from '../stickers/StickersModal';
 import { areThereCustomOrganizations, getGlobalSettingValue } from '../../../store/rootReducer';
+import { Visibility } from '../../../app/types';
 
 const Meta = ({
   branch,
@@ -42,7 +43,7 @@ const Meta = ({
   const { qualifier, description, qualityProfiles, qualityGate, visibility } = component;
 
   const isProject = qualifier === 'TRK';
-  const isPrivate = visibility === 'private';
+  const isPrivate = visibility === Visibility.Private;
 
   const hasDescription = !!description;
   const hasQualityProfiles = Array.isArray(qualityProfiles) && qualityProfiles.length > 0;
@@ -90,7 +91,7 @@ const Meta = ({
 
       {hasOrganization && <MetaOrganizationKey component={component} />}
 
-      {onSonarCloud && !isPrivate && <StickersModal branch={branch} component={component} />}
+      {onSonarCloud && !isPrivate && <StickersModal branch={branch} component={component.key} />}
     </div>
   );
 };

--- a/server/sonar-web/src/main/js/apps/overview/stickers/StickerParams.tsx
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/StickerParams.tsx
@@ -18,26 +18,88 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import * as React from 'react';
+import { connect } from 'react-redux';
 import Select from '../../../components/controls/Select';
+import { fetchWebApi } from '../../../api/web-api';
+import { Metric } from '../../../app/types';
 import { StickerColors, StickerType, StickerOptions } from './utils';
-import { translate } from '../../../helpers/l10n';
+import { getLocalizedMetricName, translate } from '../../../helpers/l10n';
+import { fetchMetrics } from '../../../store/rootActions';
+import { getMetrics } from '../../../store/rootReducer';
 
-interface Props {
+interface StateToProps {
+  metrics: { [key: string]: Metric };
+}
+
+interface DispatchToProps {
+  fetchMetrics: () => void;
+}
+
+interface OwnProps {
   className?: string;
   options: StickerOptions;
   type: StickerType;
   updateOptions: (options: Partial<StickerOptions>) => void;
 }
 
-export default class StickerParams extends React.PureComponent<Props> {
+type Props = StateToProps & DispatchToProps & OwnProps;
+
+interface State {
+  stickerMetrics: string[];
+}
+
+export class StickerParams extends React.PureComponent<Props> {
+  mounted: boolean;
+  state: State = { stickerMetrics: [] };
+
+  componentDidMount() {
+    this.mounted = true;
+    this.props.fetchMetrics();
+    this.fetchStickerMetrics();
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
+  fetchStickerMetrics() {
+    fetchWebApi(false).then(
+      webservices => {
+        if (this.mounted) {
+          const domain = webservices.find(domain => domain.path === 'api/stickers');
+          const ws = domain && domain.actions.find(ws => ws.key === 'measure');
+          const param = ws && ws.params && ws.params.find(param => param.key === 'metric');
+          if (param && param.possibleValues) {
+            this.setState({ stickerMetrics: param.possibleValues });
+          }
+        }
+      },
+      () => {}
+    );
+  }
+
   getColorOptions = () =>
     ['white', 'black', 'orange'].map(color => ({
       label: translate('overview.stickers.options.colors', color),
       value: color
     }));
 
+  getMetricOptions = () => {
+    const { metrics } = this.props;
+    return this.state.stickerMetrics.map(key => {
+      const metric = metrics[key];
+      return {
+        value: key,
+        label: metric && getLocalizedMetricName(metric)
+      };
+    });
+  };
+
   handleColorChange = ({ value }: { value: StickerColors }) =>
     this.props.updateOptions({ color: value });
+
+  handleMetricChange = ({ value }: { value: string }) =>
+    this.props.updateOptions({ metric: value });
 
   render() {
     const { className, options, type } = this.props;
@@ -59,8 +121,36 @@ export default class StickerParams extends React.PureComponent<Props> {
             />
           </div>
         );
+      case StickerType.measure:
+        return (
+          <div className={className}>
+            <label className="big-spacer-right" htmlFor="sticker-metric">
+              {translate('overview.stickers.metric')}
+            </label>
+            <Select
+              className="input-medium"
+              clearable={false}
+              name="sticker-metric"
+              onChange={this.handleMetricChange}
+              options={this.getMetricOptions()}
+              searchable={false}
+              value={options.metric}
+            />
+          </div>
+        );
       default:
         return null;
     }
   }
 }
+
+const mapDispatchToProps: DispatchToProps = { fetchMetrics };
+
+const mapStateToProps = (state: any): StateToProps => ({
+  metrics: getMetrics(state)
+});
+
+export default connect<StateToProps, DispatchToProps, OwnProps>(
+  mapStateToProps,
+  mapDispatchToProps
+)(StickerParams);

--- a/server/sonar-web/src/main/js/apps/overview/stickers/StickersModal.tsx
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/StickersModal.tsx
@@ -23,13 +23,12 @@ import StickerButton from './StickerButton';
 import StickerSnippet from './StickerSnippet';
 import StickerParams from './StickerParams';
 import { getStickerUrl, StickerType, StickerOptions } from './utils';
-import { Component } from '../../../app/types';
 import { translate } from '../../../helpers/l10n';
 import './styles.css';
 
 interface Props {
   branch: string;
-  component: Component;
+  component: string;
 }
 
 interface State {
@@ -39,29 +38,11 @@ interface State {
 }
 
 export default class StickersModal extends React.PureComponent<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      open: false,
-      selectedType: StickerType.measure,
-      stickerOptions: {
-        branch: props.branch,
-        color: 'white',
-        component: props.component.key,
-        metric: 'alert_status'
-      }
-    };
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    this.setState(state => ({
-      stickerOptions: {
-        ...state.stickerOptions,
-        branch: nextProps.branch,
-        component: nextProps.component.key
-      }
-    }));
-  }
+  state: State = {
+    open: false,
+    selectedType: StickerType.measure,
+    stickerOptions: { color: 'white', metric: 'alert_status' }
+  };
 
   handleClose = () => this.setState({ open: false });
 
@@ -77,9 +58,10 @@ export default class StickersModal extends React.PureComponent<Props, State> {
   handleCancelClick = () => this.handleClose();
 
   render() {
+    const { branch, component } = this.props;
     const { selectedType, stickerOptions } = this.state;
     const header = translate('overview.stickers.title');
-
+    const fullStickerOptions = { branch, component, ...stickerOptions };
     return (
       <>
         <button onClick={this.handleOpen}>{translate('overview.stickers.get_badge')}</button>
@@ -91,24 +73,15 @@ export default class StickersModal extends React.PureComponent<Props, State> {
             <div className="modal-body">
               <p className="huge-spacer-bottom">{translate('overview.stickers.description')}</p>
               <div className="stickers-list spacer-bottom">
-                <StickerButton
-                  onClick={this.handleSelectSticker}
-                  selected={StickerType.measure === selectedType}
-                  type={StickerType.measure}
-                  url={getStickerUrl(StickerType.measure, stickerOptions)}
-                />
-                <StickerButton
-                  onClick={this.handleSelectSticker}
-                  selected={StickerType.qualityGate === selectedType}
-                  type={StickerType.qualityGate}
-                  url={getStickerUrl(StickerType.qualityGate, stickerOptions)}
-                />
-                <StickerButton
-                  onClick={this.handleSelectSticker}
-                  selected={StickerType.marketing === selectedType}
-                  type={StickerType.marketing}
-                  url={getStickerUrl(StickerType.marketing, stickerOptions)}
-                />
+                {[StickerType.measure, StickerType.qualityGate, StickerType.marketing].map(type => (
+                  <StickerButton
+                    key={type}
+                    onClick={this.handleSelectSticker}
+                    selected={type === selectedType}
+                    type={type}
+                    url={getStickerUrl(type, fullStickerOptions)}
+                  />
+                ))}
               </div>
               <p className="text-center note huge-spacer-bottom">
                 {translate('overview.stickers', selectedType, 'description')}
@@ -119,7 +92,7 @@ export default class StickersModal extends React.PureComponent<Props, State> {
                 type={selectedType}
                 updateOptions={this.handleUpdateOptions}
               />
-              <StickerSnippet snippet={getStickerUrl(selectedType, stickerOptions)} />
+              <StickerSnippet snippet={getStickerUrl(selectedType, fullStickerOptions)} />
             </div>
             <footer className="modal-foot">
               <button className="button-link js-modal-close" onClick={this.handleCancelClick}>

--- a/server/sonar-web/src/main/js/apps/overview/stickers/StickersModal.tsx
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/StickersModal.tsx
@@ -28,6 +28,7 @@ import { translate } from '../../../helpers/l10n';
 import './styles.css';
 
 interface Props {
+  branch: string;
   component: Component;
 }
 
@@ -44,6 +45,7 @@ export default class StickersModal extends React.PureComponent<Props, State> {
       open: false,
       selectedType: StickerType.measure,
       stickerOptions: {
+        branch: props.branch,
         color: 'white',
         component: props.component.key,
         metric: 'alert_status'
@@ -53,7 +55,11 @@ export default class StickersModal extends React.PureComponent<Props, State> {
 
   componentWillReceiveProps(nextProps: Props) {
     this.setState(state => ({
-      stickerOptions: { ...state.stickerOptions, component: nextProps.component.key }
+      stickerOptions: {
+        ...state.stickerOptions,
+        branch: nextProps.branch,
+        component: nextProps.component.key
+      }
     }));
   }
 

--- a/server/sonar-web/src/main/js/apps/overview/stickers/StickersModal.tsx
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/StickersModal.tsx
@@ -99,6 +99,12 @@ export default class StickersModal extends React.PureComponent<Props, State> {
                 />
                 <StickerButton
                   onClick={this.handleSelectSticker}
+                  selected={StickerType.qualityGate === selectedType}
+                  type={StickerType.qualityGate}
+                  url={getStickerUrl(StickerType.qualityGate, stickerOptions)}
+                />
+                <StickerButton
+                  onClick={this.handleSelectSticker}
                   selected={StickerType.marketing === selectedType}
                   type={StickerType.marketing}
                   url={getStickerUrl(StickerType.marketing, stickerOptions)}

--- a/server/sonar-web/src/main/js/apps/overview/stickers/StickersModal.tsx
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/StickersModal.tsx
@@ -22,9 +22,14 @@ import Modal from '../../../components/controls/Modal';
 import StickerButton from './StickerButton';
 import StickerSnippet from './StickerSnippet';
 import StickerParams from './StickerParams';
-import { translate } from '../../../helpers/l10n';
 import { getStickerUrl, StickerType, StickerOptions } from './utils';
+import { Component } from '../../../app/types';
+import { translate } from '../../../helpers/l10n';
 import './styles.css';
+
+interface Props {
+  component: Component;
+}
 
 interface State {
   open: boolean;
@@ -32,20 +37,24 @@ interface State {
   stickerOptions: StickerOptions;
 }
 
-export default class StickersModal extends React.PureComponent<{}, State> {
-  mounted: boolean;
-  state: State = {
-    open: false,
-    selectedType: StickerType.marketing,
-    stickerOptions: { color: 'white' }
-  };
-
-  componentDidMount() {
-    this.mounted = true;
+export default class StickersModal extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      open: false,
+      selectedType: StickerType.measure,
+      stickerOptions: {
+        color: 'white',
+        component: props.component.key,
+        metric: 'alert_status'
+      }
+    };
   }
 
-  componentWillUnmount() {
-    this.mounted = false;
+  componentWillReceiveProps(nextProps: Props) {
+    this.setState(state => ({
+      stickerOptions: { ...state.stickerOptions, component: nextProps.component.key }
+    }));
   }
 
   handleClose = () => this.setState({ open: false });
@@ -64,6 +73,7 @@ export default class StickersModal extends React.PureComponent<{}, State> {
   render() {
     const { selectedType, stickerOptions } = this.state;
     const header = translate('overview.stickers.title');
+
     return (
       <>
         <button onClick={this.handleOpen}>{translate('overview.stickers.get_badge')}</button>
@@ -75,6 +85,12 @@ export default class StickersModal extends React.PureComponent<{}, State> {
             <div className="modal-body">
               <p className="huge-spacer-bottom">{translate('overview.stickers.description')}</p>
               <div className="stickers-list spacer-bottom">
+                <StickerButton
+                  onClick={this.handleSelectSticker}
+                  selected={StickerType.measure === selectedType}
+                  type={StickerType.measure}
+                  url={getStickerUrl(StickerType.measure, stickerOptions)}
+                />
                 <StickerButton
                   onClick={this.handleSelectSticker}
                   selected={StickerType.marketing === selectedType}

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/StickerParams-test.tsx
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/StickerParams-test.tsx
@@ -19,8 +19,29 @@
  */
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import StickerParams from '../StickerParams';
+import { StickerParams } from '../StickerParams';
 import { StickerType } from '../utils';
+import { Metric } from '../../../../app/types';
+
+jest.mock('../../../../api/web-api', () => ({
+  fetchWebApi: () =>
+    Promise.resolve([
+      {
+        path: 'api/stickers',
+        actions: [
+          {
+            key: 'measure',
+            params: [{ key: 'metric', possibleValues: ['alert_status', 'coverage'] }]
+          }
+        ]
+      }
+    ])
+}));
+
+const METRICS = {
+  alert_status: { key: 'alert_status', name: 'Quality Gate' } as Metric,
+  coverage: { key: 'coverage', name: 'Coverage' } as Metric
+};
 
 it('should display marketing badge params', () => {
   const updateOptions = jest.fn();
@@ -30,10 +51,20 @@ it('should display marketing badge params', () => {
   expect(updateOptions).toHaveBeenCalledWith({ color: 'black' });
 });
 
+it('should display measure badge params', () => {
+  const updateOptions = jest.fn();
+  const wrapper = getWrapper({ updateOptions, type: StickerType.measure });
+  expect(wrapper).toMatchSnapshot();
+  (wrapper.instance() as StickerParams).handleColorChange({ value: 'black' });
+  expect(updateOptions).toHaveBeenCalledWith({ color: 'black' });
+});
+
 function getWrapper(props = {}) {
   return shallow(
     <StickerParams
-      options={{ color: 'white' }}
+      fetchMetrics={jest.fn()}
+      metrics={METRICS}
+      options={{ color: 'white', metric: 'alert_status' }}
       type={StickerType.marketing}
       updateOptions={jest.fn()}
       {...props}

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/StickersModal-test.tsx
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/StickersModal-test.tsx
@@ -21,16 +21,13 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import StickersModal from '../StickersModal';
 import { click } from '../../../../helpers/testUtils';
-import { Component } from '../../../../app/types';
 
 jest.mock('../../../../helpers/urls', () => ({
   getHostUrl: () => 'host'
 }));
 
 it('should display the modal after click', () => {
-  const wrapper = shallow(
-    <StickersModal branch="branch-6.6" component={{ key: 'foo' } as Component} />
-  );
+  const wrapper = shallow(<StickersModal branch="branch-6.6" component="foo" />);
   expect(wrapper).toMatchSnapshot();
   click(wrapper.find('button'));
   expect(wrapper.find('Modal')).toMatchSnapshot();

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/StickersModal-test.tsx
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/StickersModal-test.tsx
@@ -23,8 +23,14 @@ import StickersModal from '../StickersModal';
 import { click } from '../../../../helpers/testUtils';
 import { Component } from '../../../../app/types';
 
+jest.mock('../../../../helpers/urls', () => ({
+  getHostUrl: () => 'host'
+}));
+
 it('should display the modal after click', () => {
-  const wrapper = shallow(<StickersModal component={{ key: 'foo' } as Component} />);
+  const wrapper = shallow(
+    <StickersModal branch="branch-6.6" component={{ key: 'foo' } as Component} />
+  );
   expect(wrapper).toMatchSnapshot();
   click(wrapper.find('button'));
   expect(wrapper.find('Modal')).toMatchSnapshot();

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/StickersModal-test.tsx
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/StickersModal-test.tsx
@@ -21,9 +21,10 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import StickersModal from '../StickersModal';
 import { click } from '../../../../helpers/testUtils';
+import { Component } from '../../../../app/types';
 
 it('should display the modal after click', () => {
-  const wrapper = shallow(<StickersModal />);
+  const wrapper = shallow(<StickersModal component={{ key: 'foo' } as Component} />);
   expect(wrapper).toMatchSnapshot();
   click(wrapper.find('button'));
   expect(wrapper.find('Modal')).toMatchSnapshot();

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickerParams-test.tsx.snap
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickerParams-test.tsx.snap
@@ -34,3 +34,23 @@ exports[`should display marketing badge params 1`] = `
   />
 </div>
 `;
+
+exports[`should display measure badge params 1`] = `
+<div>
+  <label
+    className="big-spacer-right"
+    htmlFor="sticker-metric"
+  >
+    overview.stickers.metric
+  </label>
+  <Select
+    className="input-medium"
+    clearable={false}
+    name="sticker-metric"
+    onChange={[Function]}
+    options={Array []}
+    searchable={false}
+    value="alert_status"
+  />
+</div>
+`;

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickersModal-test.tsx.snap
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickersModal-test.tsx.snap
@@ -36,6 +36,12 @@ exports[`should display the modal after click 2`] = `
       <StickerButton
         onClick={[Function]}
         selected={true}
+        type="measure"
+        url="null/api/stickers/measure?component=foo&metric=alert_status"
+      />
+      <StickerButton
+        onClick={[Function]}
+        selected={false}
         type="marketing"
         url="null/images/stickers/sonarcloud-white.svg"
       />
@@ -43,20 +49,22 @@ exports[`should display the modal after click 2`] = `
     <p
       className="text-center note huge-spacer-bottom"
     >
-      overview.stickers.marketing.description
+      overview.stickers.measure.description
     </p>
     <StickerParams
       className="big-spacer-bottom"
       options={
         Object {
           "color": "white",
+          "component": "foo",
+          "metric": "alert_status",
         }
       }
-      type="marketing"
+      type="measure"
       updateOptions={[Function]}
     />
     <StickerSnippet
-      snippet="null/images/stickers/sonarcloud-white.svg"
+      snippet="null/api/stickers/measure?component=foo&metric=alert_status"
     />
   </div>
   <footer

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickersModal-test.tsx.snap
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickersModal-test.tsx.snap
@@ -42,6 +42,12 @@ exports[`should display the modal after click 2`] = `
       <StickerButton
         onClick={[Function]}
         selected={false}
+        type="quality_gate"
+        url="host/api/stickers/quality_gate?branch=branch-6.6&component=foo"
+      />
+      <StickerButton
+        onClick={[Function]}
+        selected={false}
         type="marketing"
         url="host/images/stickers/sonarcloud-white.svg"
       />

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickersModal-test.tsx.snap
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickersModal-test.tsx.snap
@@ -37,13 +37,13 @@ exports[`should display the modal after click 2`] = `
         onClick={[Function]}
         selected={true}
         type="measure"
-        url="null/api/stickers/measure?component=foo&metric=alert_status"
+        url="host/api/stickers/measure?branch=branch-6.6&component=foo&metric=alert_status"
       />
       <StickerButton
         onClick={[Function]}
         selected={false}
         type="marketing"
-        url="null/images/stickers/sonarcloud-white.svg"
+        url="host/images/stickers/sonarcloud-white.svg"
       />
     </div>
     <p
@@ -55,6 +55,7 @@ exports[`should display the modal after click 2`] = `
       className="big-spacer-bottom"
       options={
         Object {
+          "branch": "branch-6.6",
           "color": "white",
           "component": "foo",
           "metric": "alert_status",
@@ -64,7 +65,7 @@ exports[`should display the modal after click 2`] = `
       updateOptions={[Function]}
     />
     <StickerSnippet
-      snippet="null/api/stickers/measure?component=foo&metric=alert_status"
+      snippet="host/api/stickers/measure?branch=branch-6.6&component=foo&metric=alert_status"
     />
   </div>
   <footer

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickersModal-test.tsx.snap
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickersModal-test.tsx.snap
@@ -51,7 +51,7 @@ exports[`should display the modal after click 2`] = `
     >
       overview.stickers.measure.description
     </p>
-    <StickerParams
+    <Connect(StickerParams)
       className="big-spacer-bottom"
       options={
         Object {

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickersModal-test.tsx.snap
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/__snapshots__/StickersModal-test.tsx.snap
@@ -34,18 +34,21 @@ exports[`should display the modal after click 2`] = `
       className="stickers-list spacer-bottom"
     >
       <StickerButton
+        key="measure"
         onClick={[Function]}
         selected={true}
         type="measure"
         url="host/api/stickers/measure?branch=branch-6.6&component=foo&metric=alert_status"
       />
       <StickerButton
+        key="quality_gate"
         onClick={[Function]}
         selected={false}
         type="quality_gate"
         url="host/api/stickers/quality_gate?branch=branch-6.6&component=foo"
       />
       <StickerButton
+        key="marketing"
         onClick={[Function]}
         selected={false}
         type="marketing"
@@ -61,9 +64,7 @@ exports[`should display the modal after click 2`] = `
       className="big-spacer-bottom"
       options={
         Object {
-          "branch": "branch-6.6",
           "color": "white",
-          "component": "foo",
           "metric": "alert_status",
         }
       }

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/utils-test.ts
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/utils-test.ts
@@ -24,7 +24,7 @@ jest.mock('../../../../helpers/urls', () => ({
 }));
 
 describe('#getStickerUrl', () => {
-  it('it should generate correct marketing sticker links', () => {
+  it('should generate correct marketing sticker links', () => {
     expect(getStickerUrl(StickerType.marketing, { color: 'white', metric: 'alert_status' })).toBe(
       'host/images/stickers/sonarcloud-white.svg'
     );
@@ -37,13 +37,20 @@ describe('#getStickerUrl', () => {
     ).toBe('host/images/stickers/sonarcloud-orange.svg');
   });
 
-  it('it should generate correct quality gates sticker links', () => {
+  it('should generate correct quality gates sticker links', () => {
     expect(
       getStickerUrl(StickerType.measure, {
+        branch: 'master',
         color: 'white',
         component: 'foo',
         metric: 'alert_status'
       })
-    ).toBe('host/api/stickers/measure?component=foo&metric=alert_status');
+    ).toBe('host/api/stickers/measure?branch=master&component=foo&metric=alert_status');
+  });
+
+  it('should ignore undefined parameters', () => {
+    expect(getStickerUrl(StickerType.measure, { color: 'white', metric: 'alert_status' })).toBe(
+      'host/api/stickers/measure?metric=alert_status'
+    );
   });
 });

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/utils-test.ts
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/utils-test.ts
@@ -17,35 +17,37 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { getStickerUrl, StickerType } from '../utils';
+import { getStickerUrl, StickerOptions, StickerType } from '../utils';
 
 jest.mock('../../../../helpers/urls', () => ({
   getHostUrl: () => 'host'
 }));
 
+const options: StickerOptions = {
+  branch: 'master',
+  color: 'white',
+  component: 'foo',
+  metric: 'alert_status'
+};
+
 describe('#getStickerUrl', () => {
   it('should generate correct marketing sticker links', () => {
-    expect(getStickerUrl(StickerType.marketing, { color: 'white', metric: 'alert_status' })).toBe(
+    expect(getStickerUrl(StickerType.marketing, options)).toBe(
       'host/images/stickers/sonarcloud-white.svg'
     );
-    expect(
-      getStickerUrl(StickerType.marketing, {
-        color: 'orange',
-        component: 'foo',
-        metric: 'alert_status'
-      })
-    ).toBe('host/images/stickers/sonarcloud-orange.svg');
+    expect(getStickerUrl(StickerType.marketing, { ...options, color: 'orange' })).toBe(
+      'host/images/stickers/sonarcloud-orange.svg'
+    );
   });
 
-  it('should generate correct quality gates sticker links', () => {
-    expect(
-      getStickerUrl(StickerType.measure, {
-        branch: 'master',
-        color: 'white',
-        component: 'foo',
-        metric: 'alert_status'
-      })
-    ).toBe('host/api/stickers/measure?branch=master&component=foo&metric=alert_status');
+  it('should generate correct quality gate sticker links', () => {
+    expect(getStickerUrl(StickerType.qualityGate, options));
+  });
+
+  it('should generate correct measures sticker links', () => {
+    expect(getStickerUrl(StickerType.measure, options)).toBe(
+      'host/api/stickers/measure?branch=master&component=foo&metric=alert_status'
+    );
   });
 
   it('should ignore undefined parameters', () => {

--- a/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/utils-test.ts
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/__tests__/utils-test.ts
@@ -25,11 +25,25 @@ jest.mock('../../../../helpers/urls', () => ({
 
 describe('#getStickerUrl', () => {
   it('it should generate correct marketing sticker links', () => {
-    expect(getStickerUrl(StickerType.marketing, { color: 'white' })).toBe(
+    expect(getStickerUrl(StickerType.marketing, { color: 'white', metric: 'alert_status' })).toBe(
       'host/images/stickers/sonarcloud-white.svg'
     );
-    expect(getStickerUrl(StickerType.marketing, { color: 'orange' })).toBe(
-      'host/images/stickers/sonarcloud-orange.svg'
-    );
+    expect(
+      getStickerUrl(StickerType.marketing, {
+        color: 'orange',
+        component: 'foo',
+        metric: 'alert_status'
+      })
+    ).toBe('host/images/stickers/sonarcloud-orange.svg');
+  });
+
+  it('it should generate correct quality gates sticker links', () => {
+    expect(
+      getStickerUrl(StickerType.measure, {
+        color: 'white',
+        component: 'foo',
+        metric: 'alert_status'
+      })
+    ).toBe('host/api/stickers/measure?component=foo&metric=alert_status');
   });
 });

--- a/server/sonar-web/src/main/js/apps/overview/stickers/utils.ts
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/utils.ts
@@ -25,9 +25,9 @@ export type StickerColors = 'white' | 'black' | 'orange';
 
 export interface StickerOptions {
   branch?: string;
-  color: StickerColors;
+  color?: StickerColors;
   component?: string;
-  metric: string;
+  metric?: string;
 }
 
 export enum StickerType {
@@ -42,15 +42,15 @@ export function getStickerUrl(
 ) {
   switch (type) {
     case StickerType.marketing:
-      return `${getHostUrl()}/images/stickers/sonarcloud-${color}.svg`;
+      return `${getHostUrl()}/images/stickers/sonarcloud-${color || 'white'}.svg`;
+    case StickerType.qualityGate:
+      return `${getHostUrl()}/api/stickers/quality_gate?${stringify(
+        omitNil({ branch, component })
+      )}`;
     case StickerType.measure:
+    default:
       return `${getHostUrl()}/api/stickers/measure?${stringify(
-        omitNil({
-          branch,
-          component,
-          metric
-        })
+        omitNil({ branch, component, metric: metric || 'alert_status' })
       )}`;
   }
-  return '';
 }

--- a/server/sonar-web/src/main/js/apps/overview/stickers/utils.ts
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/utils.ts
@@ -17,28 +17,32 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+import { stringify } from 'querystring';
 import { getHostUrl } from '../../../helpers/urls';
 
 export type StickerColors = 'white' | 'black' | 'orange';
 
 export interface StickerOptions {
   color: StickerColors;
+  component?: string;
+  metric: string;
 }
 
 export enum StickerType {
-  badge = 'badge',
-  card = 'card',
-  marketing = 'marketing'
+  marketing = 'marketing',
+  measure = 'measure',
+  qualityGate = 'quality_gate'
 }
 
-export function getStickerUrl(type: StickerType, options: StickerOptions) {
+export function getStickerUrl(type: StickerType, { color, component, metric }: StickerOptions) {
   switch (type) {
     case StickerType.marketing:
-      return `${getHostUrl()}/images/stickers/sonarcloud-${options.color}.svg`;
-    case StickerType.card:
-      return '';
-    case StickerType.badge:
-    default:
-      return '';
+      return `${getHostUrl()}/images/stickers/sonarcloud-${color}.svg`;
+    case StickerType.measure:
+      return `${getHostUrl()}/api/stickers/measure?${stringify({
+        component,
+        metric
+      })}`;
   }
+  return '';
 }

--- a/server/sonar-web/src/main/js/apps/overview/stickers/utils.ts
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/utils.ts
@@ -31,18 +31,18 @@ export interface StickerOptions {
 }
 
 export enum StickerType {
-  marketing = 'marketing',
   measure = 'measure',
-  qualityGate = 'quality_gate'
+  qualityGate = 'quality_gate',
+  marketing = 'marketing'
 }
 
 export function getStickerUrl(
   type: StickerType,
-  { branch, color, component, metric }: StickerOptions
+  { branch, component, color = 'white', metric = 'alert_status' }: StickerOptions
 ) {
   switch (type) {
     case StickerType.marketing:
-      return `${getHostUrl()}/images/stickers/sonarcloud-${color || 'white'}.svg`;
+      return `${getHostUrl()}/images/stickers/sonarcloud-${color}.svg`;
     case StickerType.qualityGate:
       return `${getHostUrl()}/api/stickers/quality_gate?${stringify(
         omitNil({ branch, component })
@@ -50,7 +50,7 @@ export function getStickerUrl(
     case StickerType.measure:
     default:
       return `${getHostUrl()}/api/stickers/measure?${stringify(
-        omitNil({ branch, component, metric: metric || 'alert_status' })
+        omitNil({ branch, component, metric })
       )}`;
   }
 }

--- a/server/sonar-web/src/main/js/apps/overview/stickers/utils.ts
+++ b/server/sonar-web/src/main/js/apps/overview/stickers/utils.ts
@@ -18,11 +18,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { stringify } from 'querystring';
+import { omitNil } from '../../../helpers/request';
 import { getHostUrl } from '../../../helpers/urls';
 
 export type StickerColors = 'white' | 'black' | 'orange';
 
 export interface StickerOptions {
+  branch?: string;
   color: StickerColors;
   component?: string;
   metric: string;
@@ -34,15 +36,21 @@ export enum StickerType {
   qualityGate = 'quality_gate'
 }
 
-export function getStickerUrl(type: StickerType, { color, component, metric }: StickerOptions) {
+export function getStickerUrl(
+  type: StickerType,
+  { branch, color, component, metric }: StickerOptions
+) {
   switch (type) {
     case StickerType.marketing:
       return `${getHostUrl()}/images/stickers/sonarcloud-${color}.svg`;
     case StickerType.measure:
-      return `${getHostUrl()}/api/stickers/measure?${stringify({
-        component,
-        metric
-      })}`;
+      return `${getHostUrl()}/api/stickers/measure?${stringify(
+        omitNil({
+          branch,
+          component,
+          metric
+        })
+      )}`;
   }
   return '';
 }

--- a/server/sonar-web/src/main/js/apps/web-api/components/ResponseExample.tsx
+++ b/server/sonar-web/src/main/js/apps/web-api/components/ResponseExample.tsx
@@ -55,8 +55,9 @@ export default class ResponseExample extends React.PureComponent<Props, State> {
 
   fetchResponseExample() {
     const { domain, action } = this.props;
-    fetchResponseExampleApi(domain.path, action.key).then(responseExample =>
-      this.setState({ responseExample })
+    fetchResponseExampleApi(domain.path, action.key).then(
+      responseExample => this.setState({ responseExample }),
+      () => {}
     );
   }
 

--- a/server/sonar-web/src/main/js/apps/web-api/components/WebApiApp.tsx
+++ b/server/sonar-web/src/main/js/apps/web-api/components/WebApiApp.tsx
@@ -81,12 +81,15 @@ export default class WebApiApp extends React.PureComponent<Props, State> {
     }
   }
 
-  fetchList(cb?: () => void) {
-    fetchWebApi().then(domains => {
-      if (this.mounted) {
-        this.setState({ domains }, cb);
-      }
-    });
+  fetchList() {
+    fetchWebApi().then(
+      domains => {
+        if (this.mounted) {
+          this.setState({ domains });
+        }
+      },
+      () => {}
+    );
   }
 
   scrollToAction = () => {

--- a/sonar-core/src/main/resources/org/sonar/l10n/core.properties
+++ b/sonar-core/src/main/resources/org/sonar/l10n/core.properties
@@ -2330,6 +2330,8 @@ overview.stickers.measure.alt=Standard badge
 overview.stickers.measure.description=This badge dynamically displays the current status of one metric of your project.
 overview.stickers.marketing.alt=Scanned on SonarCloud badge
 overview.stickers.marketing.description=This badge lets you advertise that you're using SonarCloud for code quality
+overview.stickers.quality_gate.alt=SonarCloud Quality Gate badge
+overview.stickers.quality_gate.description=This badge dynamically displays the current quality gate status of your project.
 
 widget.as_calculated_on_x=As calculated on {0}
 

--- a/sonar-core/src/main/resources/org/sonar/l10n/core.properties
+++ b/sonar-core/src/main/resources/org/sonar/l10n/core.properties
@@ -2322,6 +2322,7 @@ overview.deprecated_profile=This quality profile uses {0} deprecated rules and s
 overview.stickers.get_badge=Get project badges
 overview.stickers.title=Badges
 overview.stickers.description=Show the status of your project metrics on your README or website. Pick your style:
+overview.stickers.metric=Metric
 overview.stickers.options.colors.white=White
 overview.stickers.options.colors.black=Black
 overview.stickers.options.colors.orange=Orange

--- a/sonar-core/src/main/resources/org/sonar/l10n/core.properties
+++ b/sonar-core/src/main/resources/org/sonar/l10n/core.properties
@@ -2329,7 +2329,7 @@ overview.stickers.options.colors.orange=Orange
 overview.stickers.measure.alt=Standard badge
 overview.stickers.measure.description=This badge dynamically displays the current status of one metric of your project.
 overview.stickers.marketing.alt=Scanned on SonarCloud badge
-overview.stickers.marketing.description=This badge lets you advertise that you're using SonarCloud for code quality
+overview.stickers.marketing.description=This badge lets you advertise that you're using SonarCloud for code quality.
 overview.stickers.quality_gate.alt=SonarCloud Quality Gate badge
 overview.stickers.quality_gate.description=This badge dynamically displays the current quality gate status of your project.
 

--- a/sonar-core/src/main/resources/org/sonar/l10n/core.properties
+++ b/sonar-core/src/main/resources/org/sonar/l10n/core.properties
@@ -2319,14 +2319,16 @@ overview.complexity_tooltip.file={0} files have complexity around {1}
 
 overview.deprecated_profile=This quality profile uses {0} deprecated rules and should be updated.
 
-overview.stickers.get_badge=Get project badge
+overview.stickers.get_badge=Get project badges
 overview.stickers.title=Badges
-overview.stickers.description=Show the status of your project metrics into your README or websites. Pick your style:
+overview.stickers.description=Show the status of your project metrics on your README or website. Pick your style:
 overview.stickers.options.colors.white=White
 overview.stickers.options.colors.black=Black
 overview.stickers.options.colors.orange=Orange
+overview.stickers.measure.alt=Standard badge
+overview.stickers.measure.description=This badge dynamically displays the current status of one metric of your project.
 overview.stickers.marketing.alt=Scanned on SonarCloud badge
-overview.stickers.marketing.description=This badge helps you advertise that you are using SonarCloud to enhance your code quality.
+overview.stickers.marketing.description=This badge lets you advertise that you're using SonarCloud for code quality
 
 widget.as_calculated_on_x=As calculated on {0}
 


### PR DESCRIPTION
@stas-vilchik Currently the two WS are not yet ready, they are mocks. So when choosing a different metric you wont see the badge change (only the url) and it's the wrong image that is displayed as the second badge.
So if you prefer you can wait a bit until the WS are merged on master and I rebase. Julien is targeting to merge around noon.