### PR TITLE
Optimized build, bumped Gradle to 6.9.3 and Gradle Shadow plugin to 6.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   // Ordered alphabetically
   id 'com.github.hierynomus.license' version '0.15.0'
   id "com.github.hierynomus.license-report" version "0.15.0" apply false
-  id 'com.github.johnrengelman.shadow' version '5.2.0' apply false
+  id 'com.github.johnrengelman.shadow' version '6.1.0' apply false
   id 'com.google.protobuf' version '0.8.19' apply false
   id 'com.jfrog.artifactory' version '4.24.23'
   id "de.undercouch.download" version "5.0.1" apply false

--- a/buildSrc/src/main/groovy/org.sonar.build/LicenseReader.groovy
+++ b/buildSrc/src/main/groovy/org.sonar.build/LicenseReader.groovy
@@ -5,25 +5,25 @@ import groovy.json.JsonSlurper
 
 class LicenseReader extends FilterReader {
 
-    LicenseReader(Reader fileReader) {
-        super(build(fileReader))
-    }
+  LicenseReader(Reader fileReader) {
+    super(build(fileReader))
+  }
 
-    private static Reader build(Reader fileReader) {
-        def json = new JsonSlurper().parse(fileReader)
+  private static Reader build(Reader fileReader) {
+    def json = new JsonSlurper().parse(fileReader)
 
-        json.dependencies.each { dependency ->
-            if (dependency.licenses.size() > 1) {
-                def idx = dependency.licenses.findIndexOf { it.name == "Elastic License 2.0" }
-                if (idx >= 0) {
-                    dependency.licenses = [dependency.licenses[idx]]
-                }
-            }
+    json.dependencies.each { dependency ->
+      if (dependency.licenses.size() > 1) {
+        def idx = dependency.licenses.findIndexOf { it.name == "Elastic License 2.0" }
+        if (idx >= 0) {
+          dependency.licenses = [dependency.licenses[idx]]
         }
-
-        json.dependencies.sort { it.name }
-
-        def jsonText = JsonOutput.toJson(json)
-        return new StringReader(JsonOutput.prettyPrint(jsonText))
+      }
     }
+
+    json.dependencies.sort { it.name }
+
+    def jsonText = JsonOutput.toJson(json)
+    return new StringReader(JsonOutput.prettyPrint(jsonText))
+  }
 }

--- a/buildSrc/src/main/groovy/org.sonar.build/LicenseReader.groovy
+++ b/buildSrc/src/main/groovy/org.sonar.build/LicenseReader.groovy
@@ -1,0 +1,29 @@
+package org.sonar.build
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+class LicenseReader extends FilterReader {
+
+    LicenseReader(Reader fileReader) {
+        super(build(fileReader))
+    }
+
+    private static Reader build(Reader fileReader) {
+        def json = new JsonSlurper().parse(fileReader)
+
+        json.dependencies.each { dependency ->
+            if (dependency.licenses.size() > 1) {
+                def idx = dependency.licenses.findIndexOf { it.name == "Elastic License 2.0" }
+                if (idx >= 0) {
+                    dependency.licenses = [dependency.licenses[idx]]
+                }
+            }
+        }
+
+        json.dependencies.sort { it.name }
+
+        def jsonText = JsonOutput.toJson(json)
+        return new StringReader(JsonOutput.prettyPrint(jsonText))
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sonar-application/build.gradle
+++ b/sonar-application/build.gradle
@@ -1,6 +1,5 @@
-import groovy.json.JsonOutput
-import groovy.json.JsonSlurper
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.sonar.build.LicenseReader
 
 plugins {
   id "com.github.hierynomus.license-report"
@@ -123,20 +122,7 @@ task zip(type: Zip, dependsOn: [configurations.compileClasspath, tasks.downloadL
   into("${archiveDir}/") {
     from(tasks.downloadLicenses.outputs) {
       include 'dependency-license.json'
-      eachFile { jsonFile ->
-        def json = new JsonSlurper().parse(jsonFile.file)
-        json.dependencies.each { dependency ->
-          if (dependency.licenses.size() > 1) {
-            def idx = dependency.licenses.findIndexOf { it.name == "Elastic License 2.0" }
-            if (idx >= 0) {
-              dependency.licenses = [dependency.licenses[idx]]
-            }
-          }
-        }
-        json.dependencies.sort { it.name }
-        def jsonText = JsonOutput.toJson(json)
-        jsonFile.file.text = JsonOutput.prettyPrint(jsonText)
-      }
+      filter(LicenseReader)
     }
     from(file('src/main/assembly')) {
       exclude 'conf/sonar.properties'
@@ -258,7 +244,11 @@ task zip(type: Zip, dependsOn: [configurations.compileClasspath, tasks.downloadL
   }
   // Create the empty dir (plugins) required by elasticsearch
   into("${archiveDir}/elasticsearch/") {
-    from "$buildDir/elasticsearch"
+    // Create the empty dir required by elasticsearch
+    from {
+      new File(buildDir, 'elasticsearch/plugins').mkdirs()
+      "$buildDir/elasticsearch"
+    }
   }
   into("${archiveDir}/lib/extensions/") {
     from configurations.bundledPlugin
@@ -298,10 +288,7 @@ task zip(type: Zip, dependsOn: [configurations.compileClasspath, tasks.downloadL
     from configurations.shutdowner
   }
 }
-// Create the empty dir required by elasticsearch
-zip.doFirst {
-  new File(buildDir, 'elasticsearch/plugins').mkdirs()
-}
+
 // Check the size of the archive
 zip.doLast {
   def minLength = 272000000


### PR DESCRIPTION
In this PR I optimized the Gradle build using Gradle Enterprise, which was a part of my onboarding at the Gradle company; I chose your project because I think it's valuable and I saw that it uses Gradle.

I additionally bumped Gradle to 6.9.3, which is the latest 6.x release, and bumped the Gradle Shadow plugin to 6.1.0 which is the latest version to be used with Gradle 6.x.

Here is the build scan of the `clean build` command run on the master branch (note that I excluded tests from the build, as well as one module that did not always work on my local setup due to some npm issue):
https://scans.gradle.com/s/lr34ucq3gipt4/timeline?sort=longest
and here is the build scan of the `build` command run on the master branch, right after the `clean build` that was run previously:
https://scans.gradle.com/s/h7fx3a64dsz44/timeline?sort=longest
it took 12.628s.

Here's the build scan of the `clean build` command run on this PR's branch:
https://scans.gradle.com/s/2xosfbuqxcq2y/timeline?sort=longest
and here's the scan of the `build` command run on that branch right after the `clean build` that was run previously:
https://scans.gradle.com/s/d3jhfhx2pgvxm/timeline?sort=longest
it took 3.174s.

The rework that I did allowed the `zip` and `downloadLicenses` tasks to use the [incremental build feature](https://docs.gradle.org/current/userguide/performance.html#incremental_build). See also [this](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:filter(java.lang.Class)) and [this](https://stackoverflow.com/questions/33248064/gradle-zip-task-replace-entire-file-content-while-being-copied/33248692#33248692). [Here](https://docs.gradle.org/current/userguide/common_caching_problems.html#avoid_changing_inputs_external_to_your_build) the `doFirst` replacement is explained.