### PR TITLE
Update install-server.md

### DIFF
--- a/server/sonar-docs/src/pages/setup/install-server.md
+++ b/server/sonar-docs/src/pages/setup/install-server.md
@@ -142,7 +142,7 @@ The user used to launch SonarQube must have read and write access to those direc
 The default port is "9000" and the context path is "/". These values can be changed in _$SONARQUBE-HOME/conf/sonar.properties_:
 
 ```
-sonar.web.host=192.0.0.1
+sonar.web.host=192.168.0.1
 sonar.web.port=80
 sonar.web.context=/sonarqube
 ```


### PR DESCRIPTION
Updated installation documentation to still show an example of a "customized" web host IP without the example being a non-RFC-1918 address to avoid any users accidentally referencing and using that IP address since per best practice security you would never want to be running a server or the service directly on the edge.


SonarSource Team,
Feel free to delete if you feel it is unnecessary.
