### PR TITLE
Introduce toolchain to compile with Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,6 @@ import groovy.json.JsonOutput
 import groovy.text.SimpleTemplateEngine
 import org.sonar.build.BlackBoxTest
 
-import static org.gradle.api.JavaVersion.VERSION_17
-
 plugins {
   // Ordered alphabetically
   id 'com.github.hierynomus.license' version '0.16.1'
@@ -15,10 +13,6 @@ plugins {
   id 'io.spring.dependency-management' version '1.1.3'
   id "org.cyclonedx.bom" version "1.7.4" apply false
   id 'org.sonarqube' version '4.4.1.3373'
-}
-
-if (!JavaVersion.current().isCompatibleWith(VERSION_17)) {
-  throw new GradleException("JDK 17+ is required to perform this build. It's currently " + System.getProperty("java.home") + ".")
 }
 
 /**
@@ -186,6 +180,12 @@ subprojects {
   apply plugin: 'java-library'
   apply plugin: 'idea'
   apply plugin: 'signing'
+
+  java {
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(17)
+    }
+  }
 
   // do not deploy to Artifactory by default
   artifactoryPublish.skip = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ pluginManagement {
   plugins {
     id 'com.bmuschko.docker-remote-api' version '7.3.0'
     id 'org.ajoberstar.grgit' version '4.1.1'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
   }
 }
 


### PR DESCRIPTION
Currently, Gradle buildscript forces developers to install Java 17+. This process can be handled by the [JVM toolchain](https://docs.gradle.org/7.5.1/userguide/toolchains.html), suggested in this PR, and it helps developers set up the development environment more easily.

JVM toolchain tries to find existing JDK, so this change will not affect existing development/build environments.