### PR TITLE
SONAR-10315 CE task fails when a plugin has been uninstalled after project analysis

### DIFF
--- a/server/sonar-ce/src/main/java/org/sonar/ce/container/CePluginRepository.java
+++ b/server/sonar-ce/src/main/java/org/sonar/ce/container/CePluginRepository.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.io.FileUtils;
 import org.picocontainer.Startable;
 import org.sonar.api.Plugin;
+import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.core.platform.PluginInfo;
 import org.sonar.core.platform.PluginLoader;
@@ -45,6 +46,7 @@ import static java.lang.String.format;
  */
 public class CePluginRepository implements PluginRepository, Startable {
 
+  private static final Logger LOGGER = Loggers.get(CePluginRepository.class);
   private static final String[] JAR_FILE_EXTENSIONS = new String[] {"jar"};
   private static final String NOT_STARTED_YET = "not started yet";
 
@@ -63,12 +65,13 @@ public class CePluginRepository implements PluginRepository, Startable {
 
   @Override
   public void start() {
-    Loggers.get(getClass()).info("Load plugins");
+    LOGGER.info("Load plugins");
     for (File file : listJarFiles(fs.getInstalledPluginsDir())) {
       PluginInfo info = PluginInfo.create(file);
       pluginInfosByKeys.put(info.getKey(), info);
     }
     pluginInstancesByKeys.putAll(loader.load(pluginInfosByKeys));
+    pluginInfosByKeys.values().forEach(p -> LOGGER.info("Loaded plugin {} [{}]", p.getName(), p.getKey()));
     started.set(true);
   }
 

--- a/server/sonar-ce/src/test/java/org/sonar/ce/container/CePluginRepositoryTest.java
+++ b/server/sonar-ce/src/test/java/org/sonar/ce/container/CePluginRepositoryTest.java
@@ -30,6 +30,8 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 import org.sonar.api.Plugin;
+import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.core.platform.PluginInfo;
 import org.sonar.core.platform.PluginLoader;
 import org.sonar.server.platform.ServerFileSystem;
@@ -45,6 +47,9 @@ public class CePluginRepositoryTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
+
+  @Rule
+  public LogTester logTester = new LogTester();
 
   private ServerFileSystem fs = mock(ServerFileSystem.class, Mockito.RETURNS_DEEP_STUBS);
   private PluginLoader pluginLoader = new DumbPluginLoader();
@@ -67,7 +72,7 @@ public class CePluginRepositoryTest {
   }
 
   @Test
-  public void load_plugins() throws Exception {
+  public void load_plugins() {
     String pluginKey = "test";
     when(fs.getInstalledPluginsDir()).thenReturn(new File("src/test/plugins/sonar-test-plugin/target"));
 
@@ -77,6 +82,7 @@ public class CePluginRepositoryTest {
     assertThat(underTest.getPluginInfo(pluginKey).getKey()).isEqualTo(pluginKey);
     assertThat(underTest.getPluginInstance(pluginKey)).isNotNull();
     assertThat(underTest.hasPlugin(pluginKey)).isTrue();
+    assertThat(logTester.logs(LoggerLevel.INFO)).contains("Loaded plugin Test Plugin [test]");
   }
 
   @Test

--- a/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/step/LoadReportAnalysisMetadataHolderStep.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/computation/task/projectanalysis/step/LoadReportAnalysisMetadataHolderStep.java
@@ -29,7 +29,6 @@ import org.apache.commons.lang.StringUtils;
 import org.sonar.api.utils.MessageException;
 import org.sonar.ce.queue.CeTask;
 import org.sonar.core.component.ComponentKeys;
-import org.sonar.core.platform.PluginInfo;
 import org.sonar.core.platform.PluginRepository;
 import org.sonar.core.util.stream.MoreCollectors;
 import org.sonar.db.DbClient;
@@ -129,13 +128,12 @@ public class LoadReportAnalysisMetadataHolderStep implements ComputationStep {
 
   @CheckForNull
   private String getBasePluginKey(Plugin p) {
-    PluginInfo pluginInfo = pluginRepository.getPluginInfo(p.getKey());
-    if (pluginInfo == null) {
+    if (!pluginRepository.hasPlugin(p.getKey())) {
       // May happen if plugin was uninstalled between start of scanner analysis and now.
       // But it doesn't matter since all active rules are removed anyway, so no issues will be reported
       return null;
     }
-    return pluginInfo.getBasePlugin();
+    return pluginRepository.getPluginInfo(p.getKey()).getBasePlugin();
   }
 
   /**

--- a/server/sonar-server/src/main/java/org/sonar/server/plugins/ServerPluginJarExploder.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/plugins/ServerPluginJarExploder.java
@@ -21,7 +21,6 @@ package org.sonar.server.plugins;
 
 import java.io.File;
 import org.apache.commons.io.FileUtils;
-import org.sonar.api.ce.ComputeEngineSide;
 import org.sonar.api.server.ServerSide;
 import org.sonar.api.utils.ZipUtils;
 import org.sonar.core.platform.ExplodedPlugin;
@@ -32,7 +31,6 @@ import org.sonar.server.platform.ServerFileSystem;
 import static org.apache.commons.io.FileUtils.forceMkdir;
 
 @ServerSide
-@ComputeEngineSide
 public class ServerPluginJarExploder extends PluginJarExploder {
 
   private final ServerFileSystem fs;

--- a/sonar-core/src/main/java/org/sonar/core/platform/PluginRepository.java
+++ b/sonar-core/src/main/java/org/sonar/core/platform/PluginRepository.java
@@ -35,6 +35,10 @@ public interface PluginRepository {
 
   Collection<PluginInfo> getPluginInfos();
 
+  /**
+   * Never returns {@code null}, a runtime exception is thrown
+   * if no plugins have the specified key.
+   */
   PluginInfo getPluginInfo(String key);
 
   /**


### PR DESCRIPTION
This pull request does not fix the root problem. Backdating of issues may be incorrect if a plugin is badly considered as uninstalled. However it prevents the task to randomly fail.