### PR TITLE
Support space in //NOSONAR

### DIFF
--- a/plugins/sonar-xoo-plugin/src/main/java/org/sonar/xoo/rule/NoSonarSensor.java
+++ b/plugins/sonar-xoo-plugin/src/main/java/org/sonar/xoo/rule/NoSonarSensor.java
@@ -60,7 +60,7 @@ public class NoSonarSensor implements Sensor {
       int[] lineCounter = {1};
       try (Stream<String> stream = Files.lines(inputFile.path(), inputFile.charset())) {
         stream.forEachOrdered(lineStr -> {
-          if (lineStr.contains("//NOSONAR")) {
+          if (lineStr.contains("//NOSONAR") || lineStr.contains("// NOSONAR")) {
             noSonarLines.add(lineCounter[0]);
           }
           lineCounter[0]++;


### PR DESCRIPTION
Currently, SonarQube will suppress issues reported on lines ending with a `//NOSONAR` comment, but does not affect lines ending with `// NOSONAR`.

It looks like this makes it impossible to make use of this feature together with code formatters that expect there to be a space in the middle. In particular, [Google's Java Style formatter](https://github.com/google/google-java-format) always wants there to be a space after the `//`, and deliberately provides no way to configure this behavior.