### PR TITLE
add option to enable group sync at parent level

### DIFF
--- a/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabRestClient.java
+++ b/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabRestClient.java
@@ -47,9 +47,9 @@ public class GitLabRestClient {
 
   List<GsonGroup> getGroups(OAuth20Service scribe, OAuth2AccessToken accessToken) {
     if (settings.syncUserGroupsParentLevel()) {
-      return OAuthRestClient.executePaginatedRequest(settings.url() + API_SUFFIX + "/groups?min_access_level=10", scribe, accessToken, GsonGroup::parse);
-    } else {
       return OAuthRestClient.executePaginatedRequest(settings.url() + API_SUFFIX + "/groups", scribe, accessToken, GsonGroup::parse);
+    } else {
+      return OAuthRestClient.executePaginatedRequest(settings.url() + API_SUFFIX + "/groups?min_access_level=10", scribe, accessToken, GsonGroup::parse);
     }
   }
 }

--- a/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabRestClient.java
+++ b/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabRestClient.java
@@ -46,7 +46,7 @@ public class GitLabRestClient {
   }
 
   List<GsonGroup> getGroups(OAuth20Service scribe, OAuth2AccessToken accessToken) {
-    if (gitLabSettings.syncUserGroupsParentLevel()) {
+    if (settings.syncUserGroupsParentLevel()) {
       return OAuthRestClient.executePaginatedRequest(settings.url() + API_SUFFIX + "/groups?min_access_level=10", scribe, accessToken, GsonGroup::parse);
     } else {
       return OAuthRestClient.executePaginatedRequest(settings.url() + API_SUFFIX + "/groups", scribe, accessToken, GsonGroup::parse);

--- a/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabRestClient.java
+++ b/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabRestClient.java
@@ -46,6 +46,10 @@ public class GitLabRestClient {
   }
 
   List<GsonGroup> getGroups(OAuth20Service scribe, OAuth2AccessToken accessToken) {
-    return OAuthRestClient.executePaginatedRequest(settings.url() + API_SUFFIX + "/groups?min_access_level=10", scribe, accessToken, GsonGroup::parse);
+    if (gitLabSettings.syncUserGroupsParentLevel()) {
+      return OAuthRestClient.executePaginatedRequest(settings.url() + API_SUFFIX + "/groups?min_access_level=10", scribe, accessToken, GsonGroup::parse);
+    } else {
+      return OAuthRestClient.executePaginatedRequest(settings.url() + API_SUFFIX + "/groups", scribe, accessToken, GsonGroup::parse);
+    }
   }
 }

--- a/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabSettings.java
+++ b/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabSettings.java
@@ -135,7 +135,7 @@ public class GitLabSettings {
         .defaultValue(valueOf(false))
         .index(6)
         .build(),
-      PropertyDefinition.builder(GITLAB_AUTH_SYNC_USER_GROUPS)
+      PropertyDefinition.builder(GITLAB_AUTH_SYNC_USER_GROUPS_PARENT_LEVEL)
         .name("Synchronize user groups at parent level")
         .description("If enabled, users will be associated to all parents group of his access (if it exists)")
         .category(CATEGORY)

--- a/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabSettings.java
+++ b/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabSettings.java
@@ -134,7 +134,7 @@ public class GitLabSettings {
         .type(PropertyType.BOOLEAN)
         .defaultValue(valueOf(false))
         .index(6)
-        .build()),
+        .build(),
       PropertyDefinition.builder(GITLAB_AUTH_SYNC_USER_GROUPS)
         .name("Synchronize user groups at parent level")
         .description("If enabled, users will be associated to all parents group of his access (if it exists)")

--- a/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabSettings.java
+++ b/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabSettings.java
@@ -38,6 +38,7 @@ public class GitLabSettings {
   public static final String GITLAB_AUTH_SECRET = "sonar.auth.gitlab.secret.secured";
   public static final String GITLAB_AUTH_ALLOW_USERS_TO_SIGNUP = "sonar.auth.gitlab.allowUsersToSignUp";
   public static final String GITLAB_AUTH_SYNC_USER_GROUPS = "sonar.auth.gitlab.groupsSync";
+  public static final String GITLAB_AUTH_SYNC_USER_GROUPS_PARENT_LEVEL = "sonar.auth.gitlab.groupsSyncAtParentLevel";
 
   private static final String CATEGORY = CoreProperties.CATEGORY_ALM_INTEGRATION;
   private static final String SUBCATEGORY = "gitlab";
@@ -74,6 +75,10 @@ public class GitLabSettings {
 
   public boolean syncUserGroups() {
     return configuration.getBoolean(GITLAB_AUTH_SYNC_USER_GROUPS).orElse(false);
+  }
+
+  public boolean syncUserGroupsParentLevel() {
+    return configuration.getBoolean(GITLAB_AUTH_SYNC_USER_GROUPS_PARENT_LEVEL).orElse(false);
   }
 
   static List<PropertyDefinition> definitions() {
@@ -129,6 +134,15 @@ public class GitLabSettings {
         .type(PropertyType.BOOLEAN)
         .defaultValue(valueOf(false))
         .index(6)
+        .build()),
+      PropertyDefinition.builder(GITLAB_AUTH_SYNC_USER_GROUPS)
+        .name("Synchronize user groups at parent level")
+        .description("If enabled, users will be associated to all parents group of his access (if it exists)")
+        .category(CATEGORY)
+        .subCategory(SUBCATEGORY)
+        .type(PropertyType.BOOLEAN)
+        .defaultValue(valueOf(false))
+        .index(7)
         .build());
   }
 }

--- a/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/GitLabModuleTest.java
+++ b/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/GitLabModuleTest.java
@@ -31,7 +31,7 @@ public class GitLabModuleTest {
   public void verify_count_of_added_components() {
     ComponentContainer container = new ComponentContainer();
     new GitLabModule().configure(container);
-    assertThat(container.size()).isEqualTo(COMPONENTS_IN_EMPTY_COMPONENT_CONTAINER + 10);
+    assertThat(container.size()).isEqualTo(COMPONENTS_IN_EMPTY_COMPONENT_CONTAINER + 11);
   }
 
 }

--- a/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/GitLabSettingsTest.java
+++ b/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/GitLabSettingsTest.java
@@ -33,6 +33,7 @@ import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_APPLICATION_ID;
 import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_ENABLED;
 import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_SECRET;
 import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_SYNC_USER_GROUPS;
+import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_SYNC_USER_GROUPS_PARENT_LEVEL;
 import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_URL;
 
 public class GitLabSettingsTest {

--- a/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/GitLabSettingsTest.java
+++ b/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/GitLabSettingsTest.java
@@ -77,5 +77,9 @@ public class GitLabSettingsTest {
     assertThat(config.syncUserGroups()).isFalse();
     settings.setProperty(GITLAB_AUTH_SYNC_USER_GROUPS, true);
     assertThat(config.syncUserGroups()).isTrue();
+
+    assertThat(config.syncUserGroupsParentLevel()).isFalse();
+    settings.setProperty(GITLAB_AUTH_SYNC_USER_GROUPS_PARENT_LEVEL, true);
+    assertThat(config.syncUserGroupsParentLevel()).isTrue();
   }
 }

--- a/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/IntegrationTest.java
+++ b/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/IntegrationTest.java
@@ -41,6 +41,7 @@ import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_APPLICATION_ID;
 import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_ENABLED;
 import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_SECRET;
 import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_SYNC_USER_GROUPS;
+import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_SYNC_USER_GROUPS_PARENT_LEVEL;
 import static org.sonar.auth.gitlab.GitLabSettings.GITLAB_AUTH_URL;
 
 public class IntegrationTest {
@@ -101,6 +102,7 @@ public class IntegrationTest {
   @Test
   public void synchronize_groups() throws InterruptedException {
     mapSettings.setProperty(GITLAB_AUTH_SYNC_USER_GROUPS, "true");
+    mapSettings.setProperty(GITLAB_AUTH_SYNC_USER_GROUPS_PARENT_LEVEL, "false");
     OAuth2IdentityProvider.CallbackContext callbackContext = Mockito.mock(OAuth2IdentityProvider.CallbackContext.class);
     when(callbackContext.getCallbackUrl()).thenReturn("http://server/callback");
 
@@ -130,6 +132,7 @@ public class IntegrationTest {
   @Test
   public void synchronize_groups_on_many_pages() {
     mapSettings.setProperty(GITLAB_AUTH_SYNC_USER_GROUPS, "true");
+    mapSettings.setProperty(GITLAB_AUTH_SYNC_USER_GROUPS_PARENT_LEVEL, "false");
     OAuth2IdentityProvider.CallbackContext callbackContext = Mockito.mock(OAuth2IdentityProvider.CallbackContext.class);
     when(callbackContext.getCallbackUrl()).thenReturn("http://server/callback");
 


### PR DESCRIPTION
Hello,

This PR is regarding an issue we got since version 9.1.
The issue was introduced by this PR ==> https://github.com/SonarSource/sonarqube/pull/3268 (https://jira.sonarsource.com/browse/SONAR-15171)

Let me explain, we have more than 500 developers, they are separated in subgroups like `org_root/business_unit/subgroup`

The rights for the users are not all set at the `org_root/business_unit/subgroup ` level, it can be on a subgroup or a project level.

Before this change, it was working well because all users of  `org_root/business_unit/subgroup` can access all project report on sonarqube.

Just after the 9.1 update, we faced an incident, to resolve this we had to recreate all subgroups under   `org_root/business_unit/subgroup` recursively.

Now we have another issue, it's for a gitlab project that allows a gitlab group to access it and not a user, this access seems not working with Sonarqube access sync.

Is there any change to have an option to enable the old way of sync that was working like a charm for us use case ? 