### PR TITLE
[TRANSPARENCY] Disable default server info collect by SonarSource

### DIFF
--- a/server/sonar-process/src/main/java/org/sonar/process/ProcessProperties.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/ProcessProperties.java
@@ -101,7 +101,7 @@ public class ProcessProperties {
     SONAR_SECURITY_REALM("sonar.security.realm"),
     SONAR_AUTHENTICATOR_IGNORE_STARTUP_FAILURE("sonar.authenticator.ignoreStartupFailure", "false"),
 
-    SONAR_TELEMETRY_ENABLE("sonar.telemetry.enable", "true"),
+    SONAR_TELEMETRY_ENABLE("sonar.telemetry.enable", "false"),
     SONAR_TELEMETRY_URL("sonar.telemetry.url", "https://telemetry.sonarsource.com/sonarqube"),
     SONAR_TELEMETRY_FREQUENCY_IN_SECONDS("sonar.telemetry.frequencyInSeconds", "21600"),
 

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -409,7 +409,7 @@
 # By sharing anonymous SonarQube statistics, you help us understand how SonarQube is used so we can improve the product to work even better for you.
 # We don't collect source code or IP addresses. And we don't share the data with anyone else.
 # To see an example of the data shared: login as a global administrator, call the WS api/system/info and check the Statistics field.
-#sonar.telemetry.enable=true
+#sonar.telemetry.enable=false
 
 
 #--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
By default, SonarSource collects server information about all SonarQube instances. 

This collect can be disabled by setting the property `sonar.telemetry.enabled` to `false`. 

But by defaut, this is enabled and SonarQube servers send server information to **https://telemetry.sonarsource.com/sonarqube** avery 6 hours. Collected information are those provided by `/api/system/info`.

No information is openly provided to users about telemetry feature and its default configuration.

It would be more *transparent* and *ethic* towards users and the community to set this feature to `false` by default, or at least warn them about **telemetry** before they launch a SoanrQube server.