### PR TITLE
[NO-JIRA] optimize slow selectProjectUuidsAssociatedToDefaultQualityProfileByLanguage

### DIFF
--- a/server/sonar-db-dao/src/main/resources/org/sonar/db/project/ProjectMapper.xml
+++ b/server/sonar-db-dao/src/main/resources/org/sonar/db/project/ProjectMapper.xml
@@ -118,11 +118,12 @@
     from
       live_measures lm
     inner join
+      projects p on (p.uuid = lm.project_uuid and p.uuid = lm.component_uuid)
+    inner join
       metrics m on m.uuid = lm.metric_uuid
     where
       m.name = 'ncloc_language_distribution'
-      and lm.component_uuid = lm.project_uuid
-      and lm.project_uuid not in (select project_uuid from project_qprofiles)
+      and p.uuid not in (select project_uuid from project_qprofiles)
       and
       <foreach collection="languageFilters" index="index" item="languageFilter" open="(" separator=" or " close=")">
         lm.text_value like #{languageFilter, jdbcType=VARCHAR} escape '/'


### PR DESCRIPTION
The project DAO [`selectProjectUuidsAssociatedToDefaultQualityProfileByLanguage`](https://github.com/SonarSource/sonarqube/blob/master/server/sonar-db-dao/src/main/resources/org/sonar/db/project/ProjectMapper.xml#L115) SQL query (introduced for [SONAR-17110](https://sonarsource.atlassian.net/browse/SONAR-17110) in https://github.com/SonarSource/sonarqube/commit/e0f897e2673d97683ebaeb3751023cd14ea329fe - ping @klaudiosinani) implies scanning through many rows of the `live_measures` table . This takes several minutes to execute in some setups (Postgres 13, 200M rows in the table), making SonarQube upgrades painfully slow (this request is executed when a bundled quality profile is updated).

A similar query can be achieved by joining the `projects` table, with a drastic improvement to the execution plan. The results are not the same though: this new version only returns uuids of actual projects, whereas the original one also returns uuids of other components (not existing in the projects table). But this is actually an improvement too: the only call sites for this DAO method (in [`QualityProfileChangeEventServiceImpl`](https://github.com/SonarSource/sonarqube/blob/master/server/sonar-webserver-pushapi/src/main/java/org/sonar/server/pushapi/qualityprofile/QualityProfileChangeEventServiceImpl.java#L273)) uses the results as an input for the `ProjectDAO.selectByUuids()` method, which only looks at the `projects` table.

Tests done on Postgres 13.6, with 16GB RAM and high-IO disks, on a freshly imported DB (minimal fragmentation, up-to-date statistics), with ~200M rows in `live_measures`. The DB schema matches what's [expected](https://github.com/SonarSource/sonarqube/blob/master/server/sonar-db-dao/src/schema/schema-sq.ddl#L437), no index is missing. There might be room for Postgres tuning on this server, but probably not to the point of making this query fast.

* **Query plan BEFORE modification:** the index scan hits many lines (4.5M) before filtering. The whole thing takes 5 minutes.

```text
sonarqube=> explain analyze select lm.project_uuid from live_measures lm inner join metrics m on m.uuid = lm.metric_uuid where m.name = 'ncloc_language_distribution' and lm.component_uuid = lm.project_uuid a
nd lm.project_uuid not in (select project_uuid from project_qprofiles) and (lm.text_value like 'java=%' escape '/' or lm.text_value like '%;java=%' escape '/') order by lm.project_uuid asc;
                                                                                          QUERY PLAN                                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=4986768.00..4986768.12 rows=46 width=21) (actual time=283121.398..283121.757 rows=8110 loops=1)
   Sort Key: lm.project_uuid
   Sort Method: quicksort  Memory: 826kB
   ->  Nested Loop  (cost=8.62..4986766.73 rows=46 width=21) (actual time=40.515..283104.442 rows=8110 loops=1)
         ->  Index Scan using metrics_unique_name on metrics m  (cost=0.14..2.36 rows=1 width=6) (actual time=0.006..0.009 rows=1 loops=1)
               Index Cond: ((name)::text = 'ncloc_language_distribution'::text)
         ->  Index Scan using live_measures_component on live_measures lm  (cost=8.47..4986763.74 rows=63 width=23) (actual time=40.506..283097.043 rows=8110 loops=1)
               Index Cond: ((metric_uuid)::text = (m.uuid)::text)
               Filter: ((NOT (hashed SubPlan 1)) AND ((component_uuid)::text = (project_uuid)::text) AND (((text_value)::text ~~ 'java=%'::text) OR ((text_value)::text ~~ '%;java=%'::text)))
               Rows Removed by Filter: 4529806
               SubPlan 1
                 ->  Seq Scan on project_qprofiles  (cost=0.00..7.12 rows=312 width=21) (actual time=0.006..0.037 rows=312 loops=1)
 Planning Time: 0.302 ms
 Execution Time: 283122.126 ms
```

* **Query plan AFTER modification:** only few rows are considered, thanks to effective selection by `project_uuid` (or `component_uuid`)

```text
sonarqube=> explain analyze select p.uuid from live_measures lm inner join projects p on (p.uuid = lm.component_uuid and p.uuid = lm.project_uuid) inner join metrics m on m.uuid = lm.metric_uuid where m.name
 = 'ncloc_language_distribution' and p.uuid not in (select project_uuid from project_qprofiles) and (lm.text_value like 'java=%' escape '/' or lm.text_value like '%;java=%' escape '/');
                                                                            QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=8.62..67595.39 rows=3 width=21) (actual time=0.222..340.407 rows=1551 loops=1)
   ->  Index Scan using metrics_unique_name on metrics m  (cost=0.14..2.36 rows=1 width=6) (actual time=0.012..0.013 rows=1 loops=1)
         Index Cond: ((name)::text = 'ncloc_language_distribution'::text)
   ->  Nested Loop  (cost=8.47..67588.93 rows=410 width=23) (actual time=0.209..340.180 rows=1551 loops=1)
         ->  Seq Scan on projects p  (cost=7.90..157.21 rows=2412 width=21) (actual time=0.123..2.719 rows=4676 loops=1)
               Filter: (NOT (hashed SubPlan 1))
               Rows Removed by Filter: 149
               SubPlan 1
                 ->  Seq Scan on project_qprofiles  (cost=0.00..7.12 rows=312 width=21) (actual time=0.013..0.057 rows=312 loops=1)
         ->  Index Scan using live_measures_component on live_measures lm  (cost=0.57..27.95 rows=1 width=44) (actual time=0.072..0.072 rows=0 loops=4676)
               Index Cond: (((component_uuid)::text = (p.uuid)::text) AND ((metric_uuid)::text = (m.uuid)::text))
               Filter: (((component_uuid)::text = (project_uuid)::text) AND (((text_value)::text ~~ 'java=%'::text) OR ((text_value)::text ~~ '%;java=%'::text)))
               Rows Removed by Filter: 0
 Planning Time: 0.572 ms
 Execution Time: 340.581 ms
```


- [X] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] ~~Provide a unit test for any code you changed~~
  - existing unit test for this query (`ProjectDaoTest`) is still okay
- [X] If there is a [JIRA](http://jira.sonarsource.com/browse/SONAR) ticket available, please make your commits and pull request start with the ticket ID (SONAR-XXXX)
  - `[NO-JIRA]`, because [JIRA](http://jira.sonarsource.com/browse/SONAR) is closed to external contributors



[SONAR-17110]: https://sonarsource.atlassian.net/browse/SONAR-17110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ