### PR TITLE
Updated jackson version to 2.8.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <elasticsearch.version>5.6.3</elasticsearch.version>
     <orchestrator.version>3.15.2.1322</orchestrator.version>
     <okhttp.version>3.7.0</okhttp.version>
-    <jackson.version>2.6.6</jackson.version>
+    <jackson.version>2.8.11</jackson.version>
     <jjwt.version>0.9.0</jjwt.version>
     <protobuf.version>3.0.0-beta-2</protobuf.version>
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [x] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

The current jackson-databind version (2.6.6) contains multiple vulnerabilities (https://github.com/FasterXML/jackson-databind/issues/1904) that were fixed in the 2.8.11 version. This also applies to jjwt dependency - https://github.com/jwtk/jjwt/issues/302 
This change will override the jackson-databind version pulled by jjwt

Current unit tests should cover compatibility.

This should solve also RSPEC-4544.