### PR TITLE
Increase number of supported webhooks

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/webhook/ws/CreateAction.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/webhook/ws/CreateAction.java
@@ -59,7 +59,7 @@ import static org.sonarqube.ws.Webhooks.CreateWsResponse.newBuilder;
 
 public class CreateAction implements WebhooksWsAction {
 
-  private static final int MAX_NUMBER_OF_WEBHOOKS = 10;
+  private static final int MAX_NUMBER_OF_WEBHOOKS = 100;
 
   private final DbClient dbClient;
   private final UserSession userSession;


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines: 

- [ ] Please explain your motives to contribute this change: Currently, if you have more than 10 jenkins instances you cannot use the same sonarqube instance as the number of the webhooks limit you.
