### PR TITLE
Add config parameter to increase elasticsearch index.max_result_window

### DIFF
--- a/server/sonar-main/src/main/java/org/sonar/application/es/EsSettings.java
+++ b/server/sonar-main/src/main/java/org/sonar/application/es/EsSettings.java
@@ -157,5 +157,11 @@ public class EsSettings {
     if (props.value("sonar.search.javaAdditionalOpts", "").contains("-D" + ALLOW_MMAP + "=false")) {
       builder.put(ALLOW_MMAP, "false");
     }
+
+    // Elasticsearch max results. This might need increasing when there are a lot of issues.
+    String maxResults = props.value("sonar.search.maxResults", "");
+    if (!maxResults.isEmpty()) {
+      builder.put("index.max_result_window", maxResults);
+    }
   }
 }

--- a/server/sonar-main/src/test/java/org/sonar/application/es/EsSettingsTest.java
+++ b/server/sonar-main/src/test/java/org/sonar/application/es/EsSettingsTest.java
@@ -339,6 +339,15 @@ public class EsSettingsTest {
     assertThat(settings.get("node.store.allow_mmapfs")).isEqualTo("false");
   }
 
+  @Test
+  public void increaseElasticsearchMaxResultWindow() throws Exception {
+    Props props = minProps(CLUSTER_DISABLED);
+    props.set("sonar.search.maxResults", "20000");
+    Map<String, String> settings = new EsSettings(props, new EsInstallation(props), System2.INSTANCE).build();
+
+    assertThat(settings.get("index.max_result_window")).isEqualTo("20000");
+  }
+
   private Props minProps(boolean cluster) throws IOException {
     File homeDir = temp.newFolder();
     Props props = new Props(new Properties());

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -276,6 +276,12 @@
 # As a security precaution, should NOT be set to a publicly available address.
 #sonar.search.host=
 
+# Elasticsearch parameter: index.max_result_window
+# Usually, the default should be fine, but for really big projects, some queries might
+# fail with error "Result window is too large" or "Can return only the first 10000 results"
+# Increasing this value might help.
+# sonar.search.maxResults=10000
+
 
 #--------------------------------------------------------------------------------------------------
 # UPDATE CENTER


### PR DESCRIPTION
When fetching over 10000 issues through api ( /api/issues/search?p=21&ps=-1 ), elasticsearch fails with exception `Result window is too large, from + size must be less than or equal to: [10000] but was [10500].` Increasing `index.max_result_window` will allow fetching of all issues for a project. 

For example IntelliJ Idea sonarqube plugin (https://github.com/sonar-intellij-plugin/sonar-intellij-plugin) will fail if there are over 10000 issues in a project..