### PR TITLE
SONAR-13559 - add workaround for JDK-8014008 (fix JMX console on CE)

### DIFF
--- a/server/sonar-process/src/main/java/org/sonar/process/SecurityManagement.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/SecurityManagement.java
@@ -19,7 +19,10 @@
  */
 package org.sonar.process;
 
+import java.security.CodeSource;
 import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
 import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.security.SecurityPermission;
@@ -66,6 +69,23 @@ public class SecurityManagement {
         }
       }
       return true;
+    }
+
+    // workaround for SONAR-13559 / JDK-8014008
+    // borrowed as-is from https://github.com/elastic/elasticsearch/pull/14274
+    @Override
+    public PermissionCollection getPermissions(CodeSource codesource) {
+        // code should not rely on this method, or at least use it correctly:
+        // https://bugs.openjdk.java.net/browse/JDK-8014008
+        // return them a new empty permissions object so jvisualvm etc work
+        for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+            if ("sun.rmi.server.LoaderHandler".equals(element.getClassName()) &&
+                    "loadClass".equals(element.getMethodName())) {
+                return new Permissions();
+            }
+        }
+        // return UNSUPPORTED_EMPTY_COLLECTION since it is safe.
+        return super.getPermissions(codesource);
     }
 
     String getDomainClassLoaderName(ProtectionDomain domain) {


### PR DESCRIPTION
Fixes [SONAR-13559](https://jira.sonarsource.com/browse/SONAR-13559).

Code borrowed from elastic/elasticsearch#14274 (similar issue in ElasticSearch a few years ago). The same code is still in ES master:
https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java#L122

I don't have unit or integration test. I've only done manual testing:
- 8.4.0.35506, default config, using "jconsole --debug" to connect on the local CE process, I get the exception from SONAR-13559.
- 8.4.0.35506 + this patch, default config, jconsole can connect to the local CE process.
