### PR TITLE
Update BatchIndex.java

### DIFF
--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/batch/BatchIndex.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/batch/BatchIndex.java
@@ -65,6 +65,8 @@ public class BatchIndex implements Startable {
           }
         }
       }
+    } else {
+      throw new NotFoundException("lib/scanner folder not found");
     }
     this.index = sb.toString();
   }


### PR DESCRIPTION
Because of unknown reason, the /lib/scanner folder was not extracted from the windows archive several times on our server. /batch/index fails without notifying the user.
The SonarQube Azure DevOps task will fail with a cryptic error : ##[error]ERROR: Failed bootstrap index response:
ERROR: Failed bootstrap index response:

