### PR TITLE
Fix SonarService.bat for supporting folders with names including spaces

### DIFF
--- a/sonar-application/src/main/assembly/bin/windows-x86-64/SonarService.bat
+++ b/sonar-application/src/main/assembly/bin/windows-x86-64/SonarService.bat
@@ -26,7 +26,7 @@ rem check if Java is found
 set JAVA_EXE=
 call "%REALPATH%lib\find_java.bat" set_java_exe FAIL || goto:eof
 rem replace JAVA_EXE with the Java path in configuration file
-powershell -Command "(Get-Content %REALPATH%lib\SonarServiceWrapperTemplate.xml) -replace 'JAVA_EXE', '%JAVA_EXE%' | Out-File -encoding ASCII %REALPATH%lib\SonarServiceWrapper.xml"
+powershell -Command "(Get-Content '%REALPATH%lib\SonarServiceWrapperTemplate.xml') -replace 'JAVA_EXE', '%JAVA_EXE%' | Out-File -encoding ASCII '%REALPATH%lib\SonarServiceWrapper.xml'"
 
 rem call the SonarServiceWrapper.exe passing all the parameters
 "%REALPATH%lib\SonarServiceWrapper.exe" %*


### PR DESCRIPTION
When %REALPATH% had a folder with whitespaces, e.g. c:\program files\sonarqube, it showed a nasty powershell error when trying to install SonarQube as a Windows service

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing (Travis build is executed for each pull request):

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
