### PR TITLE
Fix warning message when minimal version of required plugin is not installed

### DIFF
--- a/server/sonar-webserver-api/src/main/java/org/sonar/server/plugins/ServerPluginRepository.java
+++ b/server/sonar-webserver-api/src/main/java/org/sonar/server/plugins/ServerPluginRepository.java
@@ -248,8 +248,8 @@ public class ServerPluginRepository implements PluginRepository, Startable {
       Version installedRequirementVersion = installedRequirement.getVersion();
       if (installedRequirementVersion != null && requiredPlugin.getMinimalVersion().compareToIgnoreQualifier(installedRequirementVersion) > 0) {
         // it requires a more recent version
-        LOG.warn("Plugin {} [{}] is ignored because the version {} of required plugin [{}] is not supported", plugin.getName(), plugin.getKey(),
-          requiredPlugin.getKey(), requiredPlugin.getMinimalVersion());
+        LOG.warn("Plugin {} [{}] is ignored because the version {} of required plugin [{}] is not installed", plugin.getName(), plugin.getKey(),
+          requiredPlugin.getMinimalVersion(), requiredPlugin.getKey());
         return false;
       }
     }

--- a/server/sonar-webserver-api/src/test/java/org/sonar/server/plugins/ServerPluginRepositoryTest.java
+++ b/server/sonar-webserver-api/src/test/java/org/sonar/server/plugins/ServerPluginRepositoryTest.java
@@ -179,6 +179,7 @@ public class ServerPluginRepositoryTest {
 
     underTest.start();
 
+    assertThat(logs.logs()).contains("Plugin Test Require New Plugin [testrequire] is ignored because the version 0.2 of required plugin [testbase] is not installed");
     // the plugin "requirenew" is not installed as it requires base 0.2+ to be installed.
     assertThat(underTest.getPluginInfosByKeys()).containsOnlyKeys("testbase");
   }


### PR DESCRIPTION
There was a problem with the order of the parameters, and an invalid character was present in the string.