### PR TITLE
Creating specific map capacity and encapsulying others type/subtypes

### DIFF
--- a/sonar-ws/src/main/java/org/sonarqube/ws/MediaTypes.java
+++ b/sonar-ws/src/main/java/org/sonarqube/ws/MediaTypes.java
@@ -29,48 +29,67 @@ import static org.sonarqube.ws.WsUtils.isNullOrEmpty;
  * @since 5.3
  */
 public final class MediaTypes {
-
-  public static final String JSON = "application/json";
-  public static final String XML = "application/xml";
-  public static final String TXT = "text/plain";
-  public static final String PROTOBUF = "application/x-protobuf";
-  public static final String ZIP = "application/zip";
-  public static final String JAVASCRIPT = "application/javascript";
-  public static final String HTML = "text/html";
   public static final String DEFAULT = "application/octet-stream";
+  public static final String HTML = "text/html";
+  public static final String JAVASCRIPT = "application/javascript";
+  public static final String JSON = "application/json";
+  public static final String PROTOBUF = "application/x-protobuf";
   public static final String SVG = "image/svg+xml";
+  public static final String TXT = "text/plain";
+  public static final String XML = "application/xml";
+  public static final String ZIP = "application/zip";
+  private static final String BMP = "image/bmp";
+  private static final String CSS = "text/css";
+  private static final String CSV = "text/csv";
+  private static final String DTD = "application/xml-dtd";
+  private static final String GIF = "image/gif";
+  private static final String ICO = "image/x-icon";
+  private static final String JAR = "application/java-archive";
+  private static final String JNLP = "application/jnlp";
+  private static final String JPEG = "image/jpeg";
+  private static final String JPG = "image/jpeg";
+  private static final String PNG = "image/png";
+  private static final String POSTSCRIPT = "application/postscript";
+  private static final String PPT = "application/vnd.ms-powerpoint";
+  private static final String RTF = "text/rtf";
+  private static final String TAR = "application/x-tar";
+  private static final String TIFF = "image/tiff";
+  private static final String TGZ = "application/tgz";
+  private static final String TSV = "text/tab-separated-values";
+  private static final String XLS = "application/vnd.ms-excel";
+  private static final String XSLT = "application/xslt+xml";
 
-  private static final Map<String, String> MAP = new HashMap<>();
-
+  private static final Map<String, String> MAP;
   static {
+    MAP = new HashMap<>(27);
     MAP.put("js", JAVASCRIPT);
     MAP.put("json", JSON);
     MAP.put("zip", ZIP);
-    MAP.put("tgz", "application/tgz");
-    MAP.put("ps", "application/postscript");
-    MAP.put("jnlp", "application/jnlp");
-    MAP.put("jar", "application/java-archive");
-    MAP.put("xls", "application/vnd.ms-excel");
-    MAP.put("ppt", "application/vnd.ms-powerpoint");
-    MAP.put("tar", "application/x-tar");
+    MAP.put("tgz", TGZ);
+    MAP.put("ps", POSTSCRIPT);
+    MAP.put("jnlp", JNLP);
+    MAP.put("jar", JAR);
+    MAP.put("xls", XLS);
+    MAP.put("ppt", PPT);
+    MAP.put("tar", TAR);
     MAP.put("xml", XML);
-    MAP.put("dtd", "application/xml-dtd");
-    MAP.put("xslt", "application/xslt+xml");
-    MAP.put("bmp", "image/bmp");
-    MAP.put("gif", "image/gif");
-    MAP.put("jpg", "image/jpeg");
-    MAP.put("jpeg", "image/jpeg");
-    MAP.put("tiff", "image/tiff");
-    MAP.put("png", "image/png");
+    MAP.put("dtd", DTD);
+    MAP.put("xslt", XSLT);
+    MAP.put("bmp", BMP);
+    MAP.put("gif", GIF);
+    MAP.put("jpg", JPG);
+    MAP.put("jpeg", JPEG);
+    MAP.put("tiff", TIFF);
+    MAP.put("png", PNG);
     MAP.put("svg", SVG);
-    MAP.put("ico", "image/x-icon");
+    MAP.put("ico", ICO);
     MAP.put("txt", TXT);
-    MAP.put("csv", "text/csv");
+    MAP.put("csv", CSV);
     MAP.put("properties", TXT);
-    MAP.put("rtf", "text/rtf");
+    MAP.put("rtf", RTF);
     MAP.put("html", HTML);
-    MAP.put("css", "text/css");
-    MAP.put("tsv", "text/tab-separated-values");
+    MAP.put("css", CSS);
+    MAP.put("tsv", TSV);
   }
 
   private MediaTypes() {


### PR DESCRIPTION
My suggests are on `cosmetic changes` and `typo fixes`:

1. we're using a map from limited specific elements, maybe should be better creating size fixed Map
2. others type/subtypes weren't encapsuled too.

- [x]  Use the following formatting style: SonarSource/sonar-developer-toolset
- [x] Provide a unit test for any code you changed
- [ ] If there is a JIRA ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

Thank you.