### PR TITLE
SONAR-12260 - Fix invalid MSSQL delete query

### DIFF
--- a/server/sonar-db-migration/src/main/java/org/sonar/server/platform/db/migration/version/v70/DeleteFileMeasures.java
+++ b/server/sonar-db-migration/src/main/java/org/sonar/server/platform/db/migration/version/v70/DeleteFileMeasures.java
@@ -35,7 +35,7 @@ public class DeleteFileMeasures extends DataChange {
     MassUpdate massUpdate = context.prepareMassUpdate();
     massUpdate.select("select c.uuid from projects c where c.qualifier = 'UTS' or  c.qualifier = 'FIL'");
     massUpdate.rowPluralName("files");
-    massUpdate.update("delete from project_measures pm where pm.component_uuid=?")
+    massUpdate.update("delete from project_measures where component_uuid=?")
       .setBatchSize(10);
 
     massUpdate.execute((row, update) -> {


### PR DESCRIPTION
SONAR-12260 - Fix invalid MSSQL delete query for project_measures

* Original query "delete from project_measures pm where component_uuid=?" was failing on MSSQL v14 with the error "Incorrect syntax near 'pm'.", basically for delete, the pm alias requires an extra pm after the delete keyword. However, for the purpose of this query no alias is needed, therefore refactored without the pm alias which
* Tests already exist in DeleteFileMeasuresTest.java
* Checked also the similar queries from DeletePersonMeasures.java, these are working fine
* Checked all "Delete ... from" queries, there's none using aliases besides the above mentioned ones