### PR TITLE
use stopInfo() instead of stopDebug()

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/ProjectReactorBuilder.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/ProjectReactorBuilder.java
@@ -128,7 +128,7 @@ public class ProjectReactorBuilder {
     rootProjectWorkDir = rootProject.getWorkDir();
     defineChildren(rootProject, propertiesByModuleIdPath, "");
     cleanAndCheckProjectDefinitions(rootProject);
-    profiler.stopDebug();
+    profiler.stopInfo();
     return new ProjectReactor(rootProject);
   }
 


### PR DESCRIPTION
Use stopInfo() instead of stopDebug() for Process project properties, so that the log of scanner are paired.

Please review our [contribution guidelines](https://github.com/SonarSource/sonarqube/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)
