### PR TITLE
[master] SONAR-21589 Do not require 'api' scope for GitLab authentication

### DIFF
--- a/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabIdentityProvider.java
+++ b/server/sonar-auth-gitlab/src/main/java/org/sonar/auth/gitlab/GitLabIdentityProvider.java
@@ -125,13 +125,13 @@ public class GitLabIdentityProvider implements OAuth2IdentityProvider {
       .setEmail(user.getEmail());
 
 
-    Set<String> userGroups = getGroups(scribe, accessToken);
-
-    if (!gitLabSettings.allowedGroups().isEmpty()) {
-      validateUserInAllowedGroups(userGroups, gitLabSettings.allowedGroups());
-    }
-
     if (gitLabSettings.syncUserGroups()) {
+      Set<String> userGroups = getGroups(scribe, accessToken);
+
+      if (!gitLabSettings.allowedGroups().isEmpty()) {
+        validateUserInAllowedGroups(userGroups, gitLabSettings.allowedGroups());
+      }
+
       builder.setGroups(userGroups);
     }
 

--- a/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/GitLabIdentityProviderTest.java
+++ b/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/GitLabIdentityProviderTest.java
@@ -85,7 +85,7 @@ public class GitLabIdentityProviderTest {
 
     gitLabIdentityProvider.init(initContext);
 
-    verify(initContext).redirectTo("http://server/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Fserver%2Fcallback&scope=api");
+    verify(initContext).redirectTo("http://server/oauth/authorize?response_type=code&client_id=123&redirect_uri=http%3A%2F%2Fserver%2Fcallback&scope=read_user");
   }
 
   @Test

--- a/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/IntegrationTest.java
+++ b/server/sonar-auth-gitlab/src/test/java/org/sonar/auth/gitlab/IntegrationTest.java
@@ -97,6 +97,7 @@ public class IntegrationTest {
 
   @Test
   public void callback_whenNotAllowedUser_shouldThrow() {
+    mapSettings.setProperty(GITLAB_AUTH_SYNC_USER_GROUPS, "true");
     OAuth2IdentityProvider.CallbackContext callbackContext = mockCallbackContext();
 
     mockAccessTokenResponse();


### PR DESCRIPTION
This is a port of #3356 for the `master` branch. It fixes GitLab authentication when group sync is disabled and the token has only `read_user` scope, as reported in SONAR-21589.