### PR TITLE
Added a parameter which control if Sonarqube will create the missing …

### DIFF
--- a/server/sonar-server/src/test/java/org/sonar/server/authentication/SsoAuthenticatorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/authentication/SsoAuthenticatorTest.java
@@ -107,7 +107,8 @@ public class SsoAuthenticatorTest {
     db.getDbClient(),
     new UserUpdater(mock(NewUserNotifier.class), db.getDbClient(), userIndexer, organizationFlags, defaultOrganizationProvider, organizationCreation,
       new DefaultGroupFinder(db.getDbClient()), settings.asConfig()),
-    defaultOrganizationProvider, organizationFlags, new DefaultGroupFinder(db.getDbClient()));
+    defaultOrganizationProvider, organizationFlags, new DefaultGroupFinder(db.getDbClient()),
+    settings.asConfig());
 
   private HttpServletResponse response = mock(HttpServletResponse.class);
   private JwtHttpHandler jwtHttpHandler = mock(JwtHttpHandler.class);

--- a/server/sonar-server/src/test/java/org/sonar/server/authentication/UserIdentityAuthenticatorTest.java
+++ b/server/sonar-server/src/test/java/org/sonar/server/authentication/UserIdentityAuthenticatorTest.java
@@ -94,7 +94,7 @@ public class UserIdentityAuthenticatorTest {
     settings.asConfig());
 
   private UserIdentityAuthenticator underTest = new UserIdentityAuthenticator(db.getDbClient(), userUpdater, defaultOrganizationProvider, organizationFlags,
-    new DefaultGroupFinder(db.getDbClient()));
+    new DefaultGroupFinder(db.getDbClient()), settings.asConfig());
 
   @Test
   public void authenticate_new_user() {

--- a/sonar-plugin-api/src/main/java/org/sonar/api/CoreProperties.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/CoreProperties.java
@@ -228,6 +228,11 @@ public interface CoreProperties {
    * @since 2.14
    */
   String CORE_AUTHENTICATOR_REALM = "sonar.security.realm";
+  
+  /**
+   * @since 6.7.6
+   */
+  String CODE_AUTHENTICATOR_SYNC_CREATE_MISSING_GROUPS = "sonar.security.sync.createMissingGroups";
 
   String CORE_AUTHENTICATOR_IGNORE_STARTUP_FAILURE = "sonar.authenticator.ignoreStartupFailure";
 


### PR DESCRIPTION
…groups coming from a remote authentication system or not

This is useful in case Sonar is connected to Atlassian Crowd as authentication and authorization system.

Memberships in Crowd will be replicated in Sonarqube upon login of a user.