### PR TITLE
Fix incorrect documentation link of maven in analyze project tutorial

### DIFF
--- a/server/sonar-web/src/main/js/components/tutorials/manual/commands/JavaMaven.tsx
+++ b/server/sonar-web/src/main/js/components/tutorials/manual/commands/JavaMaven.tsx
@@ -52,7 +52,7 @@ export default function JavaMaven(props: JavaMavenProps) {
           id="onboarding.analysis.docs"
           values={{
             link: (
-              <Link to="/documentation/analysis/scan/sonarscanner-for-gradle/" target="_blank">
+              <Link to="/documentation/analysis/scan/sonarscanner-for-maven/" target="_blank">
                 {translate('onboarding.analysis.java.maven.docs_link')}
               </Link>
             )

--- a/server/sonar-web/src/main/js/components/tutorials/manual/commands/__tests__/__snapshots__/JavaMaven-test.tsx.snap
+++ b/server/sonar-web/src/main/js/components/tutorials/manual/commands/__tests__/__snapshots__/JavaMaven-test.tsx.snap
@@ -36,7 +36,7 @@ exports[`renders correctly 1`] = `
             onlyActiveOnIndex={false}
             style={Object {}}
             target="_blank"
-            to="/documentation/analysis/scan/sonarscanner-for-gradle/"
+            to="/documentation/analysis/scan/sonarscanner-for-maven/"
           >
             onboarding.analysis.java.maven.docs_link
           </Link>,


### PR DESCRIPTION
In the second step of creating a new project manually, at run analysis on your project part, when you select Maven, the URL in the text "Please visit the official documentation of the Scanner for Maven for more details." was pointing to the Gradle's documentation.

This commit fixes that issue by replacing it with the URL that points to the Maven's documentation.
