### PR TITLE
Do not warn if the file is excluded already

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/FileIndexer.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/FileIndexer.java
@@ -98,14 +98,6 @@ public class FileIndexer {
     throws IOException {
     // get case of real file without resolving link
     Path realAbsoluteFile = sourceFile.toRealPath(LinkOption.NOFOLLOW_LINKS).toAbsolutePath().normalize();
-    if (!realAbsoluteFile.startsWith(project.getBaseDir())) {
-      LOG.warn("File '{}' is ignored. It is not located in project basedir '{}'.", realAbsoluteFile.toAbsolutePath(), project.getBaseDir());
-      return;
-    }
-    if (!realAbsoluteFile.startsWith(module.getBaseDir())) {
-      LOG.warn("File '{}' is ignored. It is not located in module basedir '{}'.", realAbsoluteFile.toAbsolutePath(), module.getBaseDir());
-      return;
-    }
     Path projectRelativePath = project.getBaseDir().relativize(realAbsoluteFile);
     Path moduleRelativePath = module.getBaseDir().relativize(realAbsoluteFile);
     boolean included = evaluateInclusionsFilters(moduleExclusionFilters, realAbsoluteFile, projectRelativePath, moduleRelativePath, type);
@@ -116,6 +108,14 @@ public class FileIndexer {
     boolean excluded = evaluateExclusionsFilters(moduleExclusionFilters, realAbsoluteFile, projectRelativePath, moduleRelativePath, type);
     if (excluded) {
       exclusionCounter.increaseByPatternsCount();
+      return;
+    }
+    if (!realAbsoluteFile.startsWith(project.getBaseDir())) {
+      LOG.warn("File '{}' is ignored. It is not located in project basedir '{}'.", realAbsoluteFile.toAbsolutePath(), project.getBaseDir());
+      return;
+    }
+    if (!realAbsoluteFile.startsWith(module.getBaseDir())) {
+      LOG.warn("File '{}' is ignored. It is not located in module basedir '{}'.", realAbsoluteFile.toAbsolutePath(), module.getBaseDir());
       return;
     }
 


### PR DESCRIPTION
This change is only about excessive warnings in the console. We have thousands of these comments in our project because we have a certain folder that is shared between projects.

Even when I exclude the unnecessary files with Sonar, this continues to Log them.