### PR TITLE
feat: Added helpful message with plugin compatibility matrix for upgrades

### DIFF
--- a/server/sonar-server-common/src/main/java/org/sonar/server/plugins/ServerExtensionInstaller.java
+++ b/server/sonar-server-common/src/main/java/org/sonar/server/plugins/ServerExtensionInstaller.java
@@ -110,7 +110,7 @@ public abstract class ServerExtensionInstaller {
       .map(PluginInfo::getName)
       .collect(Collectors.toCollection(TreeSet::new));
     if (!noMoreCompatiblePluginNames.isEmpty()) {
-      throw MessageException.of(format("Plugins '%s' are no more compatible with SonarQube", String.join(", ", noMoreCompatiblePluginNames)));
+      throw MessageException.of(format("Plugins '%s' are no longer compatible with this version of SonarQube. Refer to https://docs.sonarqube.org/latest/instance-administration/plugin-version-matrix/", String.join(", ", noMoreCompatiblePluginNames)));
     }
   }
 

--- a/server/sonar-server-common/src/test/java/org/sonar/server/plugins/ServerExtensionInstallerTest.java
+++ b/server/sonar-server-common/src/test/java/org/sonar/server/plugins/ServerExtensionInstallerTest.java
@@ -71,7 +71,7 @@ public class ServerExtensionInstallerTest {
     ComponentContainer componentContainer = new ComponentContainer();
 
     expectedException.expect(MessageException.class);
-    expectedException.expectMessage("The following plugins 'Github Auth' are no longer compatible with the current SonarQube version. Refer to https://docs.sonarqube.org/latest/instance-administration/plugin-version-matrix/");
+    expectedException.expectMessage("Plugins 'GitHub Auth' are no longer compatible with this version of SonarQube. Refer to https://docs.sonarqube.org/latest/instance-administration/plugin-version-matrix/");
 
     underTest.installExtensions(componentContainer);
   }
@@ -84,7 +84,7 @@ public class ServerExtensionInstallerTest {
     ComponentContainer componentContainer = new ComponentContainer();
 
     expectedException.expect(MessageException.class);
-    expectedException.expectMessage("The following plugins 'Github Auth, LDAP, SAML Auth' are no longer compatible with the current SonarQube version. Refer to https://docs.sonarqube.org/latest/instance-administration/plugin-version-matrix/");
+    expectedException.expectMessage("Plugins 'GitLab Auth, LDAP, SAML Auth' are no longer compatible with this version of SonarQube. Refer to https://docs.sonarqube.org/latest/instance-administration/plugin-version-matrix/");
 
     underTest.installExtensions(componentContainer);
   }
@@ -96,7 +96,7 @@ public class ServerExtensionInstallerTest {
     ComponentContainer componentContainer = new ComponentContainer();
 
     expectedException.expect(MessageException.class);
-    expectedException.expectMessage("Plugins 'SAML Auth' are no more compatible with SonarQube");
+    expectedException.expectMessage("Plugins 'SAML Auth' are no longer compatible with this version of SonarQube. Refer to https://docs.sonarqube.org/latest/instance-administration/plugin-version-matrix/");
 
     underTest.installExtensions(componentContainer);
   }
@@ -108,7 +108,7 @@ public class ServerExtensionInstallerTest {
     ComponentContainer componentContainer = new ComponentContainer();
 
     expectedException.expect(MessageException.class);
-    expectedException.expectMessage("Plugins 'LDAP' are no more compatible with SonarQube");
+    expectedException.expectMessage("Plugins 'LDAP' are no longer compatible with this version of SonarQube. Refer to https://docs.sonarqube.org/latest/instance-administration/plugin-version-matrix/");
 
     underTest.installExtensions(componentContainer);
   }

--- a/server/sonar-server-common/src/test/java/org/sonar/server/plugins/ServerExtensionInstallerTest.java
+++ b/server/sonar-server-common/src/test/java/org/sonar/server/plugins/ServerExtensionInstallerTest.java
@@ -71,7 +71,7 @@ public class ServerExtensionInstallerTest {
     ComponentContainer componentContainer = new ComponentContainer();
 
     expectedException.expect(MessageException.class);
-    expectedException.expectMessage("Plugins 'GitHub Auth' are no more compatible with SonarQube");
+    expectedException.expectMessage("The following plugins 'Github Auth' are no longer compatible with the current SonarQube version. Refer to https://docs.sonarqube.org/latest/instance-administration/plugin-version-matrix/");
 
     underTest.installExtensions(componentContainer);
   }
@@ -84,7 +84,7 @@ public class ServerExtensionInstallerTest {
     ComponentContainer componentContainer = new ComponentContainer();
 
     expectedException.expect(MessageException.class);
-    expectedException.expectMessage("Plugins 'GitLab Auth, LDAP, SAML Auth' are no more compatible with SonarQube");
+    expectedException.expectMessage("The following plugins 'Github Auth, LDAP, SAML Auth' are no longer compatible with the current SonarQube version. Refer to https://docs.sonarqube.org/latest/instance-administration/plugin-version-matrix/");
 
     underTest.installExtensions(componentContainer);
   }


### PR DESCRIPTION
Motive:

After upgrading to 8.x, it wasn't clear that the plugins mentioned have moved to core. Making it a bit easier for newcomers to see a compatibility matrix so they can understand why or why not the plugin is no longer supported (or if it's waiting on a fix). 

A side note, the contributing link in new PRs is outdated/missing. Could we either update the link to the proper section of the readme or would we be open to a contributing.md? :)

Please review our [contribution guidelines](https://github.com/SonarSource/sonarqube/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [N/A] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)
