### PR TITLE
Build a correct path when no message

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/authentication/AuthenticationError.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/authentication/AuthenticationError.java
@@ -57,7 +57,7 @@ final class AuthenticationError {
   private static String getPath(AuthenticationException e, String contextPath) {
     String publicMessage = e.getPublicMessage();
     if (publicMessage == null || publicMessage.isEmpty()) {
-      return UNAUTHORIZED_PATH;
+      return contextPath + UNAUTHORIZED_PATH;
     }
     return contextPath + format(UNAUTHORIZED_PATH_WITH_MESSAGE, encodeMessage(publicMessage));
   }


### PR DESCRIPTION
Just fixing a little bug when using a custom context path (ex: https//www.example.org/sonarqube). The generated path is not good when there is no additional message.

Thix bug is present on branches 6.7 and master too.