### PR TITLE
docs: Fix "createdBefore" param description in issues/search API

### DIFF
--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/issue/ws/SearchAction.java
@@ -297,7 +297,7 @@ public class SearchAction implements IssuesWsAction {
         "If this parameter is set, createdSince must not be set")
       .setExampleValue("2017-10-19 or 2017-10-19T13:00:00+0200");
     action.createParam(PARAM_CREATED_BEFORE)
-      .setDescription("To retrieve issues created before the given date (inclusive). <br>" +
+      .setDescription("To retrieve issues created before the given date (exclusive). <br>" +
         "Either a date (server timezone) or datetime can be provided.")
       .setExampleValue("2017-10-19 or 2017-10-19T13:00:00+0200");
     action.createParam(PARAM_CREATED_IN_LAST)

--- a/sonar-ws-generator/src/main/resources/snapshot-of-api.json
+++ b/sonar-ws-generator/src/main/resources/snapshot-of-api.json
@@ -1892,7 +1892,7 @@
             },
             {
               "key": "createdBefore",
-              "description": "To retrieve issues created before the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided.",
+              "description": "To retrieve issues created before the given date (exclusive). <br>Either a date (server timezone) or datetime can be provided.",
               "required": false,
               "internal": false,
               "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"

--- a/sonar-ws-generator/src/main/resources/snapshot-of-api.json
+++ b/sonar-ws-generator/src/main/resources/snapshot-of-api.json
@@ -1892,7 +1892,7 @@
             },
             {
               "key": "createdBefore",
-              "description": "To retrieve issues created before the given date (exclusive). <br>Either a date (server timezone) or datetime can be provided.",
+              "description": "To retrieve issues created before the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided.",
               "required": false,
               "internal": false,
               "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"


### PR DESCRIPTION
Parameter "createdBefore" (in `issues/search` API) was being described as `inclusive`, when it is in fact `exclusive`.