### PR TITLE
To pull request

### DIFF
--- a/PullRequest.txt
+++ b/PullRequest.txt
@@ -1,0 +1,12 @@
+Hello,
+
+I’m writing to suggest that in a next version of sonarqube, you offer an extra analysis parameter, that disables or
+enables the final step of execution of sonarqube, specifically, when sonarqube pushes the results to the server to
+be presented as a report.
+
+I’m asking these as the company I work for has now other needs, and want to be able to apply sonarqube to a new tool 
+designed by us, to evaluate commits from all developers of a project and extract metrics from the sonarqube analysis,
+that throughout the time will give us more information. I notice that with the end of the analysis, the sonarqube
+scanner writes down the results to a given directory, and sonarqube just reads them from there and interpret to a
+report structure, that then pushes to the server. But, as we already have the results locally, we don’t need the
+publishing the report phase, as this would carry unnecessary overhead. And that’s why we want this new feature.

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/report/ReportPublisher.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/report/ReportPublisher.java
@@ -240,7 +240,7 @@ public class ReportPublisher implements Startable {
       LOG.info("Analysis report uploaded in " + (stopTime - startTime) + "ms");
     }
     */
-    return branchName;
+    return ""; //
   }
 
   void prepareAndDumpMetadata(String taskId) {

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/report/ReportPublisher.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/report/ReportPublisher.java
@@ -50,7 +50,7 @@ import org.sonar.scanner.protocol.output.ScannerReportWriter;
 import org.sonar.scanner.scan.ScanProperties;
 import org.sonar.scanner.scan.branch.BranchConfiguration;
 import org.sonar.scanner.scan.branch.BranchType;
-import org.sonarqube.ws.Ce;
+//import org.sonarqube.ws.Ce;
 import org.sonarqube.ws.MediaTypes;
 import org.sonarqube.ws.client.HttpException;
 import org.sonarqube.ws.client.PostRequest;
@@ -201,35 +201,36 @@ public class ReportPublisher implements Startable {
     LOG.debug("Upload report");
     long startTime = System.currentTimeMillis();
     PostRequest.Part filePart = new PostRequest.Part(MediaTypes.ZIP, report);
-    PostRequest post = new PostRequest("api/ce/submit")
+    /*PostRequest post = new PostRequest("api/ce/submit")
       .setMediaType(MediaTypes.PROTOBUF)
       .setParam("projectKey", moduleHierarchy.root().key())
       .setParam("projectName", moduleHierarchy.root().getOriginalName())
       .setPart("report", filePart);
-
+  */
     String branchName = branchConfiguration.branchName();
     if (branchName != null) {
       if (branchConfiguration.branchType() != PULL_REQUEST) {
-        post.setParam(CHARACTERISTIC, "branch=" + branchName);
-        post.setParam(CHARACTERISTIC, "branchType=" + branchConfiguration.branchType().name());
+        //post.setParam(CHARACTERISTIC, "branch=" + branchName);
+        //post.setParam(CHARACTERISTIC, "branchType=" + branchConfiguration.branchType().name());
       } else {
-        post.setParam(CHARACTERISTIC, "pullRequest=" + branchConfiguration.pullRequestKey());
+        //post.setParam(CHARACTERISTIC, "pullRequest=" + branchConfiguration.pullRequestKey());
       }
     }
 
     WsResponse response;
     try {
-      post.setWriteTimeOutInMs(properties.reportPublishTimeout() * 1000);
-      response = wsClient.call(post);
+      //post.setWriteTimeOutInMs(properties.reportPublishTimeout() * 1000);
+      //response = wsClient.call(post);
     } catch (Exception e) {
       throw new IllegalStateException("Failed to upload report: " + e.getMessage(), e);
     }
 
     try {
-      response.failIfNotSuccessful();
+      //response.failIfNotSuccessful();
     } catch (HttpException e) {
       throw MessageException.of(String.format("Server failed to process report. Please check server logs: %s", DefaultScannerWsClient.createErrorMessage(e)));
     }
+    /*
     try (InputStream protobuf = response.contentStream()) {
       return Ce.SubmitResponse.parser().parseFrom(protobuf).getTaskId();
     } catch (Exception e) {
@@ -238,6 +239,8 @@ public class ReportPublisher implements Startable {
       long stopTime = System.currentTimeMillis();
       LOG.info("Analysis report uploaded in " + (stopTime - startTime) + "ms");
     }
+    */
+    return branchName;
   }
 
   void prepareAndDumpMetadata(String taskId) {


### PR DESCRIPTION
Hello,

I’m writing to suggest that in a next version of sonarqube, you offer an extra analysis parameter, that disables or enables (the default could be enable) the final step of execution of sonarqube, specifically, when sonarqube pushes the results to the server to be presented as a report.

I’m asking these as the company I work for has now other needs, and want to be able to apply sonarqube to a new tool designed by us, to evaluate commits from all developers of a project and extract metrics from the sonarqube analysis, that throughout the time will give us more information. I notice that with the end of the analysis, the sonarqube scanner writes down the results to a given directory, and sonarqube just reads them from there and interpret to a report structure, that then pushes to the server. But, as we already have the results locally, we don’t need the publishing the report phase, as this would carry unnecessary overhead. And that’s why we want this new feature.

It is a small change that would allow your product to be applied to even more cases.

Thanks!
