### PR TITLE
NO-JIRA Make Gson usage more type-safe

### DIFF
--- a/server/sonar-alm-client/src/main/java/org/sonar/alm/client/github/GithubApplicationClientImpl.java
+++ b/server/sonar-alm-client/src/main/java/org/sonar/alm/client/github/GithubApplicationClientImpl.java
@@ -73,9 +73,12 @@ public class GithubApplicationClientImpl implements GithubApplicationClient {
   protected static final String WRITE_PERMISSION_NAME = "write";
   protected static final String READ_PERMISSION_NAME = "read";
   protected static final String FAILED_TO_REQUEST_BEGIN_MSG = "Failed to request ";
-  private static final Type REPOSITORY_TEAM_LIST_TYPE = TypeToken.getParameterized(List.class, GsonRepositoryTeam.class).getType();
-  private static final Type REPOSITORY_COLLABORATORS_LIST_TYPE = TypeToken.getParameterized(List.class, GsonRepositoryCollaborator.class).getType();
-  private static final Type ORGANIZATION_LIST_TYPE = TypeToken.getParameterized(List.class, GithubBinding.GsonInstallation.class).getType();
+  private static final TypeToken<List<GsonRepositoryTeam>> REPOSITORY_TEAM_LIST_TYPE = new TypeToken<>() {
+  };
+  private static final TypeToken<List<GsonRepositoryCollaborator>> REPOSITORY_COLLABORATORS_LIST_TYPE = new TypeToken<>() {
+  };
+  private static final TypeToken<List<GithubBinding.GsonInstallation>> ORGANIZATION_LIST_TYPE = new TypeToken<>() {
+  };
   protected final GithubApplicationHttpClient githubApplicationHttpClient;
   protected final GithubAppSecurity appSecurity;
   private final GitHubSettings gitHubSettings;

--- a/server/sonar-alm-client/src/main/java/org/sonar/alm/client/gitlab/GitlabApplicationClient.java
+++ b/server/sonar-alm-client/src/main/java/org/sonar/alm/client/gitlab/GitlabApplicationClient.java
@@ -58,8 +58,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class GitlabApplicationClient {
   private static final Logger LOG = LoggerFactory.getLogger(GitlabApplicationClient.class);
   private static final Gson GSON = new Gson();
-  private static final Type GITLAB_GROUP = TypeToken.getParameterized(List.class, GsonGroup.class).getType();
-  private static final Type GITLAB_USER = TypeToken.getParameterized(List.class, GsonUser.class).getType();
+  private static final TypeToken<List<GsonGroup>> GITLAB_GROUP = new TypeToken<>() {
+  };
+  private static final TypeToken<List<GsonUser>> GITLAB_USER = new TypeToken<>() {
+  };
 
   protected static final String PRIVATE_TOKEN = "Private-Token";
   private static final String GITLAB_GROUPS_MEMBERS_ENDPOINT = "/groups/%s/members";

--- a/server/sonar-alm-client/src/main/java/org/sonar/alm/client/gitlab/Project.java
+++ b/server/sonar-alm-client/src/main/java/org/sonar/alm/client/gitlab/Project.java
@@ -75,7 +75,7 @@ public class Project {
   public static List<Project> parseJsonArray(String json) {
     Gson gson = new Gson();
     return gson.fromJson(json, new TypeToken<LinkedList<Project>>() {
-    }.getType());
+    });
   }
 
   public long getId() {

--- a/server/sonar-alm-client/src/test/java/org/sonar/alm/client/GenericPaginatedHttpClientImplTest.java
+++ b/server/sonar-alm-client/src/test/java/org/sonar/alm/client/GenericPaginatedHttpClientImplTest.java
@@ -54,7 +54,8 @@ public class GenericPaginatedHttpClientImplTest {
 
   private static final String ENDPOINT = "/test-endpoint";
 
-  private static final Type STRING_LIST_TYPE = TypeToken.getParameterized(List.class, String.class).getType();
+  private static final TypeToken<List<String>> STRING_LIST_TYPE = new TypeToken<>() {
+  };
 
   private Gson gson = new Gson();
 

--- a/server/sonar-auth-github/src/main/java/org/sonar/auth/github/GsonEmail.java
+++ b/server/sonar-auth-github/src/main/java/org/sonar/auth/github/GsonEmail.java
@@ -58,9 +58,8 @@ public class GsonEmail {
   }
 
   public static List<GsonEmail> parse(String json) {
-    Type collectionType = new TypeToken<Collection<GsonEmail>>() {
-    }.getType();
     Gson gson = new Gson();
-    return gson.fromJson(json, collectionType);
+    return gson.fromJson(json, new TypeToken<List<GsonEmail>>() {
+    });
   }
 }

--- a/server/sonar-auth-github/src/main/java/org/sonar/auth/github/GsonTeam.java
+++ b/server/sonar-auth-github/src/main/java/org/sonar/auth/github/GsonTeam.java
@@ -52,10 +52,9 @@ public class GsonTeam {
   }
 
   public static List<GsonTeam> parse(String json) {
-    Type collectionType = new TypeToken<Collection<GsonTeam>>() {
-    }.getType();
     Gson gson = new Gson();
-    return gson.fromJson(json, collectionType);
+    return gson.fromJson(json, new TypeToken<List<GsonTeam>>() {
+    });
   }
 
   public static class GsonOrganization {

--- a/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GsonGroup.java
+++ b/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GsonGroup.java
@@ -55,9 +55,9 @@ public class GsonGroup {
   }
 
   static List<GsonGroup> parse(String json) {
-    Type collectionType = new TypeToken<Collection<GsonGroup>>() {}.getType();
     Gson gson = new Gson();
-    return gson.fromJson(json, collectionType);
+    return gson.fromJson(json, new TypeToken<List<GsonGroup>>() {
+    });
   }
 
 }

--- a/server/sonar-server-common/src/main/java/org/sonar/server/qualityprofile/QPMeasureData.java
+++ b/server/sonar-server-common/src/main/java/org/sonar/server/qualityprofile/QPMeasureData.java
@@ -48,7 +48,7 @@ public class QPMeasureData {
   }
 
   public static QPMeasureData fromJson(String json) {
-    return new QPMeasureData(StreamSupport.stream(new JsonParser().parse(json).getAsJsonArray().spliterator(), false)
+    return new QPMeasureData(StreamSupport.stream(JsonParser.parseString​(json).getAsJsonArray().spliterator(), false)
       .map(jsonElement -> {
         JsonObject jsonProfile = jsonElement.getAsJsonObject();
         return new QualityProfile(

--- a/server/sonar-webserver-auth/src/main/java/org/sonar/server/authentication/OAuth2AuthenticationParametersImpl.java
+++ b/server/sonar-webserver-auth/src/main/java/org/sonar/server/authentication/OAuth2AuthenticationParametersImpl.java
@@ -53,8 +53,8 @@ public class OAuth2AuthenticationParametersImpl implements OAuth2AuthenticationP
    */
   private static final String RETURN_TO_PARAMETER = "return_to";
 
-  private static final Type JSON_MAP_TYPE = new TypeToken<HashMap<String, String>>() {
-  }.getType();
+  private static final TypeToken<HashMap<String, String>> JSON_MAP_TYPE = new TypeToken<>() {
+  };
 
   @Override
   public void init(HttpRequest request, HttpResponse response) {

--- a/server/sonar-webserver-webapi/src/it/java/org/sonar/server/component/ws/TreeActionIT.java
+++ b/server/sonar-webserver-webapi/src/it/java/org/sonar/server/component/ws/TreeActionIT.java
@@ -565,8 +565,7 @@ public class TreeActionIT {
     db.components().insertSnapshot(projectData.getMainBranchComponent());
 
     Date now = new Date();
-    JsonParser jsonParser = new JsonParser();
-    JsonElement jsonTree = jsonParser.parseString(IOUtils.toString(getClass().getResource("tree-example.json"), UTF_8));
+    JsonElement jsonTree = JsonParser.parseString(IOUtils.toString(getClass().getResource("tree-example.json"), UTF_8));
     JsonArray components = jsonTree.getAsJsonObject().getAsJsonArray("components");
     for (int i = 0; i < components.size(); i++) {
       JsonElement componentAsJsonElement = components.get(i);

--- a/server/sonar-webserver-webapi/src/it/java/org/sonar/server/issue/ws/SearchActionIT.java
+++ b/server/sonar-webserver-webapi/src/it/java/org/sonar/server/issue/ws/SearchActionIT.java
@@ -1358,7 +1358,7 @@ public class SearchActionIT {
       .setParam("asc", "false")
       .execute();
 
-    JsonElement parse = new JsonParser().parse(response.getInput());
+    JsonElement parse = JsonParser.parseString(response.getInput());
 
     assertThat(parse.getAsJsonObject().get("issues").getAsJsonArray())
       .extracting(o -> o.getAsJsonObject().get("key").getAsString())

--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/setting/ws/SetAction.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/setting/ws/SetAction.java
@@ -305,8 +305,8 @@ public class SetAction implements SettingsWsAction {
   }
 
   private static Map<String, String> readOneFieldValues(String json, String key) {
-    Type type = new TypeToken<Map<String, String>>() {
-    }.getType();
+    TypeToken<Map<String, String>> type = new TypeToken<>() {
+    };
     Gson gson = GsonHelper.create();
     try {
       return gson.fromJson(json, type);

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/bootstrap/DefaultScannerWsClient.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/bootstrap/DefaultScannerWsClient.java
@@ -189,8 +189,7 @@ public class DefaultScannerWsClient implements ScannerWsClient {
   @CheckForNull
   private static String tryParseAsJsonError(String responseContent) {
     try {
-      JsonParser parser = new JsonParser();
-      JsonObject obj = parser.parse(responseContent).getAsJsonObject();
+      JsonObject obj = JsonParser.parseString(responseContent).getAsJsonObject();
       JsonArray errors = obj.getAsJsonArray("errors");
       List<String> errorMessages = new ArrayList<>();
       for (JsonElement e : errors) {

--- a/sonar-testing-harness/src/main/java/org/sonar/test/JsonAssert.java
+++ b/sonar-testing-harness/src/main/java/org/sonar/test/JsonAssert.java
@@ -123,7 +123,7 @@ public class JsonAssert {
   }
 
   private static String pretty(String json) {
-    JsonElement gson = new JsonParser().parse(json);
+    JsonElement gson = JsonParser.parseString(json);
     return new GsonBuilder().setPrettyPrinting().serializeNulls().create().toJson(gson);
   }
 }


### PR DESCRIPTION
Changes:
- Uses `Gson.fromJson(..., TypeToken<T>)` instead of `fromJson(..., Type)`
The overload with `TypeToken` argument was added in Gson 2.10 and provides more type-safety because the return type is bound by the `TypeToken`, whereas for the `fromJson(..., Type)` overloads the return type is unbounded, so you can accidentally specify incorrect types.
This is actually the case for `GsonEmail.java`, `GsonTeam.java` and `GsonGroup.java` which specified `Collection` as type to parse but actually expected a `List`. This just happened to work because Gson [creates an `ArrayList`](https://github.com/google/gson/blob/gson-parent-2.10.1/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java#L318-L322) when asked to create a `Collection`, but that is an implementation detail.
- Replaces usage of the deprecated `JsonParser()` constructor

:warning: I have not tested or built these changes locally because the Gradle build started by downloading a 600MB Elasticsearch Linux artifact (on a Windows machine), so I did not consider the effort to set up a development environment for this worth it.
Sorry for this; feel free to use the changes of this pull request and adapt them as necessary.