### PR TITLE
Add properties to change the initial admin username and password

### DIFF
--- a/server/sonar-ce/src/test/java/org/sonar/ce/container/ComputeEngineContainerImplTest.java
+++ b/server/sonar-ce/src/test/java/org/sonar/ce/container/ComputeEngineContainerImplTest.java
@@ -19,12 +19,6 @@
  */
 package org.sonar.ce.container;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Date;
-import java.util.Locale;
-import java.util.Properties;
-import java.util.stream.Collectors;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
@@ -45,17 +39,19 @@ import org.sonar.process.ProcessProperties;
 import org.sonar.process.Props;
 import org.sonar.server.property.InternalProperties;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
 import static java.lang.String.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.sonar.process.ProcessEntryPoint.PROPERTY_PROCESS_INDEX;
 import static org.sonar.process.ProcessEntryPoint.PROPERTY_SHARED_PATH;
-import static org.sonar.process.ProcessProperties.Property.JDBC_PASSWORD;
-import static org.sonar.process.ProcessProperties.Property.JDBC_URL;
-import static org.sonar.process.ProcessProperties.Property.JDBC_USERNAME;
-import static org.sonar.process.ProcessProperties.Property.PATH_DATA;
-import static org.sonar.process.ProcessProperties.Property.PATH_HOME;
-import static org.sonar.process.ProcessProperties.Property.PATH_TEMP;
+import static org.sonar.process.ProcessProperties.Property.*;
 
 public class ComputeEngineContainerImplTest {
   private static final int CONTAINER_ITSELF = 1;
@@ -123,7 +119,7 @@ public class ComputeEngineContainerImplTest {
           + 26 // level 1
           + 60 // content of DaoModule
           + 3 // content of EsModule
-          + 53 // content of CorePropertyDefinitions
+                + 55 // content of CorePropertyDefinitions
           + 1 // StopFlagContainer
       );
       assertThat(

--- a/server/sonar-db-migration/src/test/java/org/sonar/server/platform/db/migration/version/v56/PopulateInitialSchemaTest.java
+++ b/server/sonar-db-migration/src/test/java/org/sonar/server/platform/db/migration/version/v56/PopulateInitialSchemaTest.java
@@ -22,9 +22,13 @@ package org.sonar.server.platform.db.migration.version.v56;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.sonar.api.CoreProperties;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.System2;
 import org.sonar.core.util.stream.MoreCollectors;
 import org.sonar.db.CoreDbTester;
@@ -41,15 +45,18 @@ public class PopulateInitialSchemaTest {
   public ExpectedException expectedException = ExpectedException.none();
 
   private System2 system2 = mock(System2.class);
+  private Configuration configuration = mock(Configuration.class);
 
   @Rule
   public CoreDbTester db = CoreDbTester.createForSchema(PopulateInitialSchemaTest.class, "v56.sql");
 
-  private PopulateInitialSchema underTest = new PopulateInitialSchema(db.database(), system2);
+  private PopulateInitialSchema underTest = new PopulateInitialSchema(db.database(), configuration, system2);
 
   @Test
   public void migration_inserts_users_and_groups() throws SQLException {
     when(system2.now()).thenReturn(NOW);
+    when(configuration.get(CoreProperties.ADMIN_DEFAULT_USERNAME)).thenReturn(Optional.of("admin"));
+    when(configuration.get(CoreProperties.ADMIN_DEFAULT_PASSWORD)).thenReturn(Optional.of("admin"));
 
     underTest.execute();
 

--- a/server/sonar-db-migration/src/test/java/org/sonar/server/platform/db/migration/version/v56/PopulateInitialSchemaTest.java
+++ b/server/sonar-db-migration/src/test/java/org/sonar/server/platform/db/migration/version/v56/PopulateInitialSchemaTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -127,8 +128,11 @@ public class PopulateInitialSchemaTest {
     assertThat(cols.get("name")).isEqualTo("Administrator");
     assertThat(cols.get("email")).isEqualTo("");
     assertThat(cols.get("user_local")).isEqualTo(true);
-    assertThat(cols.get("crypted_password")).isEqualTo("a373a0e667abb2604c1fd571eb4ad47fe8cc0878");
-    assertThat(cols.get("salt")).isEqualTo("48bc4b0d93179b5103fd3885ea9119498e9d161b");
+    String salt = "48bc4b0d93179b5103fd3885ea9119498e9d161b";
+    String password = configuration.get(CoreProperties.ADMIN_DEFAULT_PASSWORD).orElse("admin");
+    password = DigestUtils.sha1Hex(String.format("--%s--%s--", salt, password));
+    assertThat(cols.get("crypted_password")).isEqualTo(password);
+    assertThat(cols.get("salt")).isEqualTo(salt);
     assertThat(cols.get("created_at")).isEqualTo(NOW);
     assertThat(cols.get("updated_at")).isEqualTo(NOW);
     assertThat(cols.get("remember_token")).isNull();

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -20,7 +20,7 @@
 # H2 embedded database server listening port, defaults to 9092
 #sonar.embeddedDatabase.port=9092
 
-#----- DEPRECATED 
+#----- DEPRECATED
 #----- MySQL >=5.6 && <8.0
 # Support of MySQL is dropped in Data Center Editions and deprecated in all other editions
 # Only InnoDB storage engine is supported (not myISAM).
@@ -146,6 +146,7 @@
 # The passcode should be provided in HTTP requests with the header "X-Sonar-Passcode".
 # By default feature is disabled.
 #sonar.web.systemPasscode=
+
 #--------------------------------------------------------------------------------------------------
 # AUTHENTICATION
 # Initial username for the admin user

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -151,6 +151,7 @@
 # AUTHENTICATION
 # Initial username for the admin user
 #sonar.admin.username=admin
+
 # Initial password for the admin user
 #sonar.admin.password=admin
 

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -146,7 +146,12 @@
 # The passcode should be provided in HTTP requests with the header "X-Sonar-Passcode".
 # By default feature is disabled.
 #sonar.web.systemPasscode=
-
+#--------------------------------------------------------------------------------------------------
+# AUTHENTICATION
+# Initial username for the admin user
+#sonar.admin.username=admin
+# Initial password for the admin user
+#sonar.admin.password=admin
 
 #--------------------------------------------------------------------------------------------------
 # SSO AUTHENTICATION

--- a/sonar-core/src/main/java/org/sonar/core/config/CorePropertyDefinitions.java
+++ b/sonar-core/src/main/java/org/sonar/core/config/CorePropertyDefinitions.java
@@ -21,6 +21,7 @@ package org.sonar.core.config;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.sonar.api.CoreProperties;
 import org.sonar.api.PropertyType;
 import org.sonar.api.config.EmailSettings;
@@ -28,7 +29,9 @@ import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
 
 import static java.util.Arrays.asList;
-import static org.sonar.api.PropertyType.BOOLEAN;
+import static org.sonar.api.CoreProperties.ADMIN_DEFAULT_PASSWORD;
+import static org.sonar.api.CoreProperties.ADMIN_DEFAULT_USERNAME;
+import static org.sonar.api.PropertyType.*;
 
 public class CorePropertyDefinitions {
 
@@ -211,6 +214,20 @@ public class CorePropertyDefinitions {
         .category(CATEGORY_ORGANIZATIONS)
         .type(BOOLEAN)
         .hidden()
+        .build(),
+
+      // ADMIN SETTINGS
+      PropertyDefinition.builder(ADMIN_DEFAULT_USERNAME)
+        .name("Default username for the admin user")
+        .defaultValue("admin")
+        .category(CoreProperties.CATEGORY_GENERAL)
+        .type(STRING)
+        .build(),
+      PropertyDefinition.builder(ADMIN_DEFAULT_PASSWORD)
+        .name("Default password for the admin user")
+        .defaultValue("admin")
+        .category(CoreProperties.CATEGORY_GENERAL)
+        .type(PASSWORD)
         .build()));
     return defs;
   }

--- a/sonar-core/src/test/java/org/sonar/core/config/CorePropertyDefinitionsTest.java
+++ b/sonar-core/src/test/java/org/sonar/core/config/CorePropertyDefinitionsTest.java
@@ -20,6 +20,7 @@
 package org.sonar.core.config;
 
 import java.util.List;
+
 import org.junit.Test;
 import org.sonar.api.config.PropertyDefinition;
 
@@ -30,7 +31,7 @@ public class CorePropertyDefinitionsTest {
   @Test
   public void all() {
     List<PropertyDefinition> defs = CorePropertyDefinitions.all();
-    assertThat(defs).hasSize(53);
+    assertThat(defs).hasSize(55);
   }
 
   @Test

--- a/sonar-plugin-api/src/main/java/org/sonar/api/CoreProperties.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/CoreProperties.java
@@ -346,7 +346,7 @@ public interface CoreProperties {
   /**
    * @since 7.6
    */
-  String ADMIN_DEFAULT_USERNAME = "sonar.admin.password";
+  String ADMIN_DEFAULT_USERNAME = "sonar.admin.username";
 
   /**
    * @since 7.6

--- a/sonar-plugin-api/src/main/java/org/sonar/api/CoreProperties.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/CoreProperties.java
@@ -344,6 +344,16 @@ public interface CoreProperties {
   String LINKS_SOURCES_DEV = "sonar.links.scm_dev";
 
   /**
+   * @since 7.6
+   */
+  String ADMIN_DEFAULT_USERNAME = "sonar.admin.password";
+
+  /**
+   * @since 7.6
+   */
+  String ADMIN_DEFAULT_PASSWORD = "sonar.admin.password";
+
+  /**
    * @since 3.4
    */
   String LOGIN = "sonar.login";

--- a/travis.sh
+++ b/travis.sh
@@ -35,15 +35,13 @@ cancel_branch_build_with_pr || if [[ $? -eq 1 ]]; then exit 0; fi
 case "$TARGET" in
 
 BUILD)
-  if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-    git fetch --unshallow
-    ./gradlew build sonarqube --no-daemon --console plain \
-      -PjacocoEnabled=true \
-      -Dsonar.projectKey=org.sonarsource.sonarqube:sonarqube \
-      -Dsonar.organization=sonarsource \
-      -Dsonar.host.url=https://sonarcloud.io \
-      -Dsonar.login=$SONAR_TOKEN
-  fi
+  git fetch --unshallow
+  ./gradlew build sonarqube --no-daemon --console plain \
+    -PjacocoEnabled=true \
+    -Dsonar.projectKey=org.sonarsource.sonarqube:sonarqube \
+    -Dsonar.organization=sonarsource \
+    -Dsonar.host.url=https://sonarcloud.io \
+    -Dsonar.login=$SONAR_TOKEN
   ;;
 
 WEB_TESTS)

--- a/travis.sh
+++ b/travis.sh
@@ -35,13 +35,15 @@ cancel_branch_build_with_pr || if [[ $? -eq 1 ]]; then exit 0; fi
 case "$TARGET" in
 
 BUILD)
-  git fetch --unshallow
-  ./gradlew build sonarqube --no-daemon --console plain \
-  -PjacocoEnabled=true \
-  -Dsonar.projectKey=org.sonarsource.sonarqube:sonarqube \
-  -Dsonar.organization=sonarsource \
-  -Dsonar.host.url=https://sonarcloud.io \
-  -Dsonar.login=$SONAR_TOKEN
+  if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+    git fetch --unshallow
+    ./gradlew build sonarqube --no-daemon --console plain \
+      -PjacocoEnabled=true \
+      -Dsonar.projectKey=org.sonarsource.sonarqube:sonarqube \
+      -Dsonar.organization=sonarsource \
+      -Dsonar.host.url=https://sonarcloud.io \
+      -Dsonar.login=$SONAR_TOKEN
+  fi
   ;;
 
 WEB_TESTS)


### PR DESCRIPTION
Because of security reasons, that I will explain later, this change adds two properties to the application to change the default username and password for SonarQube (admin/admin, by default).

Why do we need this? Currently it is possible to change the Authentication to SSO with OAuth2 already using the properties. However when you do this, it still leaves the admin/admin credentials default.

Mainly this is done to make integrating into the docker image easier, because for example in docker-compose is would be quite nasty to do post-startup database changes and this allows for users to set the defaults themselves.

Also, here is an example of what could happen if someone forgot to change the default password when having SSO enabled: https://nakedsecurity.sophos.com/2018/05/14/2-million-lines-of-source-code-left-exposed-by-phone-company-ee/