### PR TITLE
[NO-JIRA]: default value for Artifactory URL

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,4 @@ org.gradle.caching=true
 org.gradle.vfs.watch=true
 elasticsearchVersion=8.7.0
 projectType=application
+artifactoryUrl=https://repox.jfrog.io/repox


### PR DESCRIPTION
Actually, on master, the project is not building locally:

```
❯ ./gradlew test

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/bruno/workspaces/idea/open-source-softwares/sonarqube/build.gradle' line: 88

* What went wrong:
A problem occurred evaluating root project 'sonarqube'.
> Invalid artifactoryUrl
```

I noticed that this [commit](https://github.com/SonarSource/sonarqube/commit/92b69f90be5767fa2d26b7d3e0201be5b29f26bf) throws a exception when there is no _artifactory url_:

1. Defined on **Environment Variables**
2. Inside of **gradle.properties**

I didn't find this kind of configuration on README.

If make sense, i proppouse:
1. Update the README to show that requirement to the Community who wants to help the OSS(like me, :D)
2. Add a default value in gradle.properties to that URL(my approach below).

---
I have a suggestion on  `fix`:

1. Added a default value for Artifactory URL.

- [x]  Use the following formatting style: SonarSource/sonar-developer-toolset
- [x] Provide a unit test for any code you changed
- [ ] If there is a JIRA ticket available, please make your commits and pull request starting with the ticket ID (SONAR-XXXX)

Thank you.