### PR TITLE
Add a CockroachDB dialect

### DIFF
--- a/server/sonar-db-core/src/main/java/org/sonar/db/dialect/CockroachDB.java
+++ b/server/sonar-db-core/src/main/java/org/sonar/db/dialect/CockroachDB.java
@@ -1,0 +1,73 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.db.dialect;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.utils.Version;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class CockroachDB extends AbstractDialect {
+
+    public static final String ID = "cockroachdb";
+    @VisibleForTesting
+    static final List<String> INIT_STATEMENTS = ImmutableList.of("SET standard_conforming_strings=on");
+    private static final Version MIN_SUPPORTED_VERSION = Version.create(19, 1, 0);
+
+    private boolean initialized = false;
+
+    public CockroachDB() {
+        // CockroachDB currently uses the same driver as PostgreSQL.
+        super(ID, "org.postgresql.Driver", "true", "false", "SELECT 1");
+    }
+
+    @Override
+    public boolean matchesJdbcUrl(String jdbcConnectionURL) {
+        return StringUtils.startsWithIgnoreCase(jdbcConnectionURL, "jdbc:cockroachdb:");
+    }
+
+    @Override
+    public List<String> getConnectionInitStatements() {
+        return INIT_STATEMENTS;
+    }
+
+    @Override
+    public boolean supportsMigration() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsUpsert() {
+        checkState(initialized, "onInit() must be called before calling supportsUpsert()");
+        return true;
+    }
+
+    @Override
+    public void init(DatabaseMetaData metaData) throws SQLException {
+        checkState(!initialized, "onInit() must be called once");
+        checkDbVersion(metaData, MIN_SUPPORTED_VERSION);
+        initialized = true;
+    }
+}

--- a/server/sonar-db-core/src/test/java/org/sonar/db/dialect/CockroachDBTest.java
+++ b/server/sonar-db-core/src/test/java/org/sonar/db/dialect/CockroachDBTest.java
@@ -1,0 +1,126 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.db.dialect;
+
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+import org.sonar.api.utils.MessageException;
+import org.sonar.api.utils.log.LogTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CockroachDBTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    @Rule
+    public LogTester logs = new LogTester();
+
+    private CockroachDB underTest = new CockroachDB();
+
+    @Test
+    public void testMatchesJdbcURL() {
+        assertThat(underTest.matchesJdbcUrl("jdbc:cockroachdb://localhost/sonar")).isTrue();
+        assertThat(underTest.matchesJdbcUrl("jdbc:postgresql:foo")).isFalse();
+    }
+
+    @Test
+    public void testShouldSetConnectionProperties() {
+        assertThat(underTest.getConnectionInitStatements()).isEqualTo(CockroachDB.INIT_STATEMENTS);
+    }
+
+    @Test
+    public void testBooleanSqlValues() {
+        assertThat(underTest.getTrueSqlValue()).isEqualTo("true");
+        assertThat(underTest.getFalseSqlValue()).isEqualTo("false");
+    }
+
+    @Test
+    public void testShouldConfigure() {
+        assertThat(underTest.getId()).isEqualTo("cockroachdb");
+        assertThat(underTest.getDefaultDriverClassName()).isEqualTo("org.postgresql.Driver");
+        assertThat(underTest.getValidationQuery()).isEqualTo("SELECT 1");
+    }
+
+    @Test
+    public void testFetchSizeForScrolling() {
+        assertThat(underTest.getScrollDefaultFetchSize()).isEqualTo(200);
+    }
+
+    @Test
+    public void testCockroachDBDoesSupportMigration() {
+        assertThat(underTest.supportsMigration()).isTrue();
+    }
+
+    @Test
+    public void testGetSqlFromDual() {
+        assertThat(underTest.getSqlFromDual()).isEqualTo("");
+    }
+
+    @Test
+    public void testCockroachDB21IsNotSupported() throws Exception {
+        expectedException.expect(MessageException.class);
+        expectedException.expectMessage("Unsupported cockroachdb version: 2.1. Minimal supported version is 19.1.");
+
+        DatabaseMetaData metadata = newMetadata(2, 1);
+        underTest.init(metadata);
+    }
+
+    @Test
+    public void testCockroach191IsSupportedWithUpsert() throws Exception {
+        DatabaseMetaData metadata = newMetadata(19, 1);
+        underTest.init(metadata);
+
+        assertThat(underTest.supportsUpsert()).isTrue();
+    }
+
+    @Test
+    public void testInitThrowsISEIfCalledTwice() throws Exception {
+        DatabaseMetaData metaData = newMetadata(19, 1);
+        underTest.init(metaData);
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("onInit() must be called once");
+
+        underTest.init(metaData);
+    }
+
+    @Test
+    public void testSupportsUpsertThrowsISEIfNotInitialized() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("onInit() must be called before calling supportsUpsert()");
+
+        underTest.supportsUpsert();
+    }
+
+    private DatabaseMetaData newMetadata(int dbMajorVersion, int dbMinorVersion) throws SQLException {
+        DatabaseMetaData metadata = mock(DatabaseMetaData.class, Mockito.RETURNS_DEEP_STUBS);
+        when(metadata.getDatabaseMajorVersion()).thenReturn(dbMajorVersion);
+        when(metadata.getDatabaseMinorVersion()).thenReturn(dbMinorVersion);
+        return metadata;
+    }
+
+}


### PR DESCRIPTION
This dialect allows users to run SonarQube with CockroachDB as a
backend. In general, CockroachDB is compatible with Postgres. Certain
settings and statements differ however. In particular, CockroachDB does
not currently support the `backslash_quote` setting, so this dialect
does not attempt to set it. Also, this dialect uses a JDBC URL prefixed
with `cockroachdb`.

Please review our [contribution guidelines](https://github.com/SonarSource/sonarqube/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [x] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)
