### PR TITLE
[NO JIRA] Fix non-compliant L10N key/value definition

### DIFF
--- a/sonar-core/src/main/resources/org/sonar/l10n/core.properties
+++ b/sonar-core/src/main/resources/org/sonar/l10n/core.properties
@@ -2230,7 +2230,7 @@ severity.INFO.description=Neither a bug nor a quality flaw. Just a finding.
 
 metric_domain.Size=Size
 metric_domain.Tests=Tests
-metric_domain.Integration Tests=Integration Tests
+metric_domain.Integration=Tests\=Integration Tests
 metric_domain.Complexity=Complexity
 metric_domain.Documentation=Documentation
 metric_domain.Rules=Rules


### PR DESCRIPTION
With previous declaration in `core.properits`:

```text
metric_domain.Integration Tests=Integration Tests
```

... following Java code:

```java
resourceBundle.getString("metric_domain.Integration")
```

... returns:

```text
Tests=Integration Tests
```

And following Java code:

```java
resourceBundle.getString("metric_domain.Integration Tests")
```

... throw exception:

```text
java.util.MissingResourceException: Can't find resource for bundle java.util.PropertyResourceBundle, key metric_domain.Integration Tests
```

-----

I don't know if it's the right fix in your context.

Perhaps following fix would be better:

```text
metric_domain.Integration\ Tests=Integration Tests
```

With this declaration in core.properties, following Java code:

```java
resourceBundle.getString("metric_domain.Integration Tests")
```

... returns:

```text
Integration Tests
```
