### PR TITLE
External issues with project scope

### DIFF
--- a/sonar-plugin-api-impl/src/main/java/org/sonar/api/batch/sensor/issue/internal/DefaultExternalIssue.java
+++ b/sonar-plugin-api-impl/src/main/java/org/sonar/api/batch/sensor/issue/internal/DefaultExternalIssue.java
@@ -86,7 +86,6 @@ public class DefaultExternalIssue extends AbstractDefaultIssue<DefaultExternalIs
     requireNonNull(this.engineId, "Engine id is mandatory on external issue");
     requireNonNull(this.ruleId, "Rule id is mandatory on external issue");
     checkState(primaryLocation != null, "Primary location is mandatory on every external issue");
-    checkState(primaryLocation.inputComponent().isFile(), "External issues must be located in files");
     checkState(primaryLocation.message() != null, "External issues must have a message");
     checkState(severity != null, "Severity is mandatory on every external issue");
     checkState(type != null, "Type is mandatory on every external issue");


### PR DESCRIPTION
As with "normal" issues it should be possible to create external issues that belong to the project instead of a single file.

There are cases where an issue can not be assigned to a location in a file. E.g. because it is not known where the issue occurred, e.g. when fuzzy testing the application.