### PR TITLE
SONAR-10485: Allow configuration of small changeset sizes

### DIFF
--- a/server/sonar-ce-task-projectanalysis/src/test/java/org/sonar/ce/task/projectanalysis/step/QualityGateMeasuresStepTest.java
+++ b/server/sonar-ce-task-projectanalysis/src/test/java/org/sonar/ce/task/projectanalysis/step/QualityGateMeasuresStepTest.java
@@ -31,8 +31,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.ce.task.projectanalysis.component.Component;
+import org.sonar.ce.task.projectanalysis.component.ConfigurationRepository;
 import org.sonar.ce.task.projectanalysis.component.ReportComponent;
 import org.sonar.ce.task.projectanalysis.component.TreeRootHolderRule;
 import org.sonar.ce.task.projectanalysis.measure.Measure;
@@ -55,6 +57,7 @@ import org.sonar.ce.task.step.TestComputationStepContext;
 
 import static com.google.common.collect.ImmutableList.of;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sonar.api.measures.CoreMetrics.ALERT_STATUS_KEY;
@@ -88,8 +91,10 @@ public class QualityGateMeasuresStepTest {
   public MeasureRepositoryRule measureRepository = MeasureRepositoryRule.create(treeRootHolder, metricRepository);
 
   private EvaluationResultTextConverter resultTextConverter = mock(EvaluationResultTextConverter.class);
+  private ConfigurationRepository configurationRepository = mock(ConfigurationRepository.class);
+  private Configuration configuration = mock(Configuration.class);
   private QualityGateMeasuresStep underTest = new QualityGateMeasuresStep(treeRootHolder, qualityGateHolder, qualityGateStatusHolder, measureRepository, metricRepository,
-    resultTextConverter, new SmallChangesetQualityGateSpecialCase(measureRepository, metricRepository));
+    resultTextConverter, new SmallChangesetQualityGateSpecialCase(measureRepository, metricRepository, configurationRepository));
 
   @Before
   public void setUp() {
@@ -109,6 +114,8 @@ public class QualityGateMeasuresStepTest {
         return dumbResultTextAnswer(condition, evaluationResult.getLevel(), evaluationResult.getValue());
       }
     });
+    when(configurationRepository.getConfiguration()).thenReturn(configuration);
+    when(configuration.getInt(anyString())).thenReturn(Optional.empty());
   }
 
   private static String dumbResultTextAnswer(Condition condition, Measure.Level level, Object value) {

--- a/server/sonar-ce/src/test/java/org/sonar/ce/container/ComputeEngineContainerImplTest.java
+++ b/server/sonar-ce/src/test/java/org/sonar/ce/container/ComputeEngineContainerImplTest.java
@@ -130,7 +130,7 @@ public class ComputeEngineContainerImplTest {
           + 27 // level 1
           + 65 // content of DaoModule
           + 3 // content of EsModule
-          + 50 // content of CorePropertyDefinitions
+          + 51 // content of CorePropertyDefinitions
           + 1 // StopFlagContainer
       );
       assertThat(

--- a/sonar-core/src/main/java/org/sonar/core/config/CorePropertyDefinitions.java
+++ b/sonar-core/src/main/java/org/sonar/core/config/CorePropertyDefinitions.java
@@ -173,6 +173,16 @@ public class CorePropertyDefinitions {
         .category(CATEGORY_ORGANIZATIONS)
         .type(BOOLEAN)
         .hidden()
+        .build(),
+
+       //Changeset size
+       PropertyDefinition.builder(CoreProperties.SMALL_CHANGESET_MAX_LINES)
+        .name("Small Changeset Size")
+        .description("Any change containing less than this number of lines will have some metrics excluded from Quality Gate checks")
+        .category(CoreProperties.CATEGORY_GENERAL)
+        .type(PropertyType.INTEGER)
+        .defaultValue("20")
+        .onQualifiers(Qualifiers.PROJECT)
         .build()));
     return defs;
   }

--- a/sonar-core/src/test/java/org/sonar/core/config/CorePropertyDefinitionsTest.java
+++ b/sonar-core/src/test/java/org/sonar/core/config/CorePropertyDefinitionsTest.java
@@ -30,7 +30,7 @@ public class CorePropertyDefinitionsTest {
   @Test
   public void all() {
     List<PropertyDefinition> defs = CorePropertyDefinitions.all();
-    assertThat(defs).hasSize(50);
+    assertThat(defs).hasSize(51);
   }
 
   @Test

--- a/sonar-plugin-api/src/main/java/org/sonar/api/CoreProperties.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/CoreProperties.java
@@ -486,4 +486,9 @@ public interface CoreProperties {
    * @since 7.6
    */
   String MODULE_LEVEL_ARCHIVED_SETTINGS = "sonar.subproject.settings.archived";
+
+  /**
+   * @since 8.2
+   */
+  String SMALL_CHANGESET_MAX_LINES = "sonar.smallchangeset.maxlines";
 }


### PR DESCRIPTION
SONAR-9352 introduced the concept of small changesets to allow the Quality Gate to ignore certain failing conditions where only a small number of lines had changed. This is useful for some scenarios where changes to a single line in code that already contained technical debt would not be feasible to make without large refactoring which would prevent making small changes quickly. However, this allows technical debt to creep into a code-base over time, such as new lines not having any tests to cover them, or code smells being introduced as part of minor changes.

This change introduces a new property to the UI of `sonar.smallchangeset.maxlines`, set at a Global level and allowed to be overridden per project. Any changeset that changes less than this number of lines will continue to have certain metrics excluded from Quality Gate checks, but any change that changes more than this number of lines will have all their metrics checked. To retain backwards-compatibility with the current change-set filtering, the default value treats and changeset with less than 20 lines as a small changeset. Setting this value to `0` would effectivley force all changesets to have all metrics checked, so require all changes to fix any issues that exist on the lines being changed, and not to introduce any new issues.

Please review our [contribution guidelines](https://github.com/SonarSource/sonarqube/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [x] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)
