### PR TITLE
Add Gitea to ALM enum

### DIFF
--- a/server/sonar-db-dao/src/main/java/org/sonar/db/alm/setting/ALM.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/alm/setting/ALM.java
@@ -25,7 +25,8 @@ public enum ALM {
   GITHUB,
   BITBUCKET,
   AZURE_DEVOPS,
-  GITLAB;
+  GITLAB,
+  GITEA;
 
   public static ALM fromId(String almId) {
     return ALM.valueOf(almId.toUpperCase(Locale.ENGLISH));

--- a/sonar-ws/src/main/protobuf/ws-alm_settings.proto
+++ b/sonar-ws/src/main/protobuf/ws-alm_settings.proto
@@ -73,6 +73,7 @@ enum Alm {
   azure = 1;
   bitbucket = 2;
   gitlab = 3;
+  gitea = 4;
 }
 
 // WS api/alm_settings/list


### PR DESCRIPTION
These could be minimal required changes needed to be able to implement Gitea as external plugin. Extract from #3248

cc: @pierre-guillot-sonarsource