### PR TITLE
Clean-up in sonar-server tests

### DIFF
--- a/server/sonar-server/pom.xml
+++ b/server/sonar-server/pom.xml
@@ -176,6 +176,10 @@
           <groupId>com.carrotsearch.randomizedtesting</groupId>
           <artifactId>randomizedtesting-runner</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.elasticsearch</groupId>
+          <artifactId>securemock</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/server/sonar-server/src/test/java/org/sonar/server/app/TomcatConnectorsTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/app/TomcatConnectorsTest.java
@@ -23,10 +23,8 @@ import com.google.common.collect.ImmutableMap;
 import java.net.InetAddress;
 import java.util.Map;
 import java.util.Properties;
-import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
 import org.junit.Test;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.sonar.process.Props;
 
@@ -94,13 +92,7 @@ public class TomcatConnectorsTest {
 
     TomcatConnectors.configure(tomcat, new Props(p));
 
-    verify(tomcat.getService()).addConnector(argThat(new ArgumentMatcher<Connector>() {
-      @Override
-      public boolean matches(Object o) {
-        Connector c = (Connector) o;
-        return c.getScheme().equals("http") && c.getPort() == 9000 && ((InetAddress) c.getProperty("address")).getHostAddress().equals("0.0.0.0");
-      }
-    }));
+    verify(tomcat.getService()).addConnector(argThat(c -> c.getScheme().equals("http") && c.getPort() == 9000 && ((InetAddress) c.getProperty("address")).getHostAddress().equals("0.0.0.0")));
   }
 
   @Test
@@ -111,13 +103,8 @@ public class TomcatConnectorsTest {
 
     TomcatConnectors.configure(tomcat, new Props(p));
 
-    verify(tomcat.getService()).addConnector(argThat(new ArgumentMatcher<Connector>() {
-      @Override
-      public boolean matches(Object o) {
-        Connector c = (Connector) o;
-        return c.getScheme().equals("http") && c.getPort() == 9000 && ((InetAddress) c.getProperty("address")).getHostAddress().equals("1.2.3.4");
-      }
-    }));
+    verify(tomcat.getService())
+      .addConnector(argThat(c -> c.getScheme().equals("http") && c.getPort() == 9000 && ((InetAddress) c.getProperty("address")).getHostAddress().equals("1.2.3.4")));
   }
 
   @Test
@@ -133,36 +120,26 @@ public class TomcatConnectorsTest {
 
     Props props = new Props(properties);
     TomcatConnectors.configure(tomcat, props);
-    verify(tomcat.getService()).addConnector(argThat(new ArgumentMatcher<Connector>() {
-      @Override
-      public boolean matches(Object o) {
-        Connector c = (Connector) o;
-        return c.getMaxPostSize() == -1;
-      }
-    }));
+    verify(tomcat.getService()).addConnector(argThat(c -> c.getMaxPostSize() == -1));
   }
 
-  private void verifyHttpConnector(int expectedPort, Map<String,Object> expectedProps) {
-    verify(tomcat.getService()).addConnector(argThat(new ArgumentMatcher<Connector>() {
-      @Override
-      public boolean matches(Object o) {
-        Connector c = (Connector) o;
-        if (!c.getScheme().equals("http")) {
-          return false;
-        }
-        if (!c.getProtocol().equals(TomcatConnectors.HTTP_PROTOCOL)) {
-          return false;
-        }
-        if (c.getPort() != expectedPort) {
-          return false;
-        }
-        for (Map.Entry<String, Object> expectedProp : expectedProps.entrySet()) {
-          if (!expectedProp.getValue().equals(c.getProperty(expectedProp.getKey()))) {
-            return false;
-          }
-        }
-        return true;
+  private void verifyHttpConnector(int expectedPort, Map<String, Object> expectedProps) {
+    verify(tomcat.getService()).addConnector(argThat(c -> {
+      if (!c.getScheme().equals("http")) {
+        return false;
       }
+      if (!c.getProtocol().equals(TomcatConnectors.HTTP_PROTOCOL)) {
+        return false;
+      }
+      if (c.getPort() != expectedPort) {
+        return false;
+      }
+      for (Map.Entry<String, Object> expectedProp : expectedProps.entrySet()) {
+        if (!expectedProp.getValue().equals(c.getProperty(expectedProp.getKey()))) {
+          return false;
+        }
+      }
+      return true;
     }));
   }
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/ce/ws/CancelActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/ce/ws/CancelActionTest.java
@@ -19,8 +19,6 @@
  */
 package org.sonar.server.ce.ws;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
-
 import javax.annotation.Nullable;
 
 import org.junit.Rule;
@@ -42,6 +40,8 @@ import org.sonar.server.organization.DefaultOrganizationProvider;
 import org.sonar.server.organization.TestDefaultOrganizationProvider;
 import org.sonar.server.tester.UserSessionRule;
 import org.sonar.server.ws.WsActionTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CancelActionTest {
 

--- a/server/sonar-server/src/test/java/org/sonar/server/ce/ws/ComponentActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/ce/ws/ComponentActionTest.java
@@ -45,7 +45,7 @@ import org.sonarqube.ws.Common;
 import org.sonarqube.ws.MediaTypes;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Java6Assertions.tuple;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.sonar.db.ce.CeActivityDto.Status.SUCCESS;
 import static org.sonar.db.ce.CeQueueDto.Status.IN_PROGRESS;
 import static org.sonar.db.ce.CeQueueDto.Status.PENDING;

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/dbcleaner/ProjectCleanerTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/dbcleaner/ProjectCleanerTest.java
@@ -22,25 +22,20 @@ package org.sonar.server.computation.dbcleaner;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.CoreProperties;
-import org.sonar.api.config.Configuration;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.utils.log.Logger;
 import org.sonar.core.config.PurgeConstants;
 import org.sonar.core.config.PurgeProperties;
 import org.sonar.db.DbSession;
 import org.sonar.db.purge.IdUuidPair;
-import org.sonar.db.purge.PurgeConfiguration;
 import org.sonar.db.purge.PurgeDao;
 import org.sonar.db.purge.PurgeListener;
 import org.sonar.db.purge.PurgeProfiler;
 import org.sonar.db.purge.period.DefaultPeriodCleaner;
 
 import static java.util.Collections.emptyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -65,7 +60,7 @@ public class ProjectCleanerTest {
 
     underTest.purge(mock(DbSession.class), mock(IdUuidPair.class), settings.asConfig(), emptyList());
 
-    verify(profiler, never()).dump(anyLong(), any(Logger.class));
+    verify(profiler, never()).dump(anyLong(), any());
   }
 
   @Test
@@ -74,7 +69,7 @@ public class ProjectCleanerTest {
 
     underTest.purge(mock(DbSession.class), mock(IdUuidPair.class), settings.asConfig(), emptyList());
 
-    verify(profiler).dump(anyLong(), any(Logger.class));
+    verify(profiler).dump(anyLong(), any());
   }
 
   @Test
@@ -83,7 +78,7 @@ public class ProjectCleanerTest {
 
     underTest.purge(mock(DbSession.class), mock(IdUuidPair.class), settings.asConfig(), emptyList());
 
-    verify(periodCleaner).clean(any(DbSession.class), anyString(), any(Configuration.class));
-    verify(dao).purge(any(DbSession.class), any(PurgeConfiguration.class), any(PurgeListener.class), any(PurgeProfiler.class));
+    verify(periodCleaner).clean(any(), any(), any());
+    verify(dao).purge(any(), any(), any(), any());
   }
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/queue/ReportSubmitterTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/queue/ReportSubmitterTest.java
@@ -23,8 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,8 +57,8 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -111,8 +109,8 @@ public class ReportSubmitterTest {
 
     mockSuccessfulPrepareSubmitCall();
     ComponentDto project = newPrivateProjectDto(db.getDefaultOrganization(), PROJECT_UUID).setDbKey(PROJECT_KEY);
-    when(componentUpdater.create(any(DbSession.class), any(NewComponent.class), eq(null))).thenReturn(project);
-    when(permissionTemplateService.wouldUserHaveScanPermissionWithDefaultTemplate(any(DbSession.class), eq(defaultOrganizationUuid), anyInt(), eq(PROJECT_KEY),
+    when(componentUpdater.create(any(), any(), any())).thenReturn(project);
+    when(permissionTemplateService.wouldUserHaveScanPermissionWithDefaultTemplate(any(), eq(defaultOrganizationUuid), any(), eq(PROJECT_KEY),
       eq(Qualifiers.PROJECT)))
         .thenReturn(true);
 
@@ -144,18 +142,8 @@ public class ReportSubmitterTest {
     verifyReportIsPersisted(TASK_UUID);
     verifyZeroInteractions(permissionTemplateService);
     verifyZeroInteractions(favoriteUpdater);
-    verify(queue).submit(argThat(new TypeSafeMatcher<CeTaskSubmit>() {
-      @Override
-      protected boolean matchesSafely(CeTaskSubmit submit) {
-        return submit.getType().equals(CeTaskTypes.REPORT) && submit.getComponentUuid().equals(project.uuid()) &&
-          submit.getUuid().equals(TASK_UUID);
-      }
-
-      @Override
-      public void describeTo(Description description) {
-
-      }
-    }));
+    verify(queue).submit(argThat(submit ->
+      submit.getType().equals(CeTaskTypes.REPORT) && submit.getComponentUuid().equals(project.uuid()) && submit.getUuid().equals(TASK_UUID)));
   }
 
   @Test
@@ -167,27 +155,17 @@ public class ReportSubmitterTest {
 
     mockSuccessfulPrepareSubmitCall();
     ComponentDto createdProject = newPrivateProjectDto(organization, PROJECT_UUID).setDbKey(PROJECT_KEY);
-    when(componentUpdater.create(any(DbSession.class), any(NewComponent.class), eq(null))).thenReturn(createdProject);
+    when(componentUpdater.create(any(), any(), isNull())).thenReturn(createdProject);
     when(
-      permissionTemplateService.wouldUserHaveScanPermissionWithDefaultTemplate(any(DbSession.class), eq(organization.getUuid()), anyInt(), eq(PROJECT_KEY), eq(Qualifiers.PROJECT)))
+      permissionTemplateService.wouldUserHaveScanPermissionWithDefaultTemplate(any(), eq(organization.getUuid()), any(), eq(PROJECT_KEY), eq(Qualifiers.PROJECT)))
         .thenReturn(true);
-    when(permissionTemplateService.hasDefaultTemplateWithPermissionOnProjectCreator(any(DbSession.class), eq(organization.getUuid()), any(ComponentDto.class))).thenReturn(true);
+    when(permissionTemplateService.hasDefaultTemplateWithPermissionOnProjectCreator(any(), eq(organization.getUuid()), any())).thenReturn(true);
 
     underTest.submit(organization.getKey(), PROJECT_KEY, null, PROJECT_NAME, IOUtils.toInputStream("{binary}"));
 
     verifyReportIsPersisted(TASK_UUID);
-    verify(queue).submit(argThat(new TypeSafeMatcher<CeTaskSubmit>() {
-      @Override
-      protected boolean matchesSafely(CeTaskSubmit submit) {
-        return submit.getType().equals(CeTaskTypes.REPORT) && submit.getComponentUuid().equals(PROJECT_UUID) &&
-          submit.getUuid().equals(TASK_UUID);
-      }
-
-      @Override
-      public void describeTo(Description description) {
-
-      }
-    }));
+    verify(queue).submit(argThat(submit ->
+      submit.getType().equals(CeTaskTypes.REPORT) && submit.getComponentUuid().equals(PROJECT_UUID) && submit.getUuid().equals(TASK_UUID)));
   }
 
   @Test
@@ -198,11 +176,11 @@ public class ReportSubmitterTest {
 
     mockSuccessfulPrepareSubmitCall();
     ComponentDto createdProject = newPrivateProjectDto(db.getDefaultOrganization(), PROJECT_UUID).setDbKey(PROJECT_KEY);
-    when(componentUpdater.create(any(DbSession.class), any(NewComponent.class), eq(null))).thenReturn(createdProject);
-    when(permissionTemplateService.wouldUserHaveScanPermissionWithDefaultTemplate(any(DbSession.class), eq(defaultOrganizationUuid), anyInt(),
+    when(componentUpdater.create(any(), any(), isNull())).thenReturn(createdProject);
+    when(permissionTemplateService.wouldUserHaveScanPermissionWithDefaultTemplate(any(), eq(defaultOrganizationUuid), any(),
       eq(PROJECT_KEY), eq(Qualifiers.PROJECT)))
         .thenReturn(true);
-    when(permissionTemplateService.hasDefaultTemplateWithPermissionOnProjectCreator(any(DbSession.class), eq(defaultOrganizationUuid), any(ComponentDto.class))).thenReturn(false);
+    when(permissionTemplateService.hasDefaultTemplateWithPermissionOnProjectCreator(any(), eq(defaultOrganizationUuid), any())).thenReturn(false);
 
     underTest.submit(defaultOrganizationKey, PROJECT_KEY, null, PROJECT_NAME, IOUtils.toInputStream("{binary}"));
 
@@ -217,8 +195,8 @@ public class ReportSubmitterTest {
 
     mockSuccessfulPrepareSubmitCall();
     ComponentDto project = newPrivateProjectDto(db.getDefaultOrganization(), PROJECT_UUID).setDbKey(PROJECT_KEY);
-    when(componentUpdater.create(any(DbSession.class), any(NewComponent.class), eq(null))).thenReturn(project);
-    when(permissionTemplateService.wouldUserHaveScanPermissionWithDefaultTemplate(any(DbSession.class), eq(defaultOrganizationUuid), anyInt(),
+    when(componentUpdater.create(any(), any(), any())).thenReturn(project);
+    when(permissionTemplateService.wouldUserHaveScanPermissionWithDefaultTemplate(any(), eq(defaultOrganizationUuid), any(),
       eq(PROJECT_KEY), eq(Qualifiers.PROJECT)))
         .thenReturn(true);
 

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/duplication/ReportDuplicationMeasuresTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/duplication/ReportDuplicationMeasuresTest.java
@@ -19,6 +19,12 @@
  */
 package org.sonar.server.computation.task.projectanalysis.duplication;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.server.computation.task.projectanalysis.component.TreeRootHolderRule;
+import org.sonar.server.computation.task.projectanalysis.measure.MeasureRepositoryRule;
+import org.sonar.server.computation.task.projectanalysis.metric.MetricRepositoryRule;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.guava.api.Assertions.assertThat;
@@ -42,12 +48,6 @@ import static org.sonar.server.computation.task.projectanalysis.component.Compon
 import static org.sonar.server.computation.task.projectanalysis.component.Component.Type.PROJECT;
 import static org.sonar.server.computation.task.projectanalysis.component.ReportComponent.builder;
 import static org.sonar.server.computation.task.projectanalysis.measure.Measure.newMeasureBuilder;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.sonar.server.computation.task.projectanalysis.component.TreeRootHolderRule;
-import org.sonar.server.computation.task.projectanalysis.measure.MeasureRepositoryRule;
-import org.sonar.server.computation.task.projectanalysis.metric.MetricRepositoryRule;
 
 public class ReportDuplicationMeasuresTest {
   private static final int ROOT_REF = 1;
@@ -97,7 +97,7 @@ public class ReportDuplicationMeasuresTest {
   @Rule
   public DuplicationRepositoryRule duplicationRepository = DuplicationRepositoryRule.create(treeRootHolder);
 
-  DuplicationMeasures underTest = new DuplicationMeasures(treeRootHolder, metricRepository, measureRepository, duplicationRepository);
+  private DuplicationMeasures underTest = new DuplicationMeasures(treeRootHolder, metricRepository, measureRepository, duplicationRepository);
 
   @Test
   public void compute_duplicated_blocks_one_for_original_one_for_each_InnerDuplicate() {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/duplication/ViewsDuplicationMeasuresTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/duplication/ViewsDuplicationMeasuresTest.java
@@ -19,6 +19,12 @@
  */
 package org.sonar.server.computation.task.projectanalysis.duplication;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.server.computation.task.projectanalysis.component.TreeRootHolderRule;
+import org.sonar.server.computation.task.projectanalysis.measure.MeasureRepositoryRule;
+import org.sonar.server.computation.task.projectanalysis.metric.MetricRepositoryRule;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.guava.api.Assertions.assertThat;
 import static org.sonar.api.measures.CoreMetrics.COMMENT_LINES;
@@ -40,12 +46,6 @@ import static org.sonar.server.computation.task.projectanalysis.component.Compon
 import static org.sonar.server.computation.task.projectanalysis.component.Component.Type.VIEW;
 import static org.sonar.server.computation.task.projectanalysis.component.ViewsComponent.builder;
 import static org.sonar.server.computation.task.projectanalysis.measure.Measure.newMeasureBuilder;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.sonar.server.computation.task.projectanalysis.component.TreeRootHolderRule;
-import org.sonar.server.computation.task.projectanalysis.measure.MeasureRepositoryRule;
-import org.sonar.server.computation.task.projectanalysis.metric.MetricRepositoryRule;
 
 public class ViewsDuplicationMeasuresTest {
 
@@ -82,7 +82,7 @@ public class ViewsDuplicationMeasuresTest {
   @Rule
   public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
 
-  DuplicationMeasures underTest = new DuplicationMeasures(treeRootHolder, metricRepository, measureRepository);
+  private DuplicationMeasures underTest = new DuplicationMeasures(treeRootHolder, metricRepository, measureRepository);
 
   @Test
   public void aggregate_duplicated_blocks() {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/qualitygate/QualityGateServiceImplTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/qualitygate/QualityGateServiceImplTest.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.db.DbClient;
-import org.sonar.db.DbSession;
 import org.sonar.db.qualitygate.QualityGateConditionDao;
 import org.sonar.db.qualitygate.QualityGateConditionDto;
 import org.sonar.db.qualitygate.QualityGateDao;
@@ -77,8 +76,8 @@ public class QualityGateServiceImplTest {
 
   @Test
   public void findById_returns_QualityGate_with_empty_set_of_conditions_when_there_is_none_in_DB() {
-    when(qualityGateDao.selectById(any(DbSession.class), eq(SOME_ID))).thenReturn(QUALITY_GATE_DTO);
-    when(qualityGateConditionDao.selectForQualityGate(any(DbSession.class), eq(SOME_ID))).thenReturn(Collections.emptyList());
+    when(qualityGateDao.selectById(any(), eq(SOME_ID))).thenReturn(QUALITY_GATE_DTO);
+    when(qualityGateConditionDao.selectForQualityGate(any(), eq(SOME_ID))).thenReturn(Collections.emptyList());
 
     Optional<QualityGate> res = underTest.findById(SOME_ID);
 
@@ -90,8 +89,8 @@ public class QualityGateServiceImplTest {
 
   @Test
   public void findById_returns_conditions_when_there_is_some_in_DB() {
-    when(qualityGateDao.selectById(any(DbSession.class), eq(SOME_ID))).thenReturn(QUALITY_GATE_DTO);
-    when(qualityGateConditionDao.selectForQualityGate(any(DbSession.class), eq(SOME_ID))).thenReturn(ImmutableList.of(CONDITION_1, CONDITION_2));
+    when(qualityGateDao.selectById(any(), eq(SOME_ID))).thenReturn(QUALITY_GATE_DTO);
+    when(qualityGateConditionDao.selectForQualityGate(any(), eq(SOME_ID))).thenReturn(ImmutableList.of(CONDITION_1, CONDITION_2));
     // metrics are always supposed to be there
     when(metricRepository.getOptionalById(METRIC_ID_1)).thenReturn(Optional.of(METRIC_1));
     when(metricRepository.getOptionalById(METRIC_ID_2)).thenReturn(Optional.of(METRIC_2));
@@ -108,8 +107,8 @@ public class QualityGateServiceImplTest {
 
   @Test
   public void findById_ignores_conditions_on_missing_metrics() {
-    when(qualityGateDao.selectById(any(DbSession.class), eq(SOME_ID))).thenReturn(QUALITY_GATE_DTO);
-    when(qualityGateConditionDao.selectForQualityGate(any(DbSession.class), eq(SOME_ID))).thenReturn(ImmutableList.of(CONDITION_1, CONDITION_2));
+    when(qualityGateDao.selectById(any(), eq(SOME_ID))).thenReturn(QUALITY_GATE_DTO);
+    when(qualityGateConditionDao.selectForQualityGate(any(), eq(SOME_ID))).thenReturn(ImmutableList.of(CONDITION_1, CONDITION_2));
     // metrics are always supposed to be there
     when(metricRepository.getOptionalById(METRIC_ID_1)).thenReturn(Optional.empty());
     when(metricRepository.getOptionalById(METRIC_ID_2)).thenReturn(Optional.of(METRIC_2));

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/HighlightingLineReaderTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/HighlightingLineReaderTest.java
@@ -54,28 +54,28 @@ public class HighlightingLineReaderTest {
   @Rule
   public LogTester logTester = new LogTester();
 
-  static final Component FILE = builder(Component.Type.FILE, 1).setUuid("FILE_UUID").setKey("FILE_KEY").build();
+  private static final Component FILE = builder(Component.Type.FILE, 1).setUuid("FILE_UUID").setKey("FILE_KEY").build();
 
-  static final int DEFAULT_LINE_LENGTH = 5;
+  private static final int DEFAULT_LINE_LENGTH = 5;
 
-  static final int LINE_1 = 1;
-  static final int LINE_2 = 2;
-  static final int LINE_3 = 3;
-  static final int LINE_4 = 4;
+  private static final int LINE_1 = 1;
+  private static final int LINE_2 = 2;
+  private static final int LINE_3 = 3;
+  private static final int LINE_4 = 4;
 
-  static final String RANGE_LABEL_1 = "1,2";
-  static final String RANGE_LABEL_2 = "2,3";
-  static final String RANGE_LABEL_3 = "3,4";
-  static final String RANGE_LABEL_4 = "0,2";
-  static final String RANGE_LABEL_5 = "0,3";
+  private static final String RANGE_LABEL_1 = "1,2";
+  private static final String RANGE_LABEL_2 = "2,3";
+  private static final String RANGE_LABEL_3 = "3,4";
+  private static final String RANGE_LABEL_4 = "0,2";
+  private static final String RANGE_LABEL_5 = "0,3";
 
-  RangeOffsetConverter rangeOffsetConverter = mock(RangeOffsetConverter.class);
+  private RangeOffsetConverter rangeOffsetConverter = mock(RangeOffsetConverter.class);
 
-  DbFileSources.Data.Builder sourceData = newBuilder();
-  DbFileSources.Line.Builder line1 = sourceData.addLinesBuilder().setSource("line1").setLine(1);
-  DbFileSources.Line.Builder line2 = sourceData.addLinesBuilder().setSource("line2").setLine(2);
-  DbFileSources.Line.Builder line3 = sourceData.addLinesBuilder().setSource("line3").setLine(3);
-  DbFileSources.Line.Builder line4 = sourceData.addLinesBuilder().setSource("line4").setLine(4);
+  private DbFileSources.Data.Builder sourceData = newBuilder();
+  private DbFileSources.Line.Builder line1 = sourceData.addLinesBuilder().setSource("line1").setLine(1);
+  private DbFileSources.Line.Builder line2 = sourceData.addLinesBuilder().setSource("line2").setLine(2);
+  private DbFileSources.Line.Builder line3 = sourceData.addLinesBuilder().setSource("line3").setLine(3);
+  private DbFileSources.Line.Builder line4 = sourceData.addLinesBuilder().setSource("line4").setLine(4);
 
   @Test
   public void nothing_to_read() {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/LastCommitVisitorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/LastCommitVisitorTest.java
@@ -25,7 +25,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.server.computation.task.projectanalysis.component.Component;
-import org.sonar.server.computation.task.projectanalysis.component.ComponentVisitor;
 import org.sonar.server.computation.task.projectanalysis.component.FileAttributes;
 import org.sonar.server.computation.task.projectanalysis.component.ReportComponent;
 import org.sonar.server.computation.task.projectanalysis.component.TreeRootHolderRule;
@@ -51,13 +50,13 @@ import static org.sonar.server.computation.task.projectanalysis.measure.Measure.
 
 public class LastCommitVisitorTest {
 
-  public static final int PROJECT_REF = 1;
-  public static final int MODULE_REF = 2;
-  public static final int FILE_1_REF = 1_111;
-  public static final int FILE_2_REF = 1_112;
-  public static final int FILE_3_REF = 1_121;
-  public static final int DIR_1_REF = 3;
-  public static final int DIR_2_REF = 4;
+  private static final int PROJECT_REF = 1;
+  private static final int MODULE_REF = 2;
+  private static final int FILE_1_REF = 1_111;
+  private static final int FILE_2_REF = 1_112;
+  private static final int FILE_3_REF = 1_121;
+  private static final int DIR_1_REF = 3;
+  private static final int DIR_2_REF = 4;
 
   @Rule
   public TreeRootHolderRule treeRootHolder = new TreeRootHolderRule();
@@ -202,8 +201,7 @@ public class LastCommitVisitorTest {
         .setAuthor("john")
         .setDate(1_500_000_000_000L)
         .setRevision("rev-1")
-        .build()
-      );
+        .build());
 
     ReportComponent file = createFileComponent(FILE_1_REF);
     treeRootHolder.setRoot(file);

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/ReportIteratorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/ReportIteratorTest.java
@@ -38,9 +38,8 @@ public class ReportIteratorTest {
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
-  File file;
-
-  ReportIterator<ScannerReport.LineCoverage> underTest;
+  private File file;
+  private ReportIterator<ScannerReport.LineCoverage> underTest;
 
   @Before
   public void setUp() throws Exception {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/ScmLineReaderTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/ScmLineReaderTest.java
@@ -37,7 +37,7 @@ public class ScmLineReaderTest {
     ScmInfo scmInfo = new ScmInfoImpl(newArrayList(
       Changeset.newChangesetBuilder()
         .setAuthor("john")
-        .setDate(123456789L)
+        .setDate(123_456_789L)
         .setRevision("rev-1")
         .build()
       ));
@@ -48,7 +48,7 @@ public class ScmLineReaderTest {
     lineScm.read(lineBuilder);
 
     assertThat(lineBuilder.getScmAuthor()).isEqualTo("john");
-    assertThat(lineBuilder.getScmDate()).isEqualTo(123456789L);
+    assertThat(lineBuilder.getScmDate()).isEqualTo(123_456_789L);
     assertThat(lineBuilder.getScmRevision()).isEqualTo("rev-1");
   }
 
@@ -56,7 +56,7 @@ public class ScmLineReaderTest {
   public void set_scm_with_minim_fields() {
     ScmInfo scmInfo = new ScmInfoImpl(newArrayList(
       Changeset.newChangesetBuilder()
-        .setDate(123456789L)
+        .setDate(123_456_789L)
         .setRevision("rev-1")
         .build()
       ));
@@ -73,7 +73,7 @@ public class ScmLineReaderTest {
 
   @Test
   public void getLatestChange_returns_changeset_with_highest_date_of_read_lines() {
-    long refDate = 123456789L;
+    long refDate = 123_456_789L;
     Changeset changeset0 = Changeset.newChangesetBuilder().setDate(refDate - 636).setRevision("rev-1").build();
     Changeset changeset1 = Changeset.newChangesetBuilder().setDate(refDate + 1).setRevision("rev-2").build();
     Changeset changeset2 = Changeset.newChangesetBuilder().setDate(refDate + 2).setRevision("rev-3").build();

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/SourceLinesRepositoryImplTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/SourceLinesRepositoryImplTest.java
@@ -32,9 +32,9 @@ import static org.sonar.server.computation.task.projectanalysis.component.Report
 
 public class SourceLinesRepositoryImplTest {
 
-  static final String FILE_UUID = "FILE_UUID";
-  static final String FILE_KEY = "FILE_KEY";
-  static final int FILE_REF = 2;
+  private static final String FILE_UUID = "FILE_UUID";
+  private static final String FILE_KEY = "FILE_KEY";
+  private static final int FILE_REF = 2;
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -42,7 +42,7 @@ public class SourceLinesRepositoryImplTest {
   @Rule
   public BatchReportReaderRule reportReader = new BatchReportReaderRule();
 
-  SourceLinesRepositoryImpl underTest = new SourceLinesRepositoryImpl(reportReader);
+  private SourceLinesRepositoryImpl underTest = new SourceLinesRepositoryImpl(reportReader);
 
   @Test
   public void read_lines_from_report() {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/SymbolsLineReaderTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/source/SymbolsLineReaderTest.java
@@ -40,33 +40,33 @@ public class SymbolsLineReaderTest {
   @Rule
   public LogTester logTester = new LogTester();
 
-  static final Component FILE = builder(Component.Type.FILE, 1).setUuid("FILE_UUID").setKey("FILE_KEY").build();
+  private static final Component FILE = builder(Component.Type.FILE, 1).setUuid("FILE_UUID").setKey("FILE_KEY").build();
 
-  static final int DEFAULT_LINE_LENGTH = 5;
+  private static final int DEFAULT_LINE_LENGTH = 5;
 
-  static final int LINE_1 = 1;
-  static final int LINE_2 = 2;
-  static final int LINE_3 = 3;
-  static final int LINE_4 = 4;
+  private static final int LINE_1 = 1;
+  private static final int LINE_2 = 2;
+  private static final int LINE_3 = 3;
+  private static final int LINE_4 = 4;
 
-  static final int OFFSET_0 = 0;
-  static final int OFFSET_1 = 1;
-  static final int OFFSET_2 = 2;
-  static final int OFFSET_3 = 3;
-  static final int OFFSET_4 = 4;
+  private static final int OFFSET_0 = 0;
+  private static final int OFFSET_1 = 1;
+  private static final int OFFSET_2 = 2;
+  private static final int OFFSET_3 = 3;
+  private static final int OFFSET_4 = 4;
 
-  static final String RANGE_LABEL_1 = "1,2";
-  static final String RANGE_LABEL_2 = "2,3";
-  static final String RANGE_LABEL_3 = "3,4";
-  static final String RANGE_LABEL_4 = "0,2";
+  private static final String RANGE_LABEL_1 = "1,2";
+  private static final String RANGE_LABEL_2 = "2,3";
+  private static final String RANGE_LABEL_3 = "3,4";
+  private static final String RANGE_LABEL_4 = "0,2";
 
-  RangeOffsetConverter rangeOffsetConverter = mock(RangeOffsetConverter.class);
+  private RangeOffsetConverter rangeOffsetConverter = mock(RangeOffsetConverter.class);
 
-  DbFileSources.Data.Builder sourceData = DbFileSources.Data.newBuilder();
-  DbFileSources.Line.Builder line1 = sourceData.addLinesBuilder().setSource("line1").setLine(1);
-  DbFileSources.Line.Builder line2 = sourceData.addLinesBuilder().setSource("line2").setLine(2);
-  DbFileSources.Line.Builder line3 = sourceData.addLinesBuilder().setSource("line3").setLine(3);
-  DbFileSources.Line.Builder line4 = sourceData.addLinesBuilder().setSource("line4").setLine(4);
+  private DbFileSources.Data.Builder sourceData = DbFileSources.Data.newBuilder();
+  private DbFileSources.Line.Builder line1 = sourceData.addLinesBuilder().setSource("line1").setLine(1);
+  private DbFileSources.Line.Builder line2 = sourceData.addLinesBuilder().setSource("line2").setLine(2);
+  private DbFileSources.Line.Builder line3 = sourceData.addLinesBuilder().setSource("line3").setLine(3);
+  private DbFileSources.Line.Builder line4 = sourceData.addLinesBuilder().setSource("line4").setLine(4);
 
   @Test
   public void read_nothing() {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/BuildComponentTreeStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/BuildComponentTreeStepTest.java
@@ -68,22 +68,22 @@ import static org.sonar.scanner.protocol.output.ScannerReport.Component.Componen
 @RunWith(DataProviderRunner.class)
 public class BuildComponentTreeStepTest {
 
-  static final int ROOT_REF = 1;
-  static final int MODULE_REF = 2;
-  static final int DIR_REF_1 = 3;
-  static final int FILE_1_REF = 4;
-  static final int FILE_2_REF = 5;
-  static final int DIR_REF_2 = 6;
-  static final int FILE_3_REF = 7;
+  private static final int ROOT_REF = 1;
+  private static final int MODULE_REF = 2;
+  private static final int DIR_REF_1 = 3;
+  private static final int FILE_1_REF = 4;
+  private static final int FILE_2_REF = 5;
+  private static final int DIR_REF_2 = 6;
+  private static final int FILE_3_REF = 7;
 
-  static final String REPORT_PROJECT_KEY = "REPORT_PROJECT_KEY";
-  static final String REPORT_MODULE_KEY = "MODULE_KEY";
-  static final String REPORT_DIR_KEY_1 = "src/main/java/dir1";
-  static final String REPORT_FILE_KEY_1 = "src/main/java/dir1/File1.java";
-  static final String REPORT_DIR_KEY_2 = "src/main/java/dir2";
-  static final String REPORT_FILE_KEY_2 = "src/main/java/dir2/File2.java";
+  private static final String REPORT_PROJECT_KEY = "REPORT_PROJECT_KEY";
+  private static final String REPORT_MODULE_KEY = "MODULE_KEY";
+  private static final String REPORT_DIR_KEY_1 = "src/main/java/dir1";
+  private static final String REPORT_FILE_KEY_1 = "src/main/java/dir1/File1.java";
+  private static final String REPORT_DIR_KEY_2 = "src/main/java/dir2";
+  private static final String REPORT_FILE_KEY_2 = "src/main/java/dir2/File2.java";
 
-  static final long ANALYSIS_DATE = 123456789L;
+  private static final long ANALYSIS_DATE = 123456789L;
 
   @Rule
   public DbTester dbTester = DbTester.create(System2.INSTANCE);

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/BuildComponentTreeStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/BuildComponentTreeStepTest.java
@@ -207,7 +207,7 @@ public class BuildComponentTreeStepTest {
     when(branch.getName()).thenReturn("origin/feature");
     when(branch.isMain()).thenReturn(false);
     when(branch.isLegacyFeature()).thenReturn(false);
-    when(branch.generateKey(any(ScannerReport.Component.class), any(ScannerReport.Component.class))).thenReturn("generated");
+    when(branch.generateKey(any(), any())).thenReturn("generated");
     analysisMetadataHolder.setRootComponentRef(ROOT_REF)
       .setAnalysisDate(ANALYSIS_DATE)
       .setProject(new Project("U1", REPORT_PROJECT_KEY, REPORT_PROJECT_KEY))

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/ComputeQProfileMeasureStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/ComputeQProfileMeasureStepTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,7 +31,6 @@ import org.sonar.server.computation.task.projectanalysis.component.Component;
 import org.sonar.server.computation.task.projectanalysis.component.FileAttributes;
 import org.sonar.server.computation.task.projectanalysis.component.ReportComponent;
 import org.sonar.server.computation.task.projectanalysis.component.TreeRootHolderRule;
-import org.sonar.server.computation.task.projectanalysis.measure.Measure;
 import org.sonar.server.computation.task.projectanalysis.measure.MeasureRepositoryRule;
 import org.sonar.server.computation.task.projectanalysis.metric.MetricRepositoryRule;
 import org.sonar.server.qualityprofile.QPMeasureData;
@@ -47,7 +45,6 @@ import static org.sonar.server.computation.task.projectanalysis.component.Compon
 import static org.sonar.server.computation.task.projectanalysis.component.Component.Type.FILE;
 import static org.sonar.server.computation.task.projectanalysis.component.Component.Type.MODULE;
 import static org.sonar.server.computation.task.projectanalysis.component.Component.Type.PROJECT;
-import static org.sonar.server.computation.task.projectanalysis.measure.Measure.newMeasureBuilder;
 
 public class ComputeQProfileMeasureStepTest {
 
@@ -101,12 +98,7 @@ public class ComputeQProfileMeasureStepTest {
   @Rule
   public AnalysisMetadataHolderRule analysisMetadataHolder = new AnalysisMetadataHolderRule();
 
-  ComputeQProfileMeasureStep underTest;
-
-  @Before
-  public void setUp() throws Exception {
-    underTest = new ComputeQProfileMeasureStep(treeRootHolder, measureRepository, metricRepository, analysisMetadataHolder);
-  }
+  private ComputeQProfileMeasureStep underTest = new ComputeQProfileMeasureStep(treeRootHolder, measureRepository, metricRepository, analysisMetadataHolder);
 
   @Test
   public void add_quality_profile_measure_on_project() {
@@ -132,7 +124,7 @@ public class ComputeQProfileMeasureStepTest {
   }
 
   @Test
-  public void fail_if_report_inconsistant() {
+  public void fail_if_report_inconsistent() {
     treeRootHolder.setRoot(MULTI_MODULE_PROJECT);
     QualityProfile qpJava = createQProfile(QP_NAME_1, LANGUAGE_KEY_1);
     analysisMetadataHolder.setQProfilesByLanguage(ImmutableMap.of(LANGUAGE_KEY_1, qpJava));
@@ -148,11 +140,6 @@ public class ComputeQProfileMeasureStepTest {
 
   private static QualityProfile createQProfile(String qpName, String languageKey) {
     return new QualityProfile(qpName + "-" + languageKey, qpName, languageKey, new Date());
-  }
-
-  private void addMeasure(int componentRef, QualityProfile... qps) {
-    Measure qualityProfileMeasure = newMeasureBuilder().create(toJson(qps));
-    measureRepository.addRawMeasure(componentRef, QUALITY_PROFILES_KEY, qualityProfileMeasure);
   }
 
   private static String toJson(QualityProfile... qps) {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/DuplicationDataMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/DuplicationDataMeasuresStepTest.java
@@ -68,7 +68,7 @@ public class DuplicationDataMeasuresStepTest extends BaseStepTest {
   @Rule
   public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
 
-  DuplicationDataMeasuresStep underTest = new DuplicationDataMeasuresStep(treeRootHolder, metricRepository, measureRepository, duplicationRepository);
+  private DuplicationDataMeasuresStep underTest = new DuplicationDataMeasuresStep(treeRootHolder, metricRepository, measureRepository, duplicationRepository);
 
   @Override
   protected ComputationStep step() {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/DuplicationMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/DuplicationMeasuresStepTest.java
@@ -19,27 +19,18 @@
  */
 package org.sonar.server.computation.task.projectanalysis.step;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.sonar.server.computation.task.projectanalysis.duplication.DuplicationMeasures;
 import org.sonar.server.computation.task.step.ComputationStep;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class DuplicationMeasuresStepTest extends BaseStepTest {
-  @Mock
-  private DuplicationMeasures defaultDuplicationMeasures;
 
-  private DuplicationMeasuresStep underTest;
-
-  @Before
-  public void before() {
-    MockitoAnnotations.initMocks(this);
-    underTest = new DuplicationMeasuresStep(defaultDuplicationMeasures);
-  }
-
+  private DuplicationMeasures defaultDuplicationMeasures = mock(DuplicationMeasures.class);
+  private DuplicationMeasuresStep underTest = new DuplicationMeasuresStep(defaultDuplicationMeasures);
+  
   @Test
   public void full_analysis_mode() {
     underTest.execute();

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/EnableAnalysisStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/EnableAnalysisStepTest.java
@@ -51,7 +51,7 @@ public class EnableAnalysisStepTest {
   @Rule
   public MutableAnalysisMetadataHolderRule analysisMetadataHolder = new MutableAnalysisMetadataHolderRule();
 
-  EnableAnalysisStep underTest = new EnableAnalysisStep(db.getDbClient(), treeRootHolder, analysisMetadataHolder);
+  private EnableAnalysisStep underTest = new EnableAnalysisStep(db.getDbClient(), treeRootHolder, analysisMetadataHolder);
 
   @Test
   public void switch_islast_flag_and_mark_analysis_as_processed() {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/ExecuteVisitorsStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/ExecuteVisitorsStepTest.java
@@ -144,26 +144,26 @@ public class ExecuteVisitorsStepTest {
   }
 
   private static class VisitorA extends TypeAwareVisitorAdapter {
-    public VisitorA() {
+    VisitorA() {
       super(CrawlerDepthLimit.PROJECT, Order.PRE_ORDER);
     }
   }
 
   private static class VisitorB extends TypeAwareVisitorAdapter {
-    public VisitorB() {
+    VisitorB() {
       super(CrawlerDepthLimit.PROJECT, Order.PRE_ORDER);
     }
   }
 
   private static class VisitorC extends TypeAwareVisitorAdapter {
-    public VisitorC() {
+    VisitorC() {
       super(CrawlerDepthLimit.PROJECT, Order.PRE_ORDER);
     }
   }
 
   private class TestTypeAwareVisitor extends TypeAwareVisitorAdapter {
 
-    public TestTypeAwareVisitor() {
+    TestTypeAwareVisitor() {
       super(CrawlerDepthLimit.FILE, ComponentVisitor.Order.POST_ORDER);
     }
 
@@ -176,7 +176,7 @@ public class ExecuteVisitorsStepTest {
 
   private class TestPathAwareVisitor extends PathAwareVisitorAdapter<Counter> {
 
-    public TestPathAwareVisitor() {
+    TestPathAwareVisitor() {
       super(CrawlerDepthLimit.FILE, ComponentVisitor.Order.POST_ORDER, new SimpleStackElementFactory<Counter>() {
         @Override
         public Counter createForAny(Component component) {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/LoadCrossProjectDuplicationsRepositoryStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/LoadCrossProjectDuplicationsRepositoryStepTest.java
@@ -20,7 +20,6 @@
 package org.sonar.server.computation.task.projectanalysis.step;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -68,13 +67,12 @@ public class LoadCrossProjectDuplicationsRepositoryStepTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  static final String XOO_LANGUAGE = "xoo";
+  private static final String XOO_LANGUAGE = "xoo";
+  private static final int PROJECT_REF = 1;
+  private static final int FILE_REF = 2;
+  private static final String CURRENT_FILE_KEY = "FILE_KEY";
 
-  static final int PROJECT_REF = 1;
-  static final int FILE_REF = 2;
-  static final String CURRENT_FILE_KEY = "FILE_KEY";
-
-  static final Component CURRENT_FILE = ReportComponent.builder(FILE, FILE_REF)
+  private static final Component CURRENT_FILE = ReportComponent.builder(FILE, FILE_REF)
     .setKey(CURRENT_FILE_KEY)
     .setFileAttributes(new FileAttributes(false, XOO_LANGUAGE, 1))
     .build();
@@ -90,20 +88,17 @@ public class LoadCrossProjectDuplicationsRepositoryStepTest {
   @Rule
   public AnalysisMetadataHolderRule analysisMetadataHolder = new AnalysisMetadataHolderRule();
 
-  CrossProjectDuplicationStatusHolder crossProjectDuplicationStatusHolder = mock(CrossProjectDuplicationStatusHolder.class);
+  private CrossProjectDuplicationStatusHolder crossProjectDuplicationStatusHolder = mock(CrossProjectDuplicationStatusHolder.class);
 
   @Rule
   public DbTester dbTester = DbTester.create(System2.INSTANCE);
 
-  DbClient dbClient = dbTester.getDbClient();
+  private DbClient dbClient = dbTester.getDbClient();
+  private DbSession dbSession = dbTester.getSession();
+  private IntegrateCrossProjectDuplications integrateCrossProjectDuplications = mock(IntegrateCrossProjectDuplications.class);
+  private Analysis baseProjectAnalysis;
 
-  DbSession dbSession = dbTester.getSession();
-
-  IntegrateCrossProjectDuplications integrateCrossProjectDuplications = mock(IntegrateCrossProjectDuplications.class);
-
-  Analysis baseProjectAnalysis;
-
-  ComputationStep underTest = new LoadCrossProjectDuplicationsRepositoryStep(treeRootHolder, batchReportReader, analysisMetadataHolder, crossProjectDuplicationStatusHolder,
+  private ComputationStep underTest = new LoadCrossProjectDuplicationsRepositoryStep(treeRootHolder, batchReportReader, analysisMetadataHolder, crossProjectDuplicationStatusHolder,
     integrateCrossProjectDuplications, dbClient);
 
   @Before
@@ -154,7 +149,7 @@ public class LoadCrossProjectDuplicationsRepositoryStepTest {
     underTest.execute();
 
     verify(integrateCrossProjectDuplications).computeCpd(CURRENT_FILE,
-      Arrays.asList(
+      asList(
         new Block.Builder()
           .setResourceId(CURRENT_FILE_KEY)
           .setBlockHash(new ByteArray(hash))
@@ -162,7 +157,7 @@ public class LoadCrossProjectDuplicationsRepositoryStepTest {
           .setLines(originBlock.getStartLine(), originBlock.getEndLine())
           .setUnit(originBlock.getStartTokenIndex(), originBlock.getEndTokenIndex())
           .build()),
-      Arrays.asList(
+      asList(
         new Block.Builder()
           .setResourceId(otherFile.getDbKey())
           .setBlockHash(new ByteArray(hash))

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/LoadMeasureComputersStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/LoadMeasureComputersStepTest.java
@@ -54,7 +54,7 @@ public class LoadMeasureComputersStepTest {
   private static final String NEW_METRIC_3 = "metric3";
   private static final String NEW_METRIC_4 = "metric4";
 
-  MeasureComputersHolderImpl holder = new MeasureComputersHolderImpl();
+  private MeasureComputersHolderImpl holder = new MeasureComputersHolderImpl();
 
   @Test
   public void support_core_metrics_as_input_metrics() {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/LoadQualityProfilesStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/LoadQualityProfilesStepTest.java
@@ -46,8 +46,8 @@ public class LoadQualityProfilesStepTest {
   @Rule
   public RuleRepositoryRule ruleRepository = new RuleRepositoryRule();
 
-  ActiveRulesHolderImpl activeRulesHolder = new ActiveRulesHolderImpl();
-  LoadQualityProfilesStep underTest = new LoadQualityProfilesStep(batchReportReader, activeRulesHolder, ruleRepository);
+  private ActiveRulesHolderImpl activeRulesHolder = new ActiveRulesHolderImpl();
+  private LoadQualityProfilesStep underTest = new LoadQualityProfilesStep(batchReportReader, activeRulesHolder, ruleRepository);
 
   @Test
   public void feed_active_rules() {

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/NewSizeMeasuresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/NewSizeMeasuresStepTest.java
@@ -111,7 +111,7 @@ public class NewSizeMeasuresStepTest {
   @Rule
   public DuplicationRepositoryRule duplicationRepository = DuplicationRepositoryRule.create(treeRootHolder);
 
-  NewSizeMeasuresStep underTest = new NewSizeMeasuresStep(treeRootHolder, periodsHolder, metricRepository, measureRepository, scmInfoRepository,
+  private NewSizeMeasuresStep underTest = new NewSizeMeasuresStep(treeRootHolder, periodsHolder, metricRepository, measureRepository, scmInfoRepository,
     duplicationRepository);
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/PersistCrossProjectDuplicationIndexStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/PersistCrossProjectDuplicationIndexStepTest.java
@@ -26,8 +26,6 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.sonar.api.utils.System2;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbTester;
@@ -44,6 +42,7 @@ import org.sonar.server.computation.task.step.ComputationStep;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class PersistCrossProjectDuplicationIndexStepTest {
@@ -78,18 +77,14 @@ public class PersistCrossProjectDuplicationIndexStepTest {
   @Rule
   public AnalysisMetadataHolderRule analysisMetadataHolder = new AnalysisMetadataHolderRule();
 
-  @Mock
-  CrossProjectDuplicationStatusHolder crossProjectDuplicationStatusHolder;
-  @Mock
-  Analysis baseAnalysis;
+  private CrossProjectDuplicationStatusHolder crossProjectDuplicationStatusHolder = mock(CrossProjectDuplicationStatusHolder.class);
+  private Analysis baseAnalysis = mock(Analysis.class);
+  private DbClient dbClient = dbTester.getDbClient();
 
-  DbClient dbClient = dbTester.getDbClient();
-
-  ComputationStep underTest;
+  private ComputationStep underTest;
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
     when(baseAnalysis.getUuid()).thenReturn(BASE_ANALYSIS_UUID);
     analysisMetadataHolder.setUuid(ANALYSIS_UUID);
     analysisMetadataHolder.setBaseAnalysis(baseAnalysis);

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/PersistFileSourcesStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/PersistFileSourcesStepTest.java
@@ -39,7 +39,6 @@ import org.sonar.server.computation.task.projectanalysis.component.Component;
 import org.sonar.server.computation.task.projectanalysis.component.FileAttributes;
 import org.sonar.server.computation.task.projectanalysis.component.ReportComponent;
 import org.sonar.server.computation.task.projectanalysis.component.TreeRootHolderRule;
-import org.sonar.server.computation.task.projectanalysis.duplication.Duplicate;
 import org.sonar.server.computation.task.projectanalysis.duplication.Duplication;
 import org.sonar.server.computation.task.projectanalysis.duplication.DuplicationRepositoryRule;
 import org.sonar.server.computation.task.projectanalysis.duplication.InnerDuplicate;
@@ -487,5 +486,4 @@ public class PersistFileSourcesStepTest extends BaseStepTest {
       fileSourceRepository.addLine(FILE1_REF, "line" + i);
     }
   }
-
 }

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/PersistIssuesStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/PersistIssuesStepTest.java
@@ -64,7 +64,7 @@ import static org.sonar.db.component.ComponentTesting.newFileDto;
 
 public class PersistIssuesStepTest extends BaseStepTest {
 
-  public static final long NOW = 1400000000000L;
+  public static final long NOW = 1_400_000_000_000L;
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/PurgeDatastoresStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/PurgeDatastoresStepTest.java
@@ -29,10 +29,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.sonar.api.config.Configuration;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.db.DbClient;
-import org.sonar.db.DbSession;
 import org.sonar.db.purge.IdUuidPair;
 import org.sonar.server.computation.dbcleaner.ProjectCleaner;
 import org.sonar.server.computation.task.projectanalysis.component.Component;
@@ -48,7 +46,6 @@ import org.sonar.server.util.WrapInSingleElementArray;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyList;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -140,7 +137,7 @@ public class PurgeDatastoresStepTest extends BaseStepTest {
     underTest.execute();
 
     ArgumentCaptor<IdUuidPair> argumentCaptor = ArgumentCaptor.forClass(IdUuidPair.class);
-    verify(projectCleaner).purge(any(DbSession.class), argumentCaptor.capture(), any(Configuration.class), anyList());
+    verify(projectCleaner).purge(any(), argumentCaptor.capture(), any(), any());
     assertThat(argumentCaptor.getValue().getId()).isEqualTo(PROJECT_ID);
     assertThat(argumentCaptor.getValue().getUuid()).isEqualTo(PROJECT_UUID);
   }

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/SendIssueNotificationsStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/SendIssueNotificationsStepTest.java
@@ -60,8 +60,7 @@ import org.sonar.server.notification.NotificationService;
 import org.sonar.server.util.cache.DiskCache;
 
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
-import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.mockito.Matchers.anyString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -139,14 +138,14 @@ public class SendIssueNotificationsStepTest extends BaseStepTest {
       new DefaultIssue().setType(randomRuleType).setEffort(ISSUE_DURATION)
         .setCreationDate(new Date(ANALYSE_DATE)))
       .close();
-    when(notificationService.hasProjectSubscribersForTypes(PROJECT.getUuid(), SendIssueNotificationsStep.NOTIF_TYPES)).thenReturn(true);
+    when(notificationService.hasProjectSubscribersForTypes(eq(PROJECT.getUuid()), any())).thenReturn(true);
 
     underTest.execute();
 
     verify(notificationService).deliver(newIssuesNotificationMock);
     verify(newIssuesNotificationMock).setProject(PROJECT.getPublicKey(), PROJECT.getName(), null);
     verify(newIssuesNotificationMock).setAnalysisDate(new Date(ANALYSE_DATE));
-    verify(newIssuesNotificationMock).setStatistics(eq(PROJECT.getName()), any(NewIssuesStatistics.Stats.class));
+    verify(newIssuesNotificationMock).setStatistics(eq(PROJECT.getName()), any());
     verify(newIssuesNotificationMock).setDebt(ISSUE_DURATION);
   }
 
@@ -232,7 +231,7 @@ public class SendIssueNotificationsStepTest extends BaseStepTest {
       new DefaultIssue().setType(randomRuleType).setEffort(ISSUE_DURATION).setAssignee(ISSUE_ASSIGNEE)
         .setCreationDate(new Date(ANALYSE_DATE)))
       .close();
-    when(notificationService.hasProjectSubscribersForTypes(PROJECT.getUuid(), SendIssueNotificationsStep.NOTIF_TYPES)).thenReturn(true);
+    when(notificationService.hasProjectSubscribersForTypes(eq(PROJECT.getUuid()), any())).thenReturn(true);
 
     underTest.execute();
 
@@ -425,22 +424,22 @@ public class SendIssueNotificationsStepTest extends BaseStepTest {
 
   private NewIssuesNotification createNewIssuesNotificationMock() {
     NewIssuesNotification notification = mock(NewIssuesNotification.class);
-    when(notification.setProject(anyString(), anyString(), anyString())).thenReturn(notification);
-    when(notification.setProjectVersion(anyString())).thenReturn(notification);
-    when(notification.setAnalysisDate(any(Date.class))).thenReturn(notification);
-    when(notification.setStatistics(anyString(), any(NewIssuesStatistics.Stats.class))).thenReturn(notification);
-    when(notification.setDebt(any(Duration.class))).thenReturn(notification);
+    when(notification.setProject(any(), any(), any())).thenReturn(notification);
+    when(notification.setProjectVersion(any())).thenReturn(notification);
+    when(notification.setAnalysisDate(any())).thenReturn(notification);
+    when(notification.setStatistics(any(), any())).thenReturn(notification);
+    when(notification.setDebt(any())).thenReturn(notification);
     return notification;
   }
 
   private MyNewIssuesNotification createMyNewIssuesNotificationMock() {
     MyNewIssuesNotification notification = mock(MyNewIssuesNotification.class);
-    when(notification.setAssignee(anyString())).thenReturn(notification);
-    when(notification.setProject(anyString(), anyString(), anyString())).thenReturn(notification);
-    when(notification.setProjectVersion(anyString())).thenReturn(notification);
-    when(notification.setAnalysisDate(any(Date.class))).thenReturn(notification);
-    when(notification.setStatistics(anyString(), any(NewIssuesStatistics.Stats.class))).thenReturn(notification);
-    when(notification.setDebt(any(Duration.class))).thenReturn(notification);
+    when(notification.setAssignee(any())).thenReturn(notification);
+    when(notification.setProject(any(), any(), any())).thenReturn(notification);
+    when(notification.setProjectVersion(any())).thenReturn(notification);
+    when(notification.setAnalysisDate(any())).thenReturn(notification);
+    when(notification.setStatistics(any(), any())).thenReturn(notification);
+    when(notification.setDebt(any())).thenReturn(notification);
     return notification;
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/ViewsPersistComponentsStepTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/computation/task/projectanalysis/step/ViewsPersistComponentsStepTest.java
@@ -96,7 +96,6 @@ public class ViewsPersistComponentsStepTest extends BaseStepTest {
   private ComponentDbTester componentDbTester = new ComponentDbTester(dbTester);
   private MutableDisabledComponentsHolder disabledComponentsHolder = mock(MutableDisabledComponentsHolder.class, RETURNS_DEEP_STUBS);
   private PersistComponentsStep underTest;
-  private BranchPersister branchPersister;
 
   @Before
   public void setup() throws Exception {
@@ -105,7 +104,7 @@ public class ViewsPersistComponentsStepTest extends BaseStepTest {
 
     dbTester.organizations().insertForUuid(ORGANIZATION_UUID);
     analysisMetadataHolder.setBranch(new DefaultBranchImpl());
-    branchPersister = mock(BranchPersister.class);
+    BranchPersister branchPersister = mock(BranchPersister.class);
     underTest = new PersistComponentsStep(dbClient, treeRootHolder, dbIdsRepository, system2, disabledComponentsHolder, analysisMetadataHolder, branchPersister);
   }
 

--- a/server/sonar-server/src/test/java/org/sonar/server/issue/CommentActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/issue/CommentActionTest.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.issue.Issue;
 import org.sonar.core.issue.DefaultIssue;
-import org.sonar.core.issue.IssueChangeContext;
 import org.sonar.server.tester.AnonymousMockUserSession;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -60,7 +59,7 @@ public class CommentActionTest {
     when(context.issue()).thenReturn(issue);
 
     action.execute(properties, context);
-    verify(issueUpdater).addComment(eq(issue), eq(comment), any(IssueChangeContext.class));
+    verify(issueUpdater).addComment(eq(issue), eq(comment), any());
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/platform/SettingsChangeNotifierTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/platform/SettingsChangeNotifierTest.java
@@ -20,7 +20,6 @@
 package org.sonar.server.platform;
 
 import org.junit.Test;
-import org.mockito.ArgumentMatcher;
 import org.sonar.api.config.GlobalPropertyChangeHandler;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,13 +35,7 @@ public class SettingsChangeNotifierTest {
 
     notifier.onGlobalPropertyChange("foo", "bar");
 
-    verify(handler).onChange(argThat(new ArgumentMatcher<GlobalPropertyChangeHandler.PropertyChange>() {
-      @Override
-      public boolean matches(Object o) {
-        GlobalPropertyChangeHandler.PropertyChange change = (GlobalPropertyChangeHandler.PropertyChange) o;
-        return change.getKey().equals("foo") && change.getNewValue().equals("bar");
-      }
-    }));
+    verify(handler).onChange(argThat(change -> change.getKey().equals("foo") && change.getNewValue().equals("bar")));
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/plugins/PluginDownloaderTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/plugins/PluginDownloaderTest.java
@@ -63,11 +63,11 @@ public class PluginDownloaderTest {
   public TemporaryFolder testFolder = new TemporaryFolder();
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
-  File downloadDir;
-  UpdateCenterMatrixFactory updateCenterMatrixFactory;
-  UpdateCenter updateCenter;
-  HttpDownloader httpDownloader;
-  PluginDownloader pluginDownloader;
+  private File downloadDir;
+  private UpdateCenterMatrixFactory updateCenterMatrixFactory;
+  private UpdateCenter updateCenter;
+  private HttpDownloader httpDownloader;
+  private PluginDownloader pluginDownloader;
 
   @Before
   public void before() throws Exception {
@@ -306,15 +306,15 @@ public class PluginDownloaderTest {
     assertThat(new File(downloadDir, "testdep-1.0.jar")).exists();
   }
 
-  class HasFileName extends ArgumentMatcher<File> {
+  class HasFileName implements ArgumentMatcher<File> {
     private final String name;
 
     HasFileName(String name) {
       this.name = name;
     }
 
-    public boolean matches(Object obj) {
-      File file = (File) obj;
+    @Override
+    public boolean matches(File file) {
       return file.getName().equals(name);
     }
   }

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/BuiltInQualityProfilesUpdateListenerTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/BuiltInQualityProfilesUpdateListenerTest.java
@@ -34,8 +34,8 @@ import org.sonar.server.qualityprofile.BuiltInQualityProfilesNotification.Profil
 
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
-import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.assertj.core.api.Java6Assertions.tuple;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/QProfileResetImplTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/QProfileResetImplTest.java
@@ -38,8 +38,8 @@ import org.sonar.server.util.TypeValidations;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.assertj.core.api.Java6Assertions.tuple;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.Mockito.mock;
 import static org.sonar.server.qualityprofile.ActiveRuleChange.Type.ACTIVATED;
 
@@ -113,7 +113,7 @@ public class QProfileResetImplTest {
     RuleDefinitionDto defaultRule = db.rules().insert(r -> r.setLanguage(LANGUAGE));
 
     expectedException.expect(NullPointerException.class);
-    expectedException.expectMessage(String.format("Quality profile must be persisted"));
+    expectedException.expectMessage("Quality profile must be persisted");
 
     underTest.reset(db.getSession(), profile, singletonList(RuleActivation.create(defaultRule.getKey())));
   }

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/ActivateRulesActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/ActivateRulesActionTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
-import org.sonar.db.DbSession;
 import org.sonar.db.DbTester;
 import org.sonar.db.organization.OrganizationDto;
 import org.sonar.db.qualityprofile.QProfileDto;
@@ -36,7 +35,6 @@ import org.sonar.server.exceptions.ForbiddenException;
 import org.sonar.server.exceptions.UnauthorizedException;
 import org.sonar.server.organization.TestDefaultOrganizationProvider;
 import org.sonar.server.qualityprofile.RuleActivator;
-import org.sonar.server.rule.index.RuleQuery;
 import org.sonar.server.rule.ws.RuleQueryFactory;
 import org.sonar.server.tester.UserSessionRule;
 import org.sonar.server.ws.TestRequest;
@@ -45,7 +43,6 @@ import org.sonar.server.ws.WsActionTester;
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -123,7 +120,7 @@ public class ActivateRulesActionTest {
       .setParam(PARAM_TARGET_KEY, qualityProfile.getKee())
       .execute();
 
-    verify(ruleActivator).bulkActivateAndCommit(any(DbSession.class), any(RuleQuery.class), any(QProfileDto.class), anyString());
+    verify(ruleActivator).bulkActivateAndCommit(any(), any(), any(), any());
   }
 
   @Test
@@ -141,7 +138,7 @@ public class ActivateRulesActionTest {
       .setParam(PARAM_TARGET_KEY, qualityProfile.getKee())
       .execute();
 
-    verify(ruleActivator).bulkActivateAndCommit(any(DbSession.class), any(RuleQuery.class), any(QProfileDto.class), anyString());
+    verify(ruleActivator).bulkActivateAndCommit(any(), any(), any(), any());
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/DeactivateRulesActionTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/qualityprofile/ws/DeactivateRulesActionTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sonar.api.server.ws.WebService;
 import org.sonar.db.DbClient;
-import org.sonar.db.DbSession;
 import org.sonar.db.DbTester;
 import org.sonar.db.organization.OrganizationDto;
 import org.sonar.db.qualityprofile.QProfileDto;
@@ -36,7 +35,6 @@ import org.sonar.server.exceptions.ForbiddenException;
 import org.sonar.server.exceptions.UnauthorizedException;
 import org.sonar.server.organization.TestDefaultOrganizationProvider;
 import org.sonar.server.qualityprofile.RuleActivator;
-import org.sonar.server.rule.index.RuleQuery;
 import org.sonar.server.rule.ws.RuleQueryFactory;
 import org.sonar.server.tester.UserSessionRule;
 import org.sonar.server.ws.TestRequest;
@@ -119,7 +117,7 @@ public class DeactivateRulesActionTest {
       .setParam(PARAM_TARGET_KEY, qualityProfile.getKee())
       .execute();
 
-    verify(ruleActivator).bulkDeactivateAndCommit(any(DbSession.class), any(RuleQuery.class), any(QProfileDto.class));
+    verify(ruleActivator).bulkDeactivateAndCommit(any(), any(), any());
   }
 
   @Test
@@ -137,7 +135,7 @@ public class DeactivateRulesActionTest {
       .setParam(PARAM_TARGET_KEY, qualityProfile.getKee())
       .execute();
 
-    verify(ruleActivator).bulkDeactivateAndCommit(any(DbSession.class), any(RuleQuery.class), any(QProfileDto.class));
+    verify(ruleActivator).bulkDeactivateAndCommit(any(), any(), any());
   }
 
   @Test

--- a/server/sonar-server/src/test/java/org/sonar/server/settings/ChildSettingsTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/settings/ChildSettingsTest.java
@@ -31,7 +31,7 @@ import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.internal.MapSettings;
 
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ChildSettingsTest {
   private static final Random RANDOM = new Random();

--- a/server/sonar-server/src/test/java/org/sonar/server/telemetry/TelemetryDaemonTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/telemetry/TelemetryDaemonTest.java
@@ -58,6 +58,7 @@ import static java.util.Collections.emptySet;
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -199,7 +200,7 @@ public class TelemetryDaemonTest {
     internalProperties.write("telemetry.lastPing", String.valueOf(sixDaysAgo));
     settings.setProperty("sonar.telemetry.frequencyInSeconds", "1");
     underTest.start();
-    verify(client, timeout(2_000).never()).upload(anyString());
+    verify(client, after(2_000).never()).upload(anyString());
     internalProperties.write("telemetry.lastPing", String.valueOf(sevenDaysAgo));
 
     verify(client, timeout(2_000).atLeastOnce()).upload(anyString());
@@ -228,7 +229,7 @@ public class TelemetryDaemonTest {
     internalProperties.write("telemetry.lastPing", String.valueOf(sixDaysAgo));
     underTest.start();
 
-    verify(client, timeout(2_000).never()).upload(anyString());
+    verify(client, after(2_000).never()).upload(anyString());
   }
 
   @Test
@@ -253,7 +254,7 @@ public class TelemetryDaemonTest {
     underTest.start();
     underTest.start();
 
-    verify(client, timeout(2_000).never()).upload(anyString());
+    verify(client, after(2_000).never()).upload(anyString());
     verify(client, timeout(2_000).times(1)).optOut(anyString());
     assertThat(logger.logs(LoggerLevel.INFO)).contains("Sharing of SonarQube statistics is disabled.");
   }

--- a/tests/src/test/java/org/sonarqube/tests/component/BranchTest.java
+++ b/tests/src/test/java/org/sonarqube/tests/component/BranchTest.java
@@ -33,7 +33,7 @@ import org.sonarqube.ws.client.WsResponse;
 import org.sonarqube.ws.client.projectbranches.ListRequest;
 import util.ItUtils;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static util.ItUtils.runProjectAnalysis;
 
 public class BranchTest {


### PR DESCRIPTION
Removing transitive dependency on securemock allows to fix usage of Mockito