### PR TITLE
feat(charset): exclude PostGIS tables on verify database charset

### DIFF
--- a/server/sonar-db-migration/src/main/java/org/sonar/server/platform/db/migration/charset/PostgresCharsetHandler.java
+++ b/server/sonar-db-migration/src/main/java/org/sonar/server/platform/db/migration/charset/PostgresCharsetHandler.java
@@ -72,6 +72,7 @@ class PostgresCharsetHandler extends CharsetHandler {
       "from information_schema.columns " +
       "where table_schema='public' " +
       "and udt_name='varchar' " +
+      "and table_name NOT LIKE '%_columns' " + // exclude PostGIS tables
       "order by table_name, column_name", new SqlExecutor.StringsConverter(3 /* columns returned by SELECT */));
     Set<String> errors = new LinkedHashSet<>();
     for (String[] row : rows) {


### PR DESCRIPTION
Hello, 
I use PostGIS (spatial database extender for [PostgreSQL]) who must create specific view in database.

the problem:
`nested exception is Database columns [geometry_columns.f_table_catalog] must have UTF8 charset.` 
In my PR I suggest to exclude specific view of PostGIS.

Thank You!
