### PR TITLE
update to tomcat 8.5.63 to remediate CVE-2021-25329

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -317,7 +317,7 @@ subprojects {
         entry 'log4j-to-slf4j'
         entry 'log4j-core'
       }
-      dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.60') {
+      dependencySet(group: 'org.apache.tomcat.embed', version: '8.5.63') {
         entry 'tomcat-embed-core'
         entry('tomcat-embed-jasper') {
           exclude 'org.eclipse.jdt.core.compiler:ecj'


### PR DESCRIPTION
CVE-2021-25329 was opened last week and affects apache tomcat_tomcat-embed-core:8.5.60 This issue is resolved in 8.5.63. 

Requesting an upgrade to 8.5.63 from 8.5.60

Additionally, this resolves CVE-2021-25122 that is present in <8.5.63

