### PR TITLE
Adding http.nonProxyHosts option into sonar.properties

### DIFF
--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -298,6 +298,10 @@
 #https.proxyHost=
 #https.proxyPort=
 
+# Hosts that should accessed without going through the proxy (used both for HTTP and HTTPS proxies)
+# Example: "*.example.com|localhost"
+#http.nonProxyHosts=
+
 # NT domain name if NTLM proxy is used
 #http.auth.ntlm.domain=
 


### PR DESCRIPTION
Added option that define proxy-free addresses for Sonarqube.
