### PR TITLE
Improve exception message in DefaultSymbol.newReference

### DIFF
--- a/sonar-plugin-api-impl/src/main/java/org/sonar/api/batch/sensor/symbol/internal/DefaultSymbolTable.java
+++ b/sonar-plugin-api-impl/src/main/java/org/sonar/api/batch/sensor/symbol/internal/DefaultSymbolTable.java
@@ -107,7 +107,7 @@ public class DefaultSymbolTable extends DefaultStorable implements NewSymbolTabl
     @Override
     public NewSymbol newReference(TextRange range) {
       requireNonNull(range, "Provided range is null");
-      checkArgument(!declaration.overlap(range), "Overlapping symbol declaration and reference for symbol at %s", declaration);
+      checkArgument(!declaration.overlap(range), "Overlapping symbol declaration and reference for symbol declared at %s and referenced at %s in file %s", declaration, range, inputFile);
       references.add(range);
       return this;
     }

--- a/sonar-plugin-api-impl/src/test/java/org/sonar/api/batch/sensor/symbol/internal/DefaultSymbolTableTest.java
+++ b/sonar-plugin-api-impl/src/test/java/org/sonar/api/batch/sensor/symbol/internal/DefaultSymbolTableTest.java
@@ -67,4 +67,16 @@ public class DefaultSymbolTableTest {
     assertThat(referencesPerSymbol).hasSize(2);
   }
 
+  @Test
+  public void should_fail_on_reference_overlaps_declaration() {
+    DefaultSymbolTable symbolTableBuilder = new DefaultSymbolTable(mock(SensorStorage.class))
+      .onFile(INPUT_FILE);
+    symbolTableBuilder = symbolTableBuilder
+      .newSymbol(1, 0, 1, 10);
+    
+    assertThatThrownBy(() -> {
+      symbolTableBuilder.newReference(1, 0, 1, 10);
+    }).isInstanceOf(IllegalArgumentException.class)
+      .hasMessageMatching(".*");
+  }
 }


### PR DESCRIPTION
We got a community report about an exception in the import of symbol references.
https://community.sonarsource.com/t/error-with-net-8-on-azure-devops-overlapping-symbol-declaration-and-reference-for-symbol-at-range/104762

The exception message is missing the file name of the contradicting reference. This PR adds more information to the exception.