### PR TITLE
Change log level of "merge base sha1" to info

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/scm/git/GitScmProvider.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scm/git/GitScmProvider.java
@@ -352,7 +352,7 @@ public class GitScmProvider extends ScmProvider {
       }
       RevCommit base = walk.parseCommit(next);
       walk.dispose();
-      LOG.debug("Merge base sha1: {}", base.getName());
+      LOG.info("Merge base sha1: {}", base.getName());
       return Optional.of(base);
     }
   }


### PR DESCRIPTION
This info is too important to be hidden behind debug log level. I've just spent days trying to figure out why SQ doesn't detect new code properly, and it turned out to be because of some misconfiguration which I wouldn't have been able to figure out if not for this piece of info.