### PR TITLE
feat: support configuration of the tomcat keepAliveTimeout

### DIFF
--- a/server/sonar-docs/src/pages/setup/sonar-properties.md
+++ b/server/sonar-docs/src/pages/setup/sonar-properties.md
@@ -93,6 +93,9 @@ The minimum number of threads always kept running. The default value is 5.
 **`SONAR_WEB_HTTP_ACCEPTCOUNT=25`**  
 The maximum queue length for incoming connection requests when all possible request processing threads are in use. Any requests received when the queue is full will be refused. The default value is 25.
 
+**`SONAR_WEB_HTTP_KEEPALIVETIMEOUT=60000`**  
+The number of milliseconds this Connector will wait for another HTTP request before closing the connection. Use a value of -1 to indicate no (i.e. infinite) timeout. The default value is 60000 (ms).
+
 **`SONAR_AUTH_JWTBASE64HS256SECRET=`**  
 By default users are logged out and sessions closed when server is restarted. If you prefer keeping user sessions open, a secret should be defined. Value is HS256 key encoded with base64. It must be unique for each installation of SonarQube. Example of command-line:  
 echo -n "type_what_you_want" | openssl dgst -sha256 -hmac "key" -binary | base64

--- a/server/sonar-process/src/main/java/org/sonar/process/ProcessProperties.java
+++ b/server/sonar-process/src/main/java/org/sonar/process/ProcessProperties.java
@@ -96,6 +96,7 @@ public class ProcessProperties {
     WEB_HTTP_MIN_THREADS("sonar.web.http.minThreads"),
     WEB_HTTP_MAX_THREADS("sonar.web.http.maxThreads"),
     WEB_HTTP_ACCEPT_COUNT("sonar.web.http.acceptCount"),
+    WEB_HTTP_KEEP_ALIVE_TIMEOUT("sonar.web.http.keepAliveTimeout"),
     WEB_SESSION_TIMEOUT_IN_MIN("sonar.web.sessionTimeoutInMinutes"),
     WEB_SYSTEM_PASS_CODE("sonar.web.systemPasscode"),
     WEB_ACCESSLOGS_ENABLE("sonar.web.accessLogs.enable"),

--- a/server/sonar-webserver/src/main/java/org/sonar/server/app/TomcatConnectors.java
+++ b/server/sonar-webserver/src/main/java/org/sonar/server/app/TomcatConnectors.java
@@ -29,6 +29,7 @@ import static org.sonar.process.ProcessProperties.Property.WEB_HOST;
 import static org.sonar.process.ProcessProperties.Property.WEB_HTTP_ACCEPT_COUNT;
 import static org.sonar.process.ProcessProperties.Property.WEB_HTTP_MAX_THREADS;
 import static org.sonar.process.ProcessProperties.Property.WEB_HTTP_MIN_THREADS;
+import static org.sonar.process.ProcessProperties.Property.WEB_HTTP_KEEP_ALIVE_TIMEOUT;
 
 /**
  * Configuration of Tomcat connectors
@@ -82,6 +83,7 @@ class TomcatConnectors {
     connector.setProperty("minSpareThreads", String.valueOf(props.valueAsInt(WEB_HTTP_MIN_THREADS.getKey(), 5)));
     connector.setProperty("maxThreads", String.valueOf(props.valueAsInt(WEB_HTTP_MAX_THREADS.getKey(), 50)));
     connector.setProperty("acceptCount", String.valueOf(props.valueAsInt(WEB_HTTP_ACCEPT_COUNT.getKey(), 25)));
+    connector.setProperty("keepAliveTimeout", String.valueOf(props.valueAsInt(WEB_HTTP_KEEP_ALIVE_TIMEOUT.getKey(), 60000)));
   }
 
   private static void configureCompression(Connector connector) {

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -124,7 +124,7 @@
 # The number of milliseconds this Connector will wait for another HTTP request before closing the 
 # connection. The default value is to use the value that has been set for the connectionTimeout 
 # attribute. Use a value of -1 to indicate no (i.e. infinite) timeout.
-# The default value is 25.
+# The default value is 60000 (ms).
 #sonar.web.http.keepAliveTimeout=60000
 
 # By default users are logged out and sessions closed when server is restarted.

--- a/sonar-application/src/main/assembly/conf/sonar.properties
+++ b/sonar-application/src/main/assembly/conf/sonar.properties
@@ -121,6 +121,12 @@
 # The default value is 25.
 #sonar.web.http.acceptCount=25
 
+# The number of milliseconds this Connector will wait for another HTTP request before closing the 
+# connection. The default value is to use the value that has been set for the connectionTimeout 
+# attribute. Use a value of -1 to indicate no (i.e. infinite) timeout.
+# The default value is 25.
+#sonar.web.http.keepAliveTimeout=60000
+
 # By default users are logged out and sessions closed when server is restarted.
 # If you prefer keeping user sessions open, a secret should be defined. Value is
 # HS256 key encoded with base64. It must be unique for each installation of SonarQube.


### PR DESCRIPTION
- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [x] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

Hello,

This PR is opened in relation to https://community.sonarsource.com/t/need-ability-to-configure-tomcat-keepalivetimeout/59654

Google Cloud Platform [requires a >10 minute keepAliveTimeout](https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries), Sonar ships with the default 60 seconds. I hope this is a simple change which can be considered.

Thank you