### PR TITLE
Limit gitlab group sync to user's groups

### DIFF
--- a/server/sonar-auth-common/src/main/java/org/sonar/auth/OAuthRestClient.java
+++ b/server/sonar-auth-common/src/main/java/org/sonar/auth/OAuthRestClient.java
@@ -64,7 +64,7 @@ public class OAuthRestClient {
 
   public static <E> List<E> executePaginatedRequest(String request, OAuth20Service scribe, OAuth2AccessToken accessToken, Function<String, List<E>> function) {
     List<E> result = new ArrayList<>();
-    readPage(result, scribe, accessToken, request + "?per_page=" + DEFAULT_PAGE_SIZE, function);
+    readPage(result, scribe, accessToken, request + ((request.contains("?")) ? "&" : "?") + "per_page=" + DEFAULT_PAGE_SIZE, function);
     return result;
   }
 

--- a/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabRestClient.java
+++ b/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabRestClient.java
@@ -46,6 +46,6 @@ public class GitLabRestClient {
   }
 
   List<GsonGroup> getGroups(OAuth20Service scribe, OAuth2AccessToken accessToken) {
-    return OAuthRestClient.executePaginatedRequest(settings.url() + API_SUFFIX + "/groups", scribe, accessToken, GsonGroup::parse);
+    return OAuthRestClient.executePaginatedRequest(settings.url() + API_SUFFIX + "/groups?min_access_level=10", scribe, accessToken, GsonGroup::parse);
   }
 }


### PR DESCRIPTION
The /groups Gitlab API endpoint list all groups related to the Gitlab users, not only the groups on which the user is a member.

For example, if a user is a member of the projet `foo/bar`, the `foo` group will be returned with the current query even if he's not a member of the group.

With group sync enabled, the user will be added on Sonar groups even though he's not member of the Gitlab group.

The query should include the `min_access_level` set to 10 (guest access) to limit the returned list.
