### PR TITLE
Expose `revision` in PostProjectAnalysisTaskTester

### DIFF
--- a/sonar-plugin-api/src/main/java/org/sonar/api/ce/posttask/PostProjectAnalysisTaskTester.java
+++ b/sonar-plugin-api/src/main/java/org/sonar/api/ce/posttask/PostProjectAnalysisTaskTester.java
@@ -112,6 +112,8 @@ public class PostProjectAnalysisTaskTester {
   private Branch branch;
   private ScannerContext scannerContext;
   private String analysisUuid;
+  @Nullable
+  private String revision;
   @CheckForNull
   private Map<String, Object> stats;
 
@@ -203,6 +205,14 @@ public class PostProjectAnalysisTaskTester {
     return this;
   }
 
+  /**
+   * @since 8.7
+   */
+  public PostProjectAnalysisTaskTester withRevision(@Nullable String revision) {
+      this.revision = revision;
+      return this;
+  }
+
   public PostProjectAnalysisTask.ProjectAnalysis execute() {
     requireNonNull(ceTask, CE_TASK_CAN_NOT_BE_NULL);
     requireNonNull(project, PROJECT_CAN_NOT_BE_NULL);
@@ -213,6 +223,7 @@ public class PostProjectAnalysisTaskTester {
       analysis = new AnalysisBuilder()
         .setDate(date)
         .setAnalysisUuid(analysisUuid)
+        .setRevision(revision)
         .build();
     }
 


### PR DESCRIPTION
Hi,

it would be very helpful to have the `revision` property accessible via the PostProjectAnalysisTaskTester.

Thanks :)