### PR TITLE
[NO-JIRA] Update the build env to use Ubuntu 22.04 and Java 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: required
 install: true
 script: ./travis.sh
-dist: bionic
+dist: jammy
+jdk: openjdk17
 
 branches:
   except:


### PR DESCRIPTION
Our builds on TravisCI are failing because JAVA 17 is not available. In the context of this PR, we both update the underlying OS and set our build to use openjdk17.