### PR TITLE
Documentation: change SONARQUBE-HOME to SONARQUBE_HOME

### DIFF
--- a/server/sonar-docs/src/pages/instance-administration/authentication/http-header.md
+++ b/server/sonar-docs/src/pages/instance-administration/authentication/http-header.md
@@ -15,6 +15,6 @@ The tool that handles the authentication should:
 
 ![HTTP Header Authentication flow](/images/http-header-authentication.png)
 
-All the parameters required to activate and configure this feature are available in SonarQube server configuration file (in _$SONARQUBE-HOME/conf/sonar.properties_).
+All the parameters required to activate and configure this feature are available in SonarQube server configuration file (in _$SONARQUBE_HOME/conf/sonar.properties_).
 
 Using Http header authentication is an easy way integrate your SonarQube deployment with an in-house SSO implementation.

--- a/server/sonar-docs/src/pages/instance-administration/authentication/ldap.md
+++ b/server/sonar-docs/src/pages/instance-administration/authentication/ldap.md
@@ -3,7 +3,7 @@ title: LDAP
 url: /instance-administration/authentication/ldap/
 ---
 
-You can configure SonarQube authentication and authorization to an LDAP server (including LDAP Service of Active Directory) by configuring the correct values in _$SONARQUBE-HOME/conf/sonar.properties_.
+You can configure SonarQube authentication and authorization to an LDAP server (including LDAP Service of Active Directory) by configuring the correct values in _$SONARQUBE_HOME/conf/sonar.properties_.
 
 The main features are:
 
@@ -25,7 +25,7 @@ GSSAPI|![](/images/check.svg)|  |  |
 ![](/images/check.svg) = successfully tested
 
 ## Setup
-1. Configure LDAP by editing _$SONARQUBE-HOME/conf/sonar.properties_ (see table below)
+1. Configure LDAP by editing _$SONARQUBE_HOME/conf/sonar.properties_ (see table below)
 2. Restart the SonarQube server and check the log file for:
 ```
 INFO org.sonar.INFO Security realm: LDAP ...
@@ -129,4 +129,4 @@ If you are changing your delegated authentication method and migrating existing 
 * Detailed connection logs (and potential error codes received from LDAP server) are output to SonarQube's _$SONARQUBE_HOME/logs/web.log_, when logging is in `DEBUG` mode.
 
 * Time out when running SonarQube analysis using LDAP
-Java parameters are documented here: http://docs.oracle.com/javase/jndi/tutorial/ldap/connect/config.html. Such parameters can be set in `sonar.web.javaAdditionalOpts` in _$SONARQUBE-HOME/conf/sonar.properties_.
+Java parameters are documented here: http://docs.oracle.com/javase/jndi/tutorial/ldap/connect/config.html. Such parameters can be set in `sonar.web.javaAdditionalOpts` in _$SONARQUBE_HOME/conf/sonar.properties_.

--- a/server/sonar-docs/src/pages/instance-administration/marketplace.md
+++ b/server/sonar-docs/src/pages/instance-administration/marketplace.md
@@ -39,10 +39,10 @@ If you're using a commercial edition or your server doesn't have internet access
 
 To see what plugins are available and which version of a plugin is appropriate for your server, use the [plugin version matrix](/instance-administration/plugin-version-matrix/), which is kept up to date with current plugin availability and compatibility.
 
-To install a plugin, simply download it using the manual download link on the plugin documentation page, place it in `$SONARQUBE-HOME/extensions/plugins`, and restart the server.
+To install a plugin, simply download it using the manual download link on the plugin documentation page, place it in `$SONARQUBE_HOME/extensions/plugins`, and restart the server.
 
 ### Stopping the Marketplace from searching for plugin updates
-Your SonarQube server needs internet access for the Marketplace to search for plugin updates. If your server doesn't have internet access, you may get errors in your logs when the Marketplace tries to search for new plugins. You can stop this by updating `sonar.updatecenter.activate` in `$SONARQUBE-HOME/conf/sonar.properties`.
+Your SonarQube server needs internet access for the Marketplace to search for plugin updates. If your server doesn't have internet access, you may get errors in your logs when the Marketplace tries to search for new plugins. You can stop this by updating `sonar.updatecenter.activate` in `$SONARQUBE_HOME/conf/sonar.properties`.
 
 ## Which URLs does the Marketplace connect to?
 The SonarQube Marketplace connects to https://update.sonarsource.org/ to get the list of plugins. Most of the referenced plugins are downloaded from:
@@ -50,7 +50,7 @@ The SonarQube Marketplace connects to https://update.sonarsource.org/ to get the
 * https://github.com/
 
 ## Using the Marketplace behind a Proxy
-Marketplace uses HTTP(S) connections to external servers to provide these services. If SonarQube is located behind a proxy, additional information must be provided in the _$SONARQUBE-HOME/conf/sonar.properties_ configuration file:
+Marketplace uses HTTP(S) connections to external servers to provide these services. If SonarQube is located behind a proxy, additional information must be provided in the _$SONARQUBE_HOME/conf/sonar.properties_ configuration file:
 ```
 http.proxyHost=<your.proxy.host>
 http.proxyPort=<yout.proxy.port>

--- a/server/sonar-docs/src/pages/instance-administration/monitoring.md
+++ b/server/sonar-docs/src/pages/instance-administration/monitoring.md
@@ -17,7 +17,7 @@ The SonarQube application server consists of three main Java processes:
 * Elasticsearch
 * Web (including embedded web server)
 
-Each of these Java processes has its own memory settings that can be configured in the _$SONARQUBE-HOME/conf/sonar.properties_ file. The default memory settings that ship with SonarQube are fine for most instances. If you are supporting a large SonarQube instance (more than 100 users or more than 5,000,000 lines of code) or an instance that is part of your Continuous Integration pipeline, you should monitor the memory and CPU usage of all three key Java processes on your instance, along with overall disk space. Monitoring will allow you to see if any of the processes is running short of resources and take action ahead of resource shortages. There are numerous monitoring tools available, both open source and commercial, to help you with this task. SonarSource does not recommend or endorse any particular tool.
+Each of these Java processes has its own memory settings that can be configured in the _$SONARQUBE_HOME/conf/sonar.properties_ file. The default memory settings that ship with SonarQube are fine for most instances. If you are supporting a large SonarQube instance (more than 100 users or more than 5,000,000 lines of code) or an instance that is part of your Continuous Integration pipeline, you should monitor the memory and CPU usage of all three key Java processes on your instance, along with overall disk space. Monitoring will allow you to see if any of the processes is running short of resources and take action ahead of resource shortages. There are numerous monitoring tools available, both open source and commercial, to help you with this task. SonarSource does not recommend or endorse any particular tool.
 
 ## Memory settings
 
@@ -28,7 +28,7 @@ You may need to increase your memory settings if you see the following symptoms:
 * A SonarQube background task fails with an out-of-memory error in the background task log
 * The store size of the Issues index of your Elasticsearch instance (visible in the System Info) is greater than or equal to the memory allocated to the Elasticsearch Java process
 
-You can increase the maximum memory allocated to the appropriate process by increasing the  -Xmx memory setting for the corresponding Java process in your _$SONARQUBE-HOME/conf/sonar.properties_ file:
+You can increase the maximum memory allocated to the appropriate process by increasing the  -Xmx memory setting for the corresponding Java process in your _$SONARQUBE_HOME/conf/sonar.properties_ file:
 
 Java Process | SonarQube Property | Notes
 --- | --- | ---

--- a/server/sonar-docs/src/pages/instance-administration/notifications.md
+++ b/server/sonar-docs/src/pages/instance-administration/notifications.md
@@ -4,7 +4,7 @@ url: /instance-administration/notifications/
 ---
 At the end of each analysis, notifications are computed for each subscribed user. Then, asynchronously, these notifications are sent via email.
 
-To set the frequency with which the notification queue is processed, set `the sonar.notifications.delay` property (in seconds) in _$SONARQUBE-HOME/conf/sonar.properties_. The server must be restarted for the new value to be taken into account.
+To set the frequency with which the notification queue is processed, set `the sonar.notifications.delay` property (in seconds) in _$SONARQUBE_HOME/conf/sonar.properties_. The server must be restarted for the new value to be taken into account.
 
 ## Who gets notifications
 Only users who subscribe themselves will get notifications. With only one exception, there is no admin functionality to proactively subscribe another user. If you believe a user should be receiving notifications, then it's time to practice the gentle art of persuasion.

--- a/server/sonar-docs/src/pages/instance-administration/security.md
+++ b/server/sonar-docs/src/pages/instance-administration/security.md
@@ -204,14 +204,14 @@ The encryption algorithm used is AES with 256 bit keys.
 1. **Generate the secret key**  
 A unique secret key must be shared between all parts of the SonarQube infrastructure. To generate it, go to **[Administration > Configuration > Encryption](/#sonarqube-admin#/admin/settings/encryption)** and click on Generate Secret Key.
 1. **Store the secret key on the SonarQube server**  
-   * Copy the generated secret key to a file on the machine hosting the SonarQube server. The default location is _~/.sonar/sonar-secret.txt_. If you want to store it somewhere else, set its path through the `sonar.secretKeyPath` property in _$SONARQUBE-HOME/conf/sonar.properties_
+   * Copy the generated secret key to a file on the machine hosting the SonarQube server. The default location is _~/.sonar/sonar-secret.txt_. If you want to store it somewhere else, set its path through the `sonar.secretKeyPath` property in _$SONARQUBE_HOME/conf/sonar.properties_
    * Restrict file permissions to the account running the SonarQube server (ownership and read-access only).
    * Restart your SonarQube server
 1. **Generate the encrypted values of your settings**  
 Go back to **[Administration > Configuration > Encryption](/#sonarqube-admin#/admin/settings/encryption)** and use the form that has been added to the interface to generated encrypted versions of your values.
 ![Encrypt values through the admin interface](/images/encrypt-value.png)
 1. **Use the encrypted values in your SonarQube server configuration**  
-Encrypted values can either be set in SonarQube or copied into _$SONARQUBE-HOME/conf/sonar.properties_:
+Encrypted values can either be set in SonarQube or copied into _$SONARQUBE_HOME/conf/sonar.properties_:
    ```
    sonar.jdbc.password={aes-gcm}CCGCFg4Xpm6r+PiJb1Swfg==  # Encrypted DB password
    ...

--- a/server/sonar-docs/src/pages/instance-administration/system-info.md
+++ b/server/sonar-docs/src/pages/instance-administration/system-info.md
@@ -17,7 +17,7 @@ Additionally, if you have a Support contract, you might be asked by a Support re
 Your server id can be obtained from this page by expanding the **System** section. If you're running a commercial instance, you can also find this value on the License page (**[Administration > Configuration > License Manager](/#sonarqube-admin#/admin/extension/license/app)**)
 
 ## Logs
-Server-side logging is controlled by properties set in _$SONARQUBE-HOME/conf/sonar.properties_.
+Server-side logging is controlled by properties set in _$SONARQUBE_HOME/conf/sonar.properties_.
 
 4 logs files are created: one per SonarQube process.
 
@@ -47,7 +47,7 @@ To control log rolling, use the `sonar.log.rollingPolicy`
 
 ### UI Access to Logs and Log Levels
 
-The System Info page gives you the ability to download your instance's current log files (log files rotate on a regular basis), and to tune the log level via controls at the top of the page. Changes made here are temporary, and last only until the next time the instance is restarted, at which point the level will be reset to the more permanent value set in _$SONARQUBE-HOME/conf/sonar.properties_. Regardless, if you change your log level _from_ `INFO`, but sure to change it back as soon as is practical; log files can get very large very quickly at lower log levels.
+The System Info page gives you the ability to download your instance's current log files (log files rotate on a regular basis), and to tune the log level via controls at the top of the page. Changes made here are temporary, and last only until the next time the instance is restarted, at which point the level will be reset to the more permanent value set in _$SONARQUBE_HOME/conf/sonar.properties_. Regardless, if you change your log level _from_ `INFO`, but sure to change it back as soon as is practical; log files can get very large very quickly at lower log levels.
 
 ## Total Lines of Code
 The number of Lines of Code (for licensing purposes) in an instance can be found in the **System** section of the System Info page on, and on the License page (**[Administration > Configuration > License Manager](/#sonarqube-admin#/admin/extension/license/app)** in commercial editions. 

--- a/server/sonar-docs/src/pages/instance-administration/telemetry.md
+++ b/server/sonar-docs/src/pages/instance-administration/telemetry.md
@@ -20,7 +20,7 @@ If you suspect the telemetry is collecting sensitive data or the data is being i
 
 ## Turning it off
 
-You can disable telemetry at any time by setting the `sonar.telemetry.enabled` property to `false` in `$SONARQUBE-HOME/conf/sonar.properties`.
+You can disable telemetry at any time by setting the `sonar.telemetry.enabled` property to `false` in `$SONARQUBE_HOME/conf/sonar.properties`.
 By default, it is set to `true`.
 
 

--- a/server/sonar-docs/src/pages/setup/install-plugin.md
+++ b/server/sonar-docs/src/pages/setup/install-plugin.md
@@ -36,5 +36,5 @@ To manually install a plugin:
 ## Uninstalling plugins
 
 To uninstall a plugin:
-1. Delete the plugin from the `$SONARQUBE-HOME/extensions/plugins` folder.
+1. Delete the plugin from the `$SONARQUBE_HOME/extensions/plugins` folder.
 2. Restart your SonarQube server.

--- a/server/sonar-docs/src/pages/setup/install-server.md
+++ b/server/sonar-docs/src/pages/setup/install-server.md
@@ -106,11 +106,11 @@ First, check the [requirements](/requirements/requirements/). Then download and 
 
 SonarQube cannot be run as `root` on Unix-based systems, so create a dedicated user account for SonarQube if necessary.
 
-_$SONARQUBE-HOME_ (below) refers to the path to the directory where the SonarQube distribution has been unzipped.
+_$SONARQUBE_HOME_ (below) refers to the path to the directory where the SonarQube distribution has been unzipped.
 
 ### Setting the Access to the Database
 
-Edit _$SONARQUBE-HOME/conf/sonar.properties_ to configure the database settings. Templates are available for every supported database. Just uncomment and configure the template you need and comment out the lines dedicated to H2:
+Edit _$SONARQUBE_HOME/conf/sonar.properties_ to configure the database settings. Templates are available for every supported database. Just uncomment and configure the template you need and comment out the lines dedicated to H2:
 
 ```
 Example for PostgreSQL
@@ -123,13 +123,13 @@ sonar.jdbc.url=jdbc:postgresql://localhost/sonarqube
 
 Drivers for the supported databases (except Oracle) are already provided. Do not replace the provided drivers; they are the only ones supported.
 
-For Oracle, copy the JDBC driver into _$SONARQUBE-HOME/extensions/jdbc-driver/oracle_.
+For Oracle, copy the JDBC driver into _$SONARQUBE_HOME/extensions/jdbc-driver/oracle_.
 
 ### Configuring the Elasticsearch storage path
 
-By default, Elasticsearch data is stored in _$SONARQUBE-HOME/data_, but this is not recommended for production instances. Instead, you should store this data elsewhere, ideally in a dedicated volume with fast I/O. Beyond maintaining acceptable performance, doing so will also ease the upgrade of SonarQube.
+By default, Elasticsearch data is stored in _$SONARQUBE_HOME/data_, but this is not recommended for production instances. Instead, you should store this data elsewhere, ideally in a dedicated volume with fast I/O. Beyond maintaining acceptable performance, doing so will also ease the upgrade of SonarQube.
 
-Edit _$SONARQUBE-HOME/conf/sonar.properties_ to configure the following settings:
+Edit _$SONARQUBE_HOME/conf/sonar.properties_ to configure the following settings:
 
 ```
 sonar.path.data=/var/sonarqube/data
@@ -140,7 +140,7 @@ The user used to launch SonarQube must have read and write access to those direc
 
 ### Starting the Web Server
 
-The default port is "9000" and the context path is "/". These values can be changed in _$SONARQUBE-HOME/conf/sonar.properties_:
+The default port is "9000" and the context path is "/". These values can be changed in _$SONARQUBE_HOME/conf/sonar.properties_:
 
 ```
 sonar.web.host=192.168.0.1

--- a/server/sonar-docs/src/pages/setup/operate-cluster.md
+++ b/server/sonar-docs/src/pages/setup/operate-cluster.md
@@ -86,7 +86,7 @@ In addition, we provide a Web API _api/system/health_ you can use to validate th
 * YELLOW: SonarQube is usable, but it needs attention in order to be fully operational
 * RED: SonarQube is not operational
 
-To call it from a monitoring system without having to give admin credentials, it is possible to setup a system passcode. You can configure this through the `sonar.web.systemPasscode` property in _$SONARQUBE-HOME/conf/sonar.properties_ if you're using a traditional environment or through the corresponding environment variable if you're using a Docker environment.
+To call it from a monitoring system without having to give admin credentials, it is possible to setup a system passcode. You can configure this through the `sonar.web.systemPasscode` property in _$SONARQUBE_HOME/conf/sonar.properties_ if you're using a traditional environment or through the corresponding environment variable if you're using a Docker environment.
 
 ### Cluster Status
 On the System Info page at **Administration > System**, you can check whether your cluster is running safely (green) or has some nodes with problems (orange or red).
@@ -116,7 +116,7 @@ There are three TCP networks to configure:
 In a Docker environment, your properties are configured using [Environment Variables](/setup/environment-variables/).
 
 ## Traditional Environment Configuration
-The following properties may be defined in the _$SONARQUBE-HOME/conf/sonar.properties_ file of each node in a cluster. When defining a property that contains a list of hosts (`*.hosts`) the port is not required if the default port was not overridden in the configuration.
+The following properties may be defined in the _$SONARQUBE_HOME/conf/sonar.properties_ file of each node in a cluster. When defining a property that contains a list of hosts (`*.hosts`) the port is not required if the default port was not overridden in the configuration.
 
 [[warning]]
 | Ports can be unintentionally exposed. We recommend only giving external access to the application nodes and to main port (`sonar.web.port`).
@@ -138,7 +138,7 @@ Property  | Description | Required
 `sonar.cluster.node.web.port`|The Hazelcast port for communication with the WebServer process. Port must be accessible to all other application nodes. If not specified, a dynamic port will be chosen and all ports must be open among the nodes.|no
 `sonar.cluster.node.ce.port`|The Hazelcast port for communication with the ComputeEngine process. Port must be accessible to all other application nodes. If not specified, a dynamic port will be chosen and all ports must be open among the nodes.|no
 `sonar.cluster.search.hosts`|Comma-delimited list of search hosts in the cluster. The list can contain either the host or the host and port, but not both. The item format is `sonar.cluster.node.search.host` for host only or`sonar.cluster.node.search.host:sonar.cluster.node.search.port` for host and port.| yes
-`sonar.auth.jwtBase64Hs256Secret`|Required for authentication with multiple web servers. It is used to keep user sessions opened when they are redirected from one web server to another by the load balancer. See _$SONARQUBE-HOME/conf/sonar.properties_) for details about how to generate this secret key.| yes
+`sonar.auth.jwtBase64Hs256Secret`|Required for authentication with multiple web servers. It is used to keep user sessions opened when they are redirected from one web server to another by the load balancer. See _$SONARQUBE_HOME/conf/sonar.properties_) for details about how to generate this secret key.| yes
 
 ### Search nodes
 Property  | Description | Default | Required 
@@ -212,7 +212,7 @@ No. Multicast is disabled. All hosts (IP+port) must be listed.
 Yes, but it's best to have one machine for each node to be resilient to failures. To maintain an even higher level of availability, each of your three search nodes can be located in a separate availability zone *within the same region*.
 
 ### Can the members of a cluster be discovered automatically? 
-No, all nodes must be configured in _$SONARQUBE-HOME/conf/sonar.properties_
+No, all nodes must be configured in _$SONARQUBE_HOME/conf/sonar.properties_
 
 ### My keystore/truststore cannot be read by SonarQube
 Make sure that the keystore/truststore in question was generated with an algorithm that is known to Java 11. See [JDK-8267599](https://bugs.openjdk.java.net/browse/JDK-8267599) for reference


### PR DESCRIPTION
Not only is SONARQUBE-HOME not a valid env var, it is also referred to as SONARQUBE_HOME elsewhere in the docs. 

This makes it consistent.

