### PR TITLE
Reset %errorlevel% after checks in batch scripts

### DIFF
--- a/sonar-application/src/main/assembly/bin/windows-x86-64/StartSonar.bat
+++ b/sonar-application/src/main/assembly/bin/windows-x86-64/StartSonar.bat
@@ -63,7 +63,7 @@ goto:eof
         echo ERROR: Another instance of the SonarQube application is already running with PID %SQ_PROCESS%
         exit /b 1
     )
-    goto:eof
+    exit /b 0
 
 endlocal
 

--- a/sonar-application/src/main/assembly/bin/windows-x86-64/lib/find_java.bat
+++ b/sonar-application/src/main/assembly/bin/windows-x86-64/lib/find_java.bat
@@ -26,7 +26,7 @@ rem Returns an error code if Java executable is not found in the PATH and the en
         echo ERROR: java.exe not found. Please make sure that the environmental variable SONAR_JAVA_PATH points to the Java executable.
         exit /b 1
     )
-    goto:eof
+    exit /b 0
 
 :exit
 exit /b


### PR DESCRIPTION
When trying to start SonarQube 9.6.1 on Windows using the SonarStart.bat nothing happens:

![image](https://user-images.githubusercontent.com/13829/188248078-a954676a-42b7-41b9-b0bb-ec8560f86987.png)

**Cause:**

This issue happens when the executables `jps.exe` or `java.exe` are not present on PATH. Examples:

```
C:\>where jps
INFO: Could not find files for the given pattern(s)

C:\>where java
INFO: Could not find files for the given pattern(s)
```

The `jps.exe` command is part of the Java installation but it isn't added on the PATH by default on Windows and there's no indication on the SonarQube docs that it's required.

When the `where` command fails in the batch script the `%errorlevel%` is set to `1` and, even if all checks succeeded, the subroutines of the batch files still fails because when they end the `%errorlevel%` is different than 0.

**FIX:**

The proposed change simply replaces the `goto:eof` on :check_if_sonar_is_running and :set_java_exe by `exit /b 0`, so these subroutines will return the error code `0` in case of success instead of returning the error code returned by the `where` command.

**Result:**

After the changes the SonarQube server starts normally:

<img width="754" alt="image" src="https://user-images.githubusercontent.com/13829/188250557-84bac9ed-051b-4b13-9e92-51beac260ebb.png">
