### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+sonarqube9.4 metric new_lines has a bug ,when I scan my project new_lines=18,655, but after I  increase 147 lines ，I scan again new_lines=18803,
+Normally it would be 147。
+![image](https://user-images.githubusercontent.com/4475925/183040463-5c59cb10-f02d-4a43-bddf-bee58c10aaf0.png)
+![image](https://user-images.githubusercontent.com/4475925/183041099-b7e6a003-ea1a-4bbd-8fd0-00bd204e4f55.png)
+
+
 SonarQube [![Build Status](https://app.travis-ci.com/SonarSource/sonarqube.svg?branch=master)](https://app.travis-ci.com/SonarSource/sonarqube) [![Quality Gate Status](https://next.sonarqube.com/sonarqube/api/project_badges/measure?project=sonarqube&metric=alert_status&token=d95182127dd5583f57578d769b511660601a8547)](https://next.sonarqube.com/sonarqube/dashboard?id=sonarqube)
 =========
 


### PR DESCRIPTION
sonarqube9.4 metric new_lines has a bug ,when I scan my project new_lines=18,655, but after I  increase 147 lines ，I scan again new_lines=18803,
Normally it would be 147。

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing (Travis build is executed for each pull request):

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
