### PR TITLE
Stop using deprecated Gradle API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -461,9 +461,9 @@ subprojects {
 
   jacocoTestReport {
     reports {
-      xml.enabled true
-      csv.enabled false
-      html.enabled false
+      xml.required = true
+      csv.required = false
+      html.required = false
     }
   }
 

--- a/server/sonar-db-dao/build.gradle
+++ b/server/sonar-db-dao/build.gradle
@@ -50,13 +50,13 @@ test {
 }
 
 task dumpSchema(type:JavaExec) {
-    main = 'org.sonar.db.dump.DumpSQSchema'
+    mainClass = 'org.sonar.db.dump.DumpSQSchema'
     classpath = sourceSets.test.runtimeClasspath
 }
 tasks.check.dependsOn dumpSchema
 
 task createDB(type:JavaExec) {
-    main = 'org.sonar.db.createdb.CreateDb'
+    mainClass = 'org.sonar.db.createdb.CreateDb'
     classpath = sourceSets.test.runtimeClasspath
     systemProperty 'orchestrator.configUrl', System.getProperty('orchestrator.configUrl')
     if (!project.version.endsWith("-SNAPSHOT")) {

--- a/server/sonar-db-dao/build.gradle
+++ b/server/sonar-db-dao/build.gradle
@@ -65,7 +65,7 @@ task createDB(type:JavaExec) {
 }
 
 task testJar(type: Jar) {
-  classifier = 'tests'
+  archiveClassifier = 'tests'
   from sourceSets.test.output
 }
 

--- a/sonar-application/build.gradle
+++ b/sonar-application/build.gradle
@@ -229,9 +229,9 @@ zip.doLast {
 
   def length = archiveFile.get().asFile.length()
   if (length < minLength)
-    throw new GradleException("$archiveName size ($length) too small. Min is $minLength")
+    throw new GradleException("${archiveFileName.get()} size ($length) too small. Min is $minLength")
   if (length > maxLength)
-    throw new GradleException("$distsDir/$archiveName size ($length) too large. Max is $maxLength")
+    throw new GradleException("${destinationDirectory.get()}/${archiveFileName.get()} size ($length) too large. Max is $maxLength")
 }
 assemble.dependsOn zip
 

--- a/sonar-application/build.gradle
+++ b/sonar-application/build.gradle
@@ -33,8 +33,8 @@ configurations {
 
 jar.enabled = false
 shadowJar {
-  baseName = 'sonar-application'
-  classifier = null
+  archiveBaseName = 'sonar-application'
+  archiveClassifier = null
   mergeServiceFiles()
   manifest {
     attributes('Main-Class': 'org.sonar.application.App')

--- a/sonar-scanner-protocol/build.gradle
+++ b/sonar-scanner-protocol/build.gradle
@@ -27,9 +27,10 @@ task fatJar(type: Jar) {
   manifest {
     attributes 'Main-Class': 'org.sonar.scanner.protocol.viewer.ScannerReportViewerApp'
   }
-  baseName = project.name + '-all'
+  archiveBaseName.set(project.name + '-all')
   from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
   with jar
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 build.dependsOn fatJar

--- a/sonar-scanner-protocol/build.gradle
+++ b/sonar-scanner-protocol/build.gradle
@@ -27,7 +27,7 @@ task fatJar(type: Jar) {
   manifest {
     attributes 'Main-Class': 'org.sonar.scanner.protocol.viewer.ScannerReportViewerApp'
   }
-  archiveBaseName.set(project.name + '-all')
+  archiveBaseName = project.name + '-all'
   from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
   with jar
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/sonar-ws-generator/build.gradle
+++ b/sonar-ws-generator/build.gradle
@@ -22,7 +22,7 @@ task fatJar(type: Jar) {
   manifest {
     attributes 'Main-Class': 'org.sonarqube.wsgenerator.Generator'
   }
-  classifier = 'jar-with-dependencies'
+  archiveClassifier = 'jar-with-dependencies'
   from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
   with jar
 }


### PR DESCRIPTION
Hello 👋 

I [tried to optimize the Gradle build](https://github.com/KengoTODA/sonarqube/issues/1) of SonarQube and found several rooms to improve.
This PR is to suggest replacing deprecated Gradle API with the latest one. Hope that it will help to upgrade Gradle to 7 and 8 in the future. It should give no impact on build performance and built artifacts.
