### PR TITLE
SONAR-21589 Do not require 'api' scope for GitLab authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,22 +69,28 @@ allprojects {
     def artifactoryPassword = System.env.'ARTIFACTORY_PRIVATE_PASSWORD' ?: (project.hasProperty('artifactoryPassword') ? project.getProperty('artifactoryPassword') : '')
     def artifactoryUrl = System.getenv('ARTIFACTORY_URL') ?: (project.hasProperty('artifactoryUrl') ? project.getProperty('artifactoryUrl') : '')
 
-    if (artifactoryUrl == '') {
-      throw new GradleException('Invalid artifactoryUrl')
-    }
-
-    maven {
-        if (artifactoryUsername && artifactoryPassword) {
-            credentials {
-                username artifactoryUsername
-                password artifactoryPassword
-            }
-        } else {
-            // Workaround for artifactory
-            // https://www.jfrog.com/jira/browse/RTFACT-13797
-            repository = 'public'
+    if (artifactoryPassword) {
+      if (artifactoryUrl == '') {
+        throw new GradleException('Invalid artifactoryUrl')
+      }
+      maven {
+        authentication {
+          header(HttpHeaderAuthentication)
+        }
+        credentials(HttpHeaderCredentials) {
+          name = "Authorization"
+          value = "Bearer $artifactoryPassword"
         }
         url "${artifactoryUrl}/${repository}"
+      }
+    } else {
+      mavenCentral()
+      maven {
+        url 'https://jitpack.io'
+      }
+      maven {
+        url 'https://maven.codelibs.org/'
+      }
     }
     ivy {
           if (artifactoryUsername && artifactoryPassword) {
@@ -632,4 +638,3 @@ tasks.named('sonarqube') {
     outputFile.append(JsonOutput.toJson([category: "Analysis", suite: "Standalone", operation: "total", duration: taskDuration]) + '\n')
   }
 }
-

--- a/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabIdentityProvider.java
+++ b/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabIdentityProvider.java
@@ -124,13 +124,13 @@ public class GitLabIdentityProvider implements OAuth2IdentityProvider {
       .setEmail(user.getEmail());
 
 
-    Set<String> userGroups = getGroups(scribe, accessToken);
-
-    if (!gitLabSettings.allowedGroups().isEmpty()) {
-      validateUserInAllowedGroups(userGroups, gitLabSettings.allowedGroups());
-    }
-
     if (gitLabSettings.syncUserGroups()) {
+      Set<String> userGroups = getGroups(scribe, accessToken);
+
+      if (!gitLabSettings.allowedGroups().isEmpty()) {
+        validateUserInAllowedGroups(userGroups, gitLabSettings.allowedGroups());
+      }
+
       builder.setGroups(userGroups);
     }
 

--- a/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/GitLabIdentityProviderTest.java
+++ b/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/GitLabIdentityProviderTest.java
@@ -85,7 +85,7 @@ public class GitLabIdentityProviderTest {
 
     gitLabIdentityProvider.init(initContext);
 
-    verify(initContext).redirectTo("http://server/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Fserver%2Fcallback&scope=api");
+    verify(initContext).redirectTo("http://server/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Fserver%2Fcallback&scope=read_user");
   }
 
   @Test

--- a/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/IntegrationTest.java
+++ b/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/IntegrationTest.java
@@ -97,6 +97,7 @@ public class IntegrationTest {
 
   @Test
   public void callback_whenNotAllowedUser_shouldThrow() {
+    mapSettings.setProperty(GITLAB_AUTH_SYNC_USER_GROUPS, "true");
     OAuth2IdentityProvider.CallbackContext callbackContext = mockCallbackContext();
 
     mockAccessTokenResponse();


### PR DESCRIPTION
SonarQube 9.9.4 breaks GitLab authentication when group sync is disabled and the token has only `read_user` scope, as reported in SONAR-21589. (This used to work fine on v9.9.3)

The first commit on this PR backports 8f24b6c to branch-9.9 (otherwise the build doesn't work)

The second commit fixes the scope. It's a partial revert of c6027f9

The third commit fixes a problem introduced by 4e7453d: an API query was made even if group sync was disabled