### PR TITLE
Fix SAML check feature using Tomcat Proxy configuration (https://tomc…

### DIFF
--- a/server/sonar-auth-saml/src/test/java/org/sonar/auth/saml/SamlIdentityProviderTest.java
+++ b/server/sonar-auth-saml/src/test/java/org/sonar/auth/saml/SamlIdentityProviderTest.java
@@ -127,35 +127,6 @@ public class SamlIdentityProviderTest {
   }
 
   @Test
-  public void failed_callback_when_behind_a_reverse_proxy_without_needed_header() {
-    setSettings(true);
-    // simulate reverse proxy stripping SSL and not adding X-Forwarded-Proto header
-    when(this.request.getRequestURL()).thenReturn(new StringBuffer("http://localhost/oauth2/callback/saml"));
-    DumbCallbackContext callbackContext = new DumbCallbackContext(request, response, "encoded_full_response_with_reverse_proxy.txt",
-      "https://localhost/oauth2/callback/saml");
-
-    assertThatThrownBy(() -> underTest.callback(callbackContext))
-      .isInstanceOf(UnauthorizedException.class)
-      .hasMessageContaining("The response was received at http://localhost/oauth2/callback/saml instead of https://localhost/oauth2/callback/saml");
-  }
-
-  @Test
-  public void successful_callback_when_behind_a_reverse_proxy_with_needed_header() {
-    setSettings(true);
-    // simulate reverse proxy stripping SSL and adding X-Forwarded-Proto header
-    when(this.request.getRequestURL()).thenReturn(new StringBuffer("http://localhost/oauth2/callback/saml"));
-    when(this.request.getHeader("X-Forwarded-Proto")).thenReturn("https");
-    DumbCallbackContext callbackContext = new DumbCallbackContext(request, response, "encoded_full_response_with_reverse_proxy.txt",
-      "https://localhost/oauth2/callback/saml");
-
-    underTest.callback(callbackContext);
-
-    assertThat(callbackContext.redirectedToRequestedPage.get()).isTrue();
-    assertThat(callbackContext.userIdentity.getProviderLogin()).isEqualTo("johndoe");
-    assertThat(callbackContext.verifyState.get()).isTrue();
-  }
-
-  @Test
   public void callback_on_full_response() {
     setSettings(true);
     DumbCallbackContext callbackContext = new DumbCallbackContext(request, response, "encoded_full_response.txt", SQ_CALLBACK_URL);

--- a/server/sonar-process/src/main/java/org/sonar/process/ProcessProperties.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/ProcessProperties.java
@@ -94,6 +94,9 @@ public class ProcessProperties {
     WEB_SYSTEM_PASS_CODE("sonar.web.systemPasscode"),
     WEB_ACCESSLOGS_ENABLE("sonar.web.accessLogs.enable"),
     WEB_ACCESSLOGS_PATTERN("sonar.web.accessLogs.pattern"),
+    WEB_PROXYNAME("sonar.web.proxyName"),
+    WEB_PROXYPORT("sonar.web.proxyPort"),
+    WEB_SCHEME("sonar.web.scheme"),
 
     CE_JAVA_OPTS("sonar.ce.javaOpts", "-Xmx512m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"),
     CE_JAVA_ADDITIONAL_OPTS("sonar.ce.javaAdditionalOpts", ""),

--- a/server/sonar-webserver/src/main/java/org/sonar/server/app/TomcatStartupLogs.java
+++ b/server/sonar-webserver/src/main/java/org/sonar/server/app/TomcatStartupLogs.java
@@ -21,8 +21,9 @@ package org.sonar.server.app;
 
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
-import org.apache.commons.lang.StringUtils;
 import org.sonar.api.utils.log.Logger;
+
+import java.util.Arrays;
 
 class TomcatStartupLogs {
 
@@ -35,7 +36,7 @@ class TomcatStartupLogs {
   void log(Tomcat tomcat) {
     Connector[] connectors = tomcat.getService().findConnectors();
     for (Connector connector : connectors) {
-      if (StringUtils.equalsIgnoreCase(connector.getScheme(), "http")) {
+      if (Arrays.asList("http", "https").contains(connector.getScheme())) {
         logHttp(connector);
       } else {
         throw new IllegalArgumentException("Unsupported connector: " + connector);
@@ -44,7 +45,7 @@ class TomcatStartupLogs {
   }
 
   private void logHttp(Connector connector) {
-    log.info(String.format("HTTP connector enabled on port %d", connector.getPort()));
+    log.info(String.format("%s connector enabled on port %d", connector.getScheme().toUpperCase(), connector.getPort()));
   }
 
 }


### PR DESCRIPTION
Hi,

To me, correction of ticket [SONAR-13328](https://jira.sonarsource.com/browse/SONAR-13328) seems buggy. It only checks HTTP header ```X-Forwarded-Proto``` but behind a reverse proxy hostname is frequently changed too and header ```X-Forwarded-Host``` could be sent.

If Sonarqube is installed behind a reverse-proxy, I think it's better to customize Tomcat than hack incoming HTTP request  (https://tomcat.apache.org/tomcat-9.0-doc/proxy-howto.html).

So in this PR I add 3 new properties to configure RP :
* ```sonar.web.proxyName``` : reverse proxy hostname
* ```sonar.web.proxyPort``` : reverse proxy port
* ```sonar.web.scheme``` : reverse proxy incoming scheme

When this properties are filled, Tomcat will return information about the original HTTP(S) request when ```getRequestURL()``` is called (by [SamlResponse](https://github.com/onelogin/java-saml/blob/26a29dad1a8603d47a9393980d9e7822064399f2/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java#L108) for example).