### PR TITLE
build: replace compile configuration with proper one

### DIFF
--- a/plugins/sonar-xoo-plugin/build.gradle
+++ b/plugins/sonar-xoo-plugin/build.gradle
@@ -1,5 +1,5 @@
 configurations {
-  testCompile.extendsFrom(compileOnly)
+  testImplementation.extendsFrom(compileOnly)
 }
 
 configureCompileJavaToVersion 8
@@ -31,7 +31,7 @@ jar {
     )
   }
   into('META-INF/lib') {
-    from configurations.compile
+    from configurations.compileClasspath
   }
 }
 

--- a/server/sonar-auth-common/build.gradle
+++ b/server/sonar-auth-common/build.gradle
@@ -1,7 +1,7 @@
 description = 'SonarQube :: Authentication :: Common'
 
 configurations {
-    testCompile.extendsFrom compileOnly
+    testImplementation.extendsFrom compileOnly
 }
 
 dependencies {

--- a/server/sonar-auth-github/build.gradle
+++ b/server/sonar-auth-github/build.gradle
@@ -1,7 +1,7 @@
 description = 'SonarQube :: Authentication :: GitHub'
 
 configurations {
-    testCompile.extendsFrom compileOnly
+    testImplementation.extendsFrom compileOnly
 }
 
 dependencies {

--- a/server/sonar-auth-gitlab/build.gradle
+++ b/server/sonar-auth-gitlab/build.gradle
@@ -1,7 +1,7 @@
 description = 'SonarQube :: Authentication :: GitLab'
 
 configurations {
-    testCompile.extendsFrom compileOnly
+    testImplementation.extendsFrom compileOnly
 }
 
 dependencies {

--- a/server/sonar-auth-ldap/build.gradle
+++ b/server/sonar-auth-ldap/build.gradle
@@ -1,7 +1,7 @@
 description = 'SonarQube :: Authentication :: LDAP'
 
 configurations {
-    testCompile.extendsFrom compileOnly
+    testImplementation.extendsFrom compileOnly
 }
 
 dependencies {

--- a/server/sonar-auth-saml/build.gradle
+++ b/server/sonar-auth-saml/build.gradle
@@ -1,7 +1,7 @@
 description = 'SonarQube :: Authentication :: SAML'
 
 configurations {
-    testCompile.extendsFrom compileOnly
+    testImplementation.extendsFrom compileOnly
 }
 
 ext {

--- a/server/sonar-ce-common/build.gradle
+++ b/server/sonar-ce-common/build.gradle
@@ -25,7 +25,7 @@ processResources {
 }
 
 configurations {
-  testCompile.extendsFrom compileOnly
+  testImplementation.extendsFrom compileOnly
 }
 
 dependencies {

--- a/sonar-application/build.gradle
+++ b/sonar-application/build.gradle
@@ -90,7 +90,7 @@ task downloadElasticSearch(type: Download) {
   finalizedBy verifyElasticSearchDownload
 }
 
-task zip(type: Zip, dependsOn: [configurations.compile, downloadElasticSearch, verifyElasticSearchDownload]) {
+task zip(type: Zip, dependsOn: [configurations.compileClasspath, downloadElasticSearch, verifyElasticSearchDownload]) {
   duplicatesStrategy DuplicatesStrategy.EXCLUDE
   def archiveDir = "sonarqube-$project.version"
 

--- a/sonar-plugin-api/build.gradle
+++ b/sonar-plugin-api/build.gradle
@@ -33,10 +33,9 @@ dependencies {
   testCompile project(':sonar-plugin-api-impl')
 }
 
-sourceSets {
+configurations {
   // Make the compileOnly dependencies available when compiling/running tests
-  test.compileClasspath += configurations.compileOnly + configurations.shadow
-  test.runtimeClasspath += configurations.compileOnly + configurations.shadow
+  testImplementation.extendsFrom compileOnly
 }
 
 def on3Digits(version) {
@@ -54,7 +53,7 @@ processResources {
 }
 
 shadowJar {
-  configurations = [project.configurations.default]
+  configurations = [project.configurations.runtimeClasspath]
   minimize {
     exclude(project(':sonar-check-api'))
   }

--- a/sonar-scanner-engine/build.gradle
+++ b/sonar-scanner-engine/build.gradle
@@ -10,7 +10,7 @@ sourceSets.test.resources {
 }
 
 configurations {
-  testCompile.extendsFrom(compileOnly)
+  testImplementation.extendsFrom(compileOnly)
 }
 
 dependencies {

--- a/sonar-ws/build.gradle
+++ b/sonar-ws/build.gradle
@@ -8,7 +8,7 @@ sonarqube {
 configureCompileJavaToVersion 8
 
 configurations {
-  testCompile.extendsFrom(compileOnly)
+  testImplementation.extendsFrom(compileOnly)
 }
 
 dependencies {


### PR DESCRIPTION
This change is similar to #3276 but change the `configuration`.

1. To resolve the classpath dependency, `compileClasspath` is preferred over `compile`. Refer to [official doc](https://docs.gradle.org/6.8.2/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations) for detail.
2. To resolve the runtime dependency, `runtimeClasspath` is preferred over `default`. Refer to [official doc](https://docs.gradle.org/6.8.2/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations) for detail.
3. `testCompile` is deprecated, so use `testImplementation.extendsFrom compileOnly` to make test code depending on `compileOnly` configuration.