### PR TITLE
Put current userid in response header

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/authentication/UserSessionInitializer.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/authentication/UserSessionInitializer.java
@@ -51,7 +51,7 @@ public class UserSessionInitializer {
   /**
    * Key of attribute to be used for displaying user login
    * in logs/access.log. The pattern to be configured
-   * in property sonar.web.accessLogs.pattern is "%reqAttribute{LOGIN}"
+   * in property sonar.web.accessLogs.pattern is "%responseHeader{LOGIN}"
    */
   private static final String ACCESS_LOG_LOGIN = "LOGIN";
 
@@ -135,7 +135,7 @@ public class UserSessionInitializer {
       session = userSessionFactory.createAnonymous();
     }
     threadLocalSession.set(session);
-    request.setAttribute(ACCESS_LOG_LOGIN, defaultString(session.getLogin(), "-"));
+    response.addHeader(ACCESS_LOG_LOGIN, defaultString(session.getLogin(), "-"));
   }
 
   private void failIfAuthenticationIsRequired() {

--- a/server/sonar-server/src/main/java/org/sonar/server/authentication/UserSessionInitializer.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/authentication/UserSessionInitializer.java
@@ -135,7 +135,7 @@ public class UserSessionInitializer {
       session = userSessionFactory.createAnonymous();
     }
     threadLocalSession.set(session);
-    response.addHeader(ACCESS_LOG_LOGIN, defaultString(session.getLogin(), "-"));
+    response.setHeader(ACCESS_LOG_LOGIN, defaultString(session.getLogin(), "-"));
   }
 
   private void failIfAuthenticationIsRequired() {

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -324,7 +324,7 @@
 #    - "common" is the Common Log Format, shortcut to: %h %l %u %user %date "%r" %s %b
 #    - "combined" is another format widely recognized, shortcut to: %h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}"
 #    - else a custom pattern. See http://logback.qos.ch/manual/layouts.html#AccessPatternLayout.
-# The login of authenticated user is not implemented with "%u" but with "%responseHeader{LOGIN}" (since version 6.1).
+# The login of authenticated user is not implemented with "%u" but with "%responseHeader{LOGIN}" (since version 6.7.6).
 # The value displayed for anonymous users is "-".
 # The SonarQube's HTTP request ID can be added to the pattern with "%reqAttribute{ID}" (since version 6.2).
 # If SonarQube is behind a reverse proxy, then the following value allows to display the correct remote IP address:

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -324,7 +324,7 @@
 #    - "common" is the Common Log Format, shortcut to: %h %l %u %user %date "%r" %s %b
 #    - "combined" is another format widely recognized, shortcut to: %h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}"
 #    - else a custom pattern. See http://logback.qos.ch/manual/layouts.html#AccessPatternLayout.
-# The login of authenticated user is not implemented with "%u" but with "%reqAttribute{LOGIN}" (since version 6.1).
+# The login of authenticated user is not implemented with "%u" but with "%responseHeader{LOGIN}" (since version 6.1).
 # The value displayed for anonymous users is "-".
 # The SonarQube's HTTP request ID can be added to the pattern with "%reqAttribute{ID}" (since version 6.2).
 # If SonarQube is behind a reverse proxy, then the following value allows to display the correct remote IP address:

--- a/tests/src/test/java/org/sonarqube/tests/serverSystem/LogsTest.java
+++ b/tests/src/test/java/org/sonarqube/tests/serverSystem/LogsTest.java
@@ -45,7 +45,7 @@ import static util.ItUtils.projectDir;
 
 public class LogsTest {
 
-  public static final String ACCESS_LOGS_PATTERN = "\"%reqAttribute{ID}\" \"%reqAttribute{LOGIN}\" \"%r\" %s";
+  public static final String ACCESS_LOGS_PATTERN = "\"%reqAttribute{ID}\" \"%responseHeader{LOGIN}\" \"%r\" %s";
   private static final String PATH = "/called/from/LogsTest";
 
   @ClassRule


### PR DESCRIPTION
Currently, the current userid can be logged in the access log file provided by Sonarqube.
But some enterprise are using reverse proxies, and use the access logs from the reverse proxies instead. This provides the gain that a unified reverse proxy log setup can be put in place and used with Logstash for example to inject the logs into ElasticSearch.
So be able to do that, that information have to be made available on the response header.