### PR TITLE
Allow overriding PIDFILE.

### DIFF
--- a/sonar-application/src/main/assembly/bin/linux-x86-64/sonar.sh
+++ b/sonar-application/src/main/assembly/bin/linux-x86-64/sonar.sh
@@ -86,7 +86,7 @@ XMX="-Xmx32m"
 COMMAND_LINE="$JAVA_CMD $XMS $XMX $HAZELCAST_ADDITIONAL -jar $LIB_DIR/sonar-application-@sqversion@.jar"
 
 # Location of the pid file.
-PIDFILE="./$APP_NAME.pid"
+PIDFILE="${PIDFILE-./$APP_NAME.pid}"
 
 # Resolve the location of the 'ps' command
 PSEXE="/usr/bin/ps"


### PR DESCRIPTION
Currently, the PID file is written in the /bin folder, security-wise, this is not a good pratice as this directory should be read-only.

Allowing change to the PIDFILE via environment allows placing it in the correct location such as /run/sonarqube/sonarqube.pid

