### PR TITLE
CPP-3687 Rename *-manual-sq to *-otherci-sq

### DIFF
--- a/server/sonar-web/src/main/js/components/tutorials/components/GithubCFamilyExampleRepositories.tsx
+++ b/server/sonar-web/src/main/js/components/tutorials/components/GithubCFamilyExampleRepositories.tsx
@@ -42,8 +42,8 @@ const CI_SEARCH_MAP = {
   [TutorialModes.GitHubActions]: 'gh-actions',
   [TutorialModes.GitLabCI]: 'gitlab',
   [TutorialModes.BitbucketPipelines]: 'bitbucket',
-  [TutorialModes.Manual]: 'manual',
-  [TutorialModes.OtherCI]: 'manual'
+  [TutorialModes.Manual]: 'otherci',
+  [TutorialModes.OtherCI]: 'otherci'
 };
 
 export default function GithubCFamilyExampleRepositories(


### PR DESCRIPTION
We have renamed the *-manual-sq examples to *-otherci-sq for consistency with the *-otherci-sc examples in the https://github.com/sonarsource-cfamily-examples organization.
