### PR TITLE
BUILD-2798 Implement suggested workaround for false positive in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ notifications:
     secure: PCekbN71ZmuOt82JUFmlhzxlx3wrXucSIpvxxWdZn9lfsPYQAtXCoOESaHjIVIpggsC5HSAic3HiedsWbuDk/XojmPrDCrfjgYG2wiuSuQlAa60WvzTPqXdRmUXyMQgItaAQbRfZP7kN9No/v8TZDfg5kT3i9ewy0bsfExpjAuo=
   on_start: always
 
+after_success:
+  - "[[ $TRAVIS_TEST_RESULT = 0 ]] && echo passed"
+
 after_failure:
+  - "[[ $TRAVIS_TEST_RESULT = 1 ]] && echo failed"
   - source ./.travis/setup_environment.sh
   - notify_burgr "build" "build" "$TRAVIS_JOB_WEB_URL" "$(cat /tmp/build_start_time)" "$(date --utc +%FT%TZ)" "failed" || true


### PR DESCRIPTION
We currently have an issue in which the `after_failure` body gets executed even after the scripts have run successfully (rc=0).

A support ticket has been opened and while they're looking into it, a workaround has been provided.

The response is quoted below:

Thank you for reaching out and sorry for the hassle.

The issue encountered has been raised with our engineering team and they are looking into it. In the meantime, I will be keeping this ticket in open status and get back to you as soon as we have more information available.

Additionally, as a workaround, can you please try adding the TRAVIS_TEST_RESULT environment variable as a check (source: https://docs.travis-ci.com/user/environment-variables/#:~:text=is%20enabled.-,TRAVIS_TEST_RESULT,-%3A%200%20if) within your .travis.yml after_success/after_failure phase, e.g.:

```
after_success:
  - "[[ $TRAVIS_TEST_RESULT = 0 ]] && echo passed"

after_failure:
  - "[[ $TRAVIS_TEST_RESULT = 1 ]] && echo failed"
```

