### PR TITLE
Implemented writeTimeoutMs

### DIFF
--- a/sonar-ws/src/main/java/org/sonarqube/ws/client/BaseRequest.java
+++ b/sonar-ws/src/main/java/org/sonarqube/ws/client/BaseRequest.java
@@ -50,7 +50,8 @@ abstract class BaseRequest<SELF extends BaseRequest> implements WsRequest {
   private final DefaultParameters parameters = new DefaultParameters();
   private final DefaultHeaders headers = new DefaultHeaders();
   private OptionalInt timeOutInMs = OptionalInt.empty();
-
+  private OptionalInt writeTimeOutInMs = OptionalInt.empty();
+  
   BaseRequest(String path) {
     this.path = path;
   }
@@ -72,6 +73,16 @@ abstract class BaseRequest<SELF extends BaseRequest> implements WsRequest {
 
   public SELF setTimeOutInMs(int timeOutInMs) {
     this.timeOutInMs = OptionalInt.of(timeOutInMs);
+    return (SELF) this;
+  }
+
+  @Override
+  public OptionalInt getWriteTimeOutInMs() {
+    return writeTimeOutInMs;
+  }
+
+  public SELF setWriteTimeOutInMs(int writeTimeOutInMs) {
+    this.writeTimeOutInMs = OptionalInt.of(writeTimeOutInMs);
     return (SELF) this;
   }
 

--- a/sonar-ws/src/main/java/org/sonarqube/ws/client/OkHttpClientBuilder.java
+++ b/sonar-ws/src/main/java/org/sonarqube/ws/client/OkHttpClientBuilder.java
@@ -69,6 +69,7 @@ public class OkHttpClientBuilder {
   private String proxyPassword;
   private long connectTimeoutMs = -1;
   private long readTimeoutMs = -1;
+  private long writeTimeoutMs = -1;
   private SSLSocketFactory sslSocketFactory = null;
   private X509TrustManager sslTrustManager = null;
 
@@ -159,6 +160,18 @@ public class OkHttpClientBuilder {
     return this;
   }
 
+  /**
+   * Sets the default write timeout for new connections. A value of 0 means no timeout.
+   * Default is defined by OkHttp (10 seconds in OkHttp 3.3).
+   */
+  public OkHttpClientBuilder setWriteTimeoutMs(long l) {
+    if (l < 0) {
+      throw new IllegalArgumentException("Write timeout must be positive. Got " + l);
+    }
+    this.writeTimeoutMs = l;
+    return this;
+  }
+
   public OkHttpClient build() {
     OkHttpClient.Builder builder = new OkHttpClient.Builder();
     builder.proxy(proxy);
@@ -167,6 +180,9 @@ public class OkHttpClientBuilder {
     }
     if (readTimeoutMs >= 0) {
       builder.readTimeout(readTimeoutMs, TimeUnit.MILLISECONDS);
+    }
+    if (writeTimeoutMs >= 0) {
+      builder.writeTimeout(writeTimeoutMs, TimeUnit.MILLISECONDS);
     }
     builder.addNetworkInterceptor(this::addHeaders);
     if (proxyLogin != null) {

--- a/sonar-ws/src/main/java/org/sonarqube/ws/client/WsRequest.java
+++ b/sonar-ws/src/main/java/org/sonarqube/ws/client/WsRequest.java
@@ -35,6 +35,8 @@ public interface WsRequest {
 
   OptionalInt getTimeOutInMs();
 
+  OptionalInt getWriteTimeOutInMs();
+
   /**
    *
    * In case of multi value parameters, returns the first value


### PR DESCRIPTION
In some cases when Sonar's _Analysis Report_ is big enough, the upload process is failing with a _Session timeout_ error. This happens on big multimodal projects when analysis reports more than 1Mb. Given that nowadays=, many IT people working from home and the connection bandwidth varies a lot, in many cases, the default 10-sec write timeout inherited from OkHttp is not enough.