### PR TITLE
Fix typo - JavaGradleTravisSonarCloud.tsx

### DIFF
--- a/server/sonar-web/src/main/js/apps/tutorials/components/commands/TravisSonarCloud/JavaGradleTravisSonarCloud.tsx
+++ b/server/sonar-web/src/main/js/apps/tutorials/components/commands/TravisSonarCloud/JavaGradleTravisSonarCloud.tsx
@@ -48,7 +48,7 @@ script:
     <>
       {getSonarcloudAddonYmlRender(props.organization)}
       <br />
-      {`  script:
+      {`script:
   - ./gradlew sonarqube`}
     </>
   );


### PR DESCRIPTION
## Description
- Delete space in front of script for running analysis

## Motivation
- Configure analysis with Travis Gradle document shows wrong syntax of yml. This could misleading to users to write wrong snippet. So it makes skipping run the script `./gradlew sonarqube`

Please review our [contribution guidelines](https://github.com/SonarSource/sonarqube/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)
