### PR TITLE
One regex instead of 3

### DIFF
--- a/server/sonar-ce/src/main/java/org/sonar/ce/queue/PurgeCeActivities.java
+++ b/server/sonar-ce/src/main/java/org/sonar/ce/queue/PurgeCeActivities.java
@@ -19,55 +19,28 @@
  */
 package org.sonar.ce.queue;
 
-import java.util.Date;
-import java.util.Set;
 import org.sonar.api.Startable;
 import org.sonar.api.ce.ComputeEngineSide;
-import org.sonar.api.utils.DateUtils;
-import org.sonar.api.utils.System2;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
 import org.sonar.db.DbClient;
 import org.sonar.db.DbSession;
-import org.sonar.db.ce.CeActivityDto;
-
-import static java.util.stream.Stream.concat;
-import static org.sonar.core.util.stream.MoreCollectors.toSet;
+import org.sonar.db.purge.PurgeProfiler;
 
 @ComputeEngineSide
 public class PurgeCeActivities implements Startable {
 
-  private static final Logger LOGGER = Loggers.get(PurgeCeActivities.class);
-
   private final DbClient dbClient;
-  private final System2 system2;
+  private final PurgeProfiler profiler;
 
-  public PurgeCeActivities(DbClient dbClient, System2 system2) {
+  public PurgeCeActivities(DbClient dbClient, PurgeProfiler profiler) {
     this.dbClient = dbClient;
-    this.system2 = system2;
+    this.profiler = profiler;
   }
 
   @Override
   public void start() {
     try (DbSession dbSession = dbClient.openSession(false)) {
-      Date sixMonthsAgo = DateUtils.addDays(new Date(system2.now()), -180);
-
-      LOGGER.info("Delete the Compute Engine tasks created before {}", sixMonthsAgo.getTime());
-      Set<String> ceActivityUuids = dbClient.ceActivityDao().selectOlderThan(dbSession, sixMonthsAgo.getTime())
-        .stream()
-        .map(CeActivityDto::getUuid)
-        .collect(toSet());
-      dbClient.ceActivityDao().deleteByUuids(dbSession, ceActivityUuids);
-      dbClient.ceTaskCharacteristicsDao().deleteByTaskUuids(dbSession, ceActivityUuids);
-      dbClient.ceTaskInputDao().deleteByUuids(dbSession, ceActivityUuids);
-
-      Date fourWeeksAgo = DateUtils.addDays(new Date(system2.now()), -28);
-
-      LOGGER.info("Delete the Scanner contexts tasks created before {}", fourWeeksAgo.getTime());
-      Set<String> scannerContextUuids = dbClient.ceScannerContextDao().selectOlderThan(dbSession, fourWeeksAgo.getTime());
-      dbClient.ceScannerContextDao().deleteByUuids(
-        dbSession,
-        concat(ceActivityUuids.stream(), scannerContextUuids.stream()).collect(toSet()));
+      dbClient.purgeDao().purgeCeActivities(dbSession, profiler);
+      dbClient.purgeDao().purgeCeScannerContexts(dbSession, profiler);
       dbSession.commit();
     }
   }

--- a/server/sonar-ce/src/test/java/org/sonar/ce/queue/PurgeCeActivitiesTest.java
+++ b/server/sonar-ce/src/test/java/org/sonar/ce/queue/PurgeCeActivitiesTest.java
@@ -19,135 +19,37 @@
  */
 package org.sonar.ce.queue;
 
-import java.nio.charset.Charset;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import org.apache.commons.io.IOUtils;
-import org.junit.Rule;
 import org.junit.Test;
-import org.sonar.api.utils.System2;
-import org.sonar.core.util.UuidFactoryFast;
-import org.sonar.db.DbTester;
-import org.sonar.db.ce.CeActivityDto;
-import org.sonar.db.ce.CeQueueDto;
-import org.sonar.db.ce.CeTaskCharacteristicDto;
-import org.sonar.db.ce.CeTaskInputDao;
-import org.sonar.db.ce.CeTaskTypes;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.sonar.db.DbClient;
+import org.sonar.db.DbSession;
+import org.sonar.db.purge.PurgeDao;
+import org.sonar.db.purge.PurgeProfiler;
 
-import static java.time.ZoneOffset.UTC;
-import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class PurgeCeActivitiesTest {
 
-  private System2 system2 = mock(System2.class);
-
-  @Rule
-  public DbTester dbTester = DbTester.create(system2);
-
-  private PurgeCeActivities underTest = new PurgeCeActivities(dbTester.getDbClient(), system2);
+  private DbClient dbClient = mock(DbClient.class);
+  private PurgeDao purgeDao = mock(PurgeDao.class);
+  private DbSession dbSession = mock(DbSession.class);
+  private PurgeProfiler profiler = mock(PurgeProfiler.class);
+  private PurgeCeActivities underTest = new PurgeCeActivities(dbClient, profiler);
 
   @Test
-  public void delete_activity_older_than_180_days_and_their_scanner_context() {
-    LocalDateTime now = LocalDateTime.now();
-    insertWithDate("VERY_OLD", now.minusDays(180).minusMonths(10));
-    insertWithDate("JUST_OLD_ENOUGH", now.minusDays(180).minusDays(1));
-    insertWithDate("NOT_OLD_ENOUGH", now.minusDays(180));
-    insertWithDate("RECENT", now.minusDays(1));
-    when(system2.now()).thenReturn(now.toInstant(ZoneOffset.UTC).toEpochMilli());
+  public void starts_calls_purgeDao_and_commit() {
+    when(dbClient.purgeDao()).thenReturn(purgeDao);
+    when(dbClient.openSession(false)).thenReturn(dbSession);
 
     underTest.start();
 
-    assertThat(selectActivity("VERY_OLD").isPresent()).isFalse();
-    assertThat(selectTaskInput("VERY_OLD").isPresent()).isFalse();
-    assertThat(selectTaskCharecteristic("VERY_OLD")).hasSize(0);
-    assertThat(scannerContextExists("VERY_OLD")).isFalse();
-
-    assertThat(selectActivity("JUST_OLD_ENOUGH").isPresent()).isFalse();
-    assertThat(selectTaskInput("JUST_OLD_ENOUGH").isPresent()).isFalse();
-    assertThat(selectTaskCharecteristic("JUST_OLD_ENOUGH")).hasSize(0);
-    assertThat(scannerContextExists("JUST_OLD_ENOUGH")).isFalse();
-
-    assertThat(selectActivity("NOT_OLD_ENOUGH").isPresent()).isTrue();
-    assertThat(selectTaskInput("NOT_OLD_ENOUGH").isPresent()).isTrue();
-    assertThat(selectTaskCharecteristic("NOT_OLD_ENOUGH")).hasSize(1);
-    assertThat(scannerContextExists("NOT_OLD_ENOUGH")).isFalse(); // because more than 4 weeks old
-
-    assertThat(selectActivity("RECENT").isPresent()).isTrue();
-    assertThat(selectTaskInput("RECENT").isPresent()).isTrue();
-    assertThat(selectTaskCharecteristic("RECENT")).hasSize(1);
-    assertThat(scannerContextExists("RECENT")).isTrue();
-
-  }
-
-  @Test
-  public void delete_ce_scanner_context_older_than_28_days() {
-    LocalDateTime now = LocalDateTime.now();
-    insertWithDate("VERY_OLD", now.minusDays(28).minusMonths(12));
-    insertWithDate("JUST_OLD_ENOUGH", now.minusDays(28).minusDays(1));
-    insertWithDate("NOT_OLD_ENOUGH", now.minusDays(28));
-    insertWithDate("RECENT", now.minusDays(1));
-    when(system2.now()).thenReturn(now.toInstant(ZoneOffset.UTC).toEpochMilli());
-
-    underTest.start();
-
-    assertThat(scannerContextExists("VERY_OLD")).isFalse();
-    assertThat(scannerContextExists("JUST_OLD_ENOUGH")).isFalse();
-    assertThat(scannerContextExists("NOT_OLD_ENOUGH")).isTrue();
-    assertThat(scannerContextExists("RECENT")).isTrue();
-  }
-
-  private Optional<CeActivityDto> selectActivity(String taskUuid) {
-    return dbTester.getDbClient().ceActivityDao().selectByUuid(dbTester.getSession(), taskUuid);
-  }
-
-  private List<CeTaskCharacteristicDto> selectTaskCharecteristic(String taskUuid) {
-    return dbTester.getDbClient().ceTaskCharacteristicsDao().selectByTaskUuids(dbTester.getSession(), Collections.singletonList(taskUuid));
-  }
-
-  private Optional<CeTaskInputDao.DataStream> selectTaskInput(String taskUuid) {
-    return dbTester.getDbClient().ceTaskInputDao().selectData(dbTester.getSession(), taskUuid);
-  }
-
-  private boolean scannerContextExists(String uuid) {
-    return dbTester.countSql("select count(1) from ce_scanner_context where task_uuid = '" + uuid + "'") == 1;
-  }
-
-  private void insertWithDate(String uuid, LocalDateTime dateTime) {
-    long date = dateTime.toInstant(UTC).toEpochMilli();
-    CeQueueDto queueDto = new CeQueueDto();
-    queueDto.setUuid(uuid);
-    queueDto.setTaskType(CeTaskTypes.REPORT);
-
-    CeActivityDto dto = new CeActivityDto(queueDto);
-    dto.setStatus(CeActivityDto.Status.SUCCESS);
-    when(system2.now()).thenReturn(date);
-    CeTaskCharacteristicDto ceTaskCharacteristicDto = new CeTaskCharacteristicDto()
-      .setUuid(UuidFactoryFast.getInstance().create())
-      .setValue(randomAlphanumeric(10))
-      .setKey(randomAlphanumeric(10))
-      .setTaskUuid(dto.getUuid());
-
-    dbTester.getDbClient().ceTaskInputDao().insert(dbTester.getSession(), dto.getUuid(), IOUtils.toInputStream(randomAlphanumeric(10), Charset.forName("UTF-8")));
-    dbTester.getDbClient().ceActivityDao().insert(dbTester.getSession(), dto);
-    dbTester.getDbClient().ceTaskCharacteristicsDao().insert(dbTester.getSession(), Collections.singletonList(ceTaskCharacteristicDto));
-    dbTester.getSession().commit();
-
-    insertScannerContext(uuid, date);
-  }
-
-  private void insertScannerContext(String uuid, long createdAt) {
-    dbTester.executeInsert(
-      "CE_SCANNER_CONTEXT",
-      "task_uuid", uuid,
-      "created_at", createdAt,
-      "updated_at", 1,
-      "context_data", "YoloContent".getBytes());
-    dbTester.commit();
+    InOrder inOrder = Mockito.inOrder(purgeDao, dbSession);
+    inOrder.verify(purgeDao).purgeCeActivities(dbSession, profiler);
+    inOrder.verify(purgeDao).purgeCeScannerContexts(dbSession, profiler);
+    inOrder.verify(dbSession).commit();
+    inOrder.verify(dbSession).close();
+    inOrder.verifyNoMoreInteractions();
   }
 }

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/DaoUtils.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/DaoUtils.java
@@ -56,6 +56,6 @@ public class DaoUtils {
    */
   private static String escapePercentAndUnderscore(String value) {
     return value
-        .replaceAll("/" + "|" + "%" + "|" + "_", "/$0"); // $0 : Group zero stands for the entire expression
+        .replaceAll("/" + "|" + "%" + "|" + "_", "/$0"); // $0 : Group zero, stands for the entire expression
   }
 }

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/DaoUtils.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/DaoUtils.java
@@ -56,6 +56,6 @@ public class DaoUtils {
    */
   private static String escapePercentAndUnderscore(String value) {
     return value
-        .replaceAll("/" + "|" + "%" + "|" + "_", "/$0"); // $0 : Group zero, stands for the entire expression
+        .replaceAll("/" + "|" + "%" + "|" + "_", "/$0"); // $0 : Group zero, stands for the entire expression 
   }
 }

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/DaoUtils.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/DaoUtils.java
@@ -56,8 +56,6 @@ public class DaoUtils {
    */
   private static String escapePercentAndUnderscore(String value) {
     return value
-        .replaceAll("/", "//")
-        .replaceAll("%", "/%")
-        .replaceAll("_", "/_");
+        .replaceAll("/" + "|" + "%" + "|" + "_", "/$0"); // $0 : Group zero stands for the entire expression
   }
 }

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/purge/PurgeCommands.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/purge/PurgeCommands.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.sonar.db.DbSession;
 
 class PurgeCommands {
@@ -281,25 +282,55 @@ class PurgeCommands {
 
   void deleteCeActivity(String rootUuid) {
     profiler.start("deleteCeActivity (ce_scanner_context)");
-    purgeMapper.deleteCeScannerContextOfCeActivityByRootUuid(rootUuid);
+    purgeMapper.deleteCeScannerContextOfCeActivityByRootUuidOrBefore(rootUuid, null);
     session.commit();
     profiler.stop();
     profiler.start("deleteCeActivity (ce_task_characteristics)");
-    purgeMapper.deleteCeTaskCharacteristicsOfCeActivityByRootUuid(rootUuid);
+    purgeMapper.deleteCeTaskCharacteristicsOfCeActivityByRootUuidOrBefore(rootUuid, null);
     session.commit();
     profiler.stop();
     profiler.start("deleteCeActivity (ce_task_input)");
-    purgeMapper.deleteCeTaskInputOfCeActivityByRootUuid(rootUuid);
+    purgeMapper.deleteCeTaskInputOfCeActivityByRootUuidOrBefore(rootUuid, null);
     session.commit();
     profiler.stop();
     profiler.start("deleteCeActivity (ce_task_message)");
-    purgeMapper.deleteCeTaskMessageOfCeActivityByRootUuid(rootUuid);
+    purgeMapper.deleteCeTaskMessageOfCeActivityByRootUuidOrBefore(rootUuid, null);
     session.commit();
     profiler.stop();
     profiler.start("deleteCeActivity (ce_activity)");
-    purgeMapper.deleteCeActivityByRootUuid(rootUuid);
+    purgeMapper.deleteCeActivityByRootUuidOrBefore(rootUuid, null);
     session.commit();
     profiler.stop();
+  }
+
+  void deleteCeActivityBefore(@Nullable String rootUuid, long createdAt) {
+    profiler.start("deleteCeActivityBefore (ce_scanner_context)");
+    purgeMapper.deleteCeScannerContextOfCeActivityByRootUuidOrBefore(rootUuid, createdAt);
+    session.commit();
+    profiler.stop();
+    profiler.start("deleteCeActivityBefore (ce_task_characteristics)");
+    purgeMapper.deleteCeTaskCharacteristicsOfCeActivityByRootUuidOrBefore(rootUuid, createdAt);
+    session.commit();
+    profiler.stop();
+    profiler.start("deleteCeActivityBefore (ce_task_input)");
+    purgeMapper.deleteCeTaskInputOfCeActivityByRootUuidOrBefore(rootUuid, createdAt);
+    session.commit();
+    profiler.stop();
+    profiler.start("deleteCeActivityBefore (ce_task_message)");
+    purgeMapper.deleteCeTaskMessageOfCeActivityByRootUuidOrBefore(rootUuid, createdAt);
+    session.commit();
+    profiler.stop();
+    profiler.start("deleteCeActivityBefore (ce_activity)");
+    purgeMapper.deleteCeActivityByRootUuidOrBefore(rootUuid, createdAt);
+    session.commit();
+    profiler.stop();
+  }
+
+  void deleteCeScannerContextBefore(@Nullable String rootUuid, long createdAt) {
+    // assuming CeScannerContext of rows in table CE_QUEUE can't be older than createdAt
+    profiler.start("deleteCeScannerContextBefore");
+    purgeMapper.deleteCeScannerContextOfCeActivityByRootUuidOrBefore(rootUuid, createdAt);
+    session.commit();
   }
 
   void deleteCeQueue(String rootUuid) {

--- a/server/sonar-db-dao/src/main/java/org/sonar/db/purge/PurgeMapper.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/purge/PurgeMapper.java
@@ -94,7 +94,7 @@ public interface PurgeMapper {
   @CheckForNull
   String selectManualBaseline(@Param("projectUuid") String projectUuid);
 
-  List<IdUuidPair>  selectDisabledComponentsWithoutIssues(@Param("projectUuid") String projectUuid);
+  List<IdUuidPair> selectDisabledComponentsWithoutIssues(@Param("projectUuid") String projectUuid);
 
   void deleteIssuesFromKeys(@Param("keys") List<String> keys);
 
@@ -104,15 +104,23 @@ public interface PurgeMapper {
 
   void deleteFileSourcesByFileUuid(@Param("fileUuids") List<String> fileUuids);
 
-  void deleteCeTaskCharacteristicsOfCeActivityByRootUuid(@Param("rootUuid") String rootUuid);
+  void deleteCeTaskCharacteristicsOfCeActivityByRootUuidOrBefore(@Nullable @Param("rootUuid") String rootUuid,
+    @Nullable @Param("createdAtBefore") Long createdAtBefore);
 
-  void deleteCeTaskInputOfCeActivityByRootUuid(@Param("rootUuid") String rootUuid);
+  void deleteCeTaskInputOfCeActivityByRootUuidOrBefore(@Nullable @Param("rootUuid") String rootUuid,
+    @Nullable @Param("createdAtBefore") Long createdAtBefore);
 
-  void deleteCeScannerContextOfCeActivityByRootUuid(@Param("rootUuid") String rootUuid);
+  void deleteCeScannerContextOfCeActivityByRootUuidOrBefore(@Nullable @Param("rootUuid") String rootUuid,
+    @Nullable @Param("createdAtBefore") Long createdAtBefore);
 
-  void deleteCeTaskMessageOfCeActivityByRootUuid(@Param("rootUuid") String rootUuid);
+  void deleteCeTaskMessageOfCeActivityByRootUuidOrBefore(@Nullable @Param("rootUuid") String rootUuid,
+    @Nullable @Param("createdAtBefore") Long createdAtBefore);
 
-  void deleteCeActivityByRootUuid(@Param("rootUuid") String rootUuid);
+  /**
+   * Delete rows in CE_ACTIVITY of tasks of the specified component and/or created before specified date.
+   */
+  void deleteCeActivityByRootUuidOrBefore(@Nullable @Param("rootUuid") String rootUuid,
+    @Nullable @Param("createdAtBefore") Long createdAtBefore);
 
   void deleteCeScannerContextOfCeQueueByRootUuid(@Param("rootUuid") String rootUuid);
 

--- a/server/sonar-db-dao/src/main/resources/org/sonar/db/purge/PurgeMapper.xml
+++ b/server/sonar-db-dao/src/main/resources/org/sonar/db/purge/PurgeMapper.xml
@@ -344,64 +344,79 @@
     </foreach>
   </delete>
 
-  <delete id="deleteCeScannerContextOfCeActivityByRootUuid">
+  <delete id="deleteCeScannerContextOfCeActivityByRootUuidOrBefore">
     delete from ce_scanner_context
     where
-      task_uuid in (
-        select
-          uuid
-        from ce_activity
-        where
-          component_uuid=#{rootUuid,jdbcType=VARCHAR}
-          or main_component_uuid=#{rootUuid,jdbcType=VARCHAR}
-      )
+    task_uuid in (
+      select
+        uuid
+      from ce_activity
+      <include refid="whereClauseCeActivityByRootUuidOrBefore" />
+    )
   </delete>
 
-  <delete id="deleteCeTaskCharacteristicsOfCeActivityByRootUuid">
+  <delete id="deleteCeTaskCharacteristicsOfCeActivityByRootUuidOrBefore">
     delete from ce_task_characteristics
     where
-      task_uuid in (
-        select
-          uuid
-        from ce_activity
-        where
-          component_uuid=#{rootUuid,jdbcType=VARCHAR}
-          or main_component_uuid=#{rootUuid,jdbcType=VARCHAR}
-      )
+    task_uuid in (
+      select
+        uuid
+      from ce_activity
+      <include refid="whereClauseCeActivityByRootUuidOrBefore" />
+    )
   </delete>
 
-  <delete id="deleteCeTaskInputOfCeActivityByRootUuid">
+  <delete id="deleteCeTaskInputOfCeActivityByRootUuidOrBefore">
     delete from ce_task_input
     where
-      task_uuid in (
-        select
-          uuid
-        from ce_activity
-        where
-          component_uuid=#{rootUuid,jdbcType=VARCHAR}
-          or main_component_uuid=#{rootUuid,jdbcType=VARCHAR}
-      )
+    task_uuid in (
+      select
+        uuid
+      from ce_activity
+      <include refid="whereClauseCeActivityByRootUuidOrBefore" />
+    )
   </delete>
 
-  <delete id="deleteCeTaskMessageOfCeActivityByRootUuid">
+  <delete id="deleteCeTaskMessageOfCeActivityByRootUuidOrBefore">
     delete from ce_task_message
     where
-      task_uuid in (
-        select
-          uuid
-        from ce_activity
-        where
-          component_uuid=#{rootUuid,jdbcType=VARCHAR}
-          or main_component_uuid=#{rootUuid,jdbcType=VARCHAR}
-      )
+    task_uuid in (
+      select
+        uuid
+      from ce_activity
+      <include refid="whereClauseCeActivityByRootUuidOrBefore" />
+    )
   </delete>
 
-  <delete id="deleteCeActivityByRootUuid">
-      delete from ce_activity
-      where
+  <delete id="deleteCeActivityByRootUuidOrBefore">
+    delete from ce_activity
+      <include refid="whereClauseCeActivityByRootUuidOrBefore" />
+  </delete>
+
+  <sql id="whereClauseCeActivityByRootUuidOrBefore">
+    where
+    <choose>
+      <when test="rootUuid != null and createdAtBefore != null">
+        created_at &lt; #{createdAtBefore,jdbcType=BIGINT}
+        and (
+          component_uuid=#{rootUuid,jdbcType=VARCHAR}
+          or main_component_uuid=#{rootUuid,jdbcType=VARCHAR}
+        )
+      </when>
+      <when test="createdAtBefore != null">
+        created_at &lt; #{createdAtBefore,jdbcType=BIGINT}
+      </when>
+      <when test="rootUuid != null">
         component_uuid=#{rootUuid,jdbcType=VARCHAR}
         or main_component_uuid=#{rootUuid,jdbcType=VARCHAR}
-  </delete>
+      </when>
+      <!-- safety net when both variables are null to never generate a
+           delete statement deleting the whole table -->
+      <otherwise>
+        1 = 2
+      </otherwise>
+    </choose>
+  </sql>
 
   <delete id="deleteCeScannerContextOfCeQueueByRootUuid">
     delete from ce_scanner_context

--- a/server/sonar-web/build.gradle
+++ b/server/sonar-web/build.gradle
@@ -14,18 +14,7 @@ apply plugin: 'com.moowork.node'
 
 def webappDir = "${buildDir}/webapp"
 
-task copyBranding(type: Copy) {
-  into projectDir
-  if (findProject(':private:branding')) {
-    from project(':private:branding').file('.')
-    includeEmptyDirs = false
-  }
-}
-
 yarn_run {
-  if (official) { dependsOn copyBranding }
-  
-  inputs.property('official', official)
   inputs.property('release', release)
   inputs.property('ci', ci)
 

--- a/sonar-application/build.gradle
+++ b/sonar-application/build.gradle
@@ -166,11 +166,20 @@ task zip(type: Zip, dependsOn: [configurations.compile]) {
     from configurations.compile
   }
   into("${archiveDir}/web/") {
+    duplicatesStrategy DuplicatesStrategy.FAIL
     // FIXME use configurations.web with correct artifacts
-    from tasks.getByPath(':server:sonar-web:yarn_run').outputs
+    from(tasks.getByPath(':server:sonar-web:yarn_run').outputs) { a ->
+      if (official) {
+         project(':private:branding').fileTree('src').visit { b ->
+           if (!b.isDirectory) {
+             a.exclude b.relativePath.toString()
+           }
+         }
+      }
+    }
     from tasks.getByPath(':server:sonar-vsts:yarn_run').outputs
     if (official) {
-      from project(':private:branding').file('.')
+      from project(':private:branding').file('src')
     }
   }
   into("${archiveDir}/lib/jdbc/mssql/") {

--- a/travis.sh
+++ b/travis.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 
 ./.travis/setup_ramdisk.sh
 
@@ -36,12 +36,15 @@ case "$TARGET" in
 
 BUILD)
   git fetch --unshallow
-  ./gradlew build sonarqube --no-daemon --console plain \
-  -PjacocoEnabled=true \
-  -Dsonar.projectKey=org.sonarsource.sonarqube:sonarqube \
-  -Dsonar.organization=sonarsource \
-  -Dsonar.host.url=https://sonarcloud.io \
-  -Dsonar.login="$SONAR_TOKEN"
+  ./gradlew build --no-daemon --console plain -PjacocoEnabled=true
+
+  if [[ -n "${SONAR_TOKEN}" ]]; then
+    ./gradlew sonarqube --no-daemon --console plain \
+      -Dsonar.projectKey=org.sonarsource.sonarqube:sonarqube \
+      -Dsonar.organization=sonarsource \
+      -Dsonar.host.url=https://sonarcloud.io \
+      -Dsonar.login="$SONAR_TOKEN"
+  fi
   ;;
 
 WEB_TESTS)


### PR DESCRIPTION
Perfomance and factorising issue.
Use one regex instead of 3 by factorising the matched expression with captured group zero.

First PR, please be kind :-)

For the record: while working on https://community.sonarsource.com/t/new-rule-to-check-if-first-argument-of-string-replaceall-is-really-a-regexp/10085 I was searching if there is some possible use in Sonar.
Found this where each of 3 ".replaceAll" can be replaced by ".replace" (because first argument is not a regex) but then the 3 ".replace" can be replaced by one replaceAll with this time a true regex. :-)
