### PR TITLE
feat(sonar-scanner-engine): Support for Vela CI

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/ci/vendors/VelaCi.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/ci/vendors/VelaCi.java
@@ -1,0 +1,54 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scanner.ci.vendors;
+
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.ci.CiConfiguration;
+import org.sonar.scanner.ci.CiConfigurationImpl;
+import org.sonar.scanner.ci.CiVendor;
+
+/**
+ * Support https://go-vela.github.io/docs/
+ * <p>
+ * Environment variables are documented at https://go-vela.github.io/docs/reference/environment/variables/
+ */
+public class VelaCi implements CiVendor {
+  private final System2 system;
+
+  public VelaCi(System2 system) {
+    this.system = system;
+  }
+
+  @Override
+  public String getName() {
+    return "VelaCI";
+  }
+
+  @Override
+  public boolean isDetected() {
+    return "vela".equals(system.envVariable("CI"));
+  }
+
+  @Override
+  public CiConfiguration loadConfiguration() {
+    String revision = system.envVariable("VELA_BUILD_COMMIT");
+    return new CiConfigurationImpl(revision, getName());
+  }
+}

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/ProjectScanContainer.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/ProjectScanContainer.java
@@ -55,6 +55,7 @@ import org.sonar.scanner.ci.vendors.Buildkite;
 import org.sonar.scanner.ci.vendors.CircleCi;
 import org.sonar.scanner.ci.vendors.CirrusCi;
 import org.sonar.scanner.ci.vendors.DroneCi;
+import org.sonar.scanner.ci.vendors.VelaCi;
 import org.sonar.scanner.ci.vendors.GithubActions;
 import org.sonar.scanner.ci.vendors.GitlabCi;
 import org.sonar.scanner.ci.vendors.Jenkins;
@@ -295,6 +296,7 @@ public class ProjectScanContainer extends ComponentContainer {
       CircleCi.class,
       CirrusCi.class,
       DroneCi.class,
+      VelaCi.class,
       GithubActions.class,
       GitlabCi.class,
       Jenkins.class,

--- a/sonar-scanner-engine/src/test/java/org/sonar/scanner/ci/vendors/VelaCiTest.java
+++ b/sonar-scanner-engine/src/test/java/org/sonar/scanner/ci/vendors/VelaCiTest.java
@@ -1,0 +1,62 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scanner.ci.vendors;
+
+import org.junit.Test;
+import org.sonar.api.utils.System2;
+import org.sonar.scanner.ci.CiVendor;
+
+import javax.annotation.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VelaCiTest {
+
+  private System2 system = mock(System2.class);
+  private CiVendor underTest = new VelaCi(system);
+
+  @Test
+  public void getName() {
+    assertThat(underTest.getName()).isEqualTo("VelaCI");
+  }
+
+  @Test
+  public void isDetected() {
+    setEnvVariable("CI", "vela");
+    assertThat(underTest.isDetected()).isTrue();
+
+    setEnvVariable("CI", "not-vela");
+    assertThat(underTest.isDetected()).isFalse();
+  }
+
+  @Test
+  public void loadConfiguration() {
+    setEnvVariable("CI", "vela");
+    setEnvVariable("VELA_BUILD_COMMIT", "abd12fc");
+
+    assertThat(underTest.loadConfiguration().getScmRevision()).hasValue("abd12fc");
+  }
+
+  private void setEnvVariable(String key, @Nullable String value) {
+    when(system.envVariable(key)).thenReturn(value);
+  }
+}


### PR DESCRIPTION
Properly identify and retrieve commit information from inside of Vela continuous integration for use in sonar-scanner.

Ref: https://go-vela.github.io/docs/reference/environment/variables/

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed

## Motives

[Vela](https://go-vela.github.io/docs) is a new continuous integration platform and I want to use Sonarqube inside of Vela. Would love to have it be supported. Appreciate any feedback, this PR is roughly a copy and paste of another vendor.