### PR TITLE
Update logback from 1.3.11 to 1.3.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -284,7 +284,7 @@ subprojects {
       dependency 'org.sonarsource.text:sonar-text-plugin:2.7.1.1388'
 
       // please keep this list alphabetically ordered
-      dependencySet(group: 'ch.qos.logback', version: '1.3.11') {
+      dependencySet(group: 'ch.qos.logback', version: '1.3.14') {
         entry 'logback-access'
         entry 'logback-classic'
         entry 'logback-core'


### PR DESCRIPTION
Using latest 1.3.14 will clean up a vulnerability finding that doesn't apply to SonarQube because it doesn't use the logback receiver but might as well make it go away.  https://mvnrepository.com/artifact/ch.qos.logback/logback-core/1.3.11