### PR TITLE
Put ES javaOpts arguments on one line

### DIFF
--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -207,9 +207,7 @@
 #
 
 # JVM options of Elasticsearch process
-#sonar.search.javaOpts=-Xms512m \
-# -Xmx512m \
-# -XX:+HeapDumpOnOutOfMemoryError
+#sonar.search.javaOpts=-Xms512m -Xmx512m -XX:+HeapDumpOnOutOfMemoryError
 
 # Same as previous property, but allows to not repeat all other settings like -Xmx
 #sonar.search.javaAdditionalOpts=


### PR DESCRIPTION
Make it consistent with the two other javaOpts settings, avoiding errors due to only uncommenting one of the three lines.

Without exaggeration I spent three hours troubleshooting due to having uncommented only the top line.