### PR TITLE
Validate SonarCloud webhook signature fail was caused by the JsonWriter build request payload

### DIFF
--- a/server/sonar-server-common/src/test/java/org/sonar/server/webhook/WebhookPayloadFactoryImplTest.java
+++ b/server/sonar-server-common/src/test/java/org/sonar/server/webhook/WebhookPayloadFactoryImplTest.java
@@ -20,6 +20,9 @@
 package org.sonar.server.webhook;
 
 import com.google.common.collect.ImmutableMap;
+
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.Before;
@@ -27,6 +30,7 @@ import org.junit.Test;
 import org.sonar.api.measures.Metric;
 import org.sonar.api.platform.Server;
 import org.sonar.api.utils.System2;
+import org.sonar.api.utils.text.JsonWriter;
 import org.sonar.server.qualitygate.Condition;
 import org.sonar.server.qualitygate.EvaluatedCondition;
 import org.sonar.server.qualitygate.EvaluatedQualityGate;
@@ -300,6 +304,22 @@ public class WebhookPayloadFactoryImplTest {
         "  \"url\": \"http://foo/dashboard?id=P1\"" +
         "}" +
         "}");
+  }
+
+  @Test
+  public void verify_validate_SonarCloud_signature_fail_was_caused_by_the_JsonWriter_build_request_payload() {
+    String val1 = "key&val";
+    String val2 = "https://sonarcloud.io/dashboard?id=myOrganization";
+    String targetJson = "{\"key\":\"" + val1 +"\",\"url\":\""+ val2+"\"}";
+
+    Writer payload = new StringWriter();
+    JsonWriter writer = JsonWriter.of(payload);
+    writer.beginObject();
+    writer.prop("key", val1);
+    writer.prop("url", val2);
+    writer.endObject().close();
+
+    assertThat(payload.toString()).isNotEqualTo(targetJson);
   }
 
   private static ProjectAnalysis newAnalysis(@Nullable CeTask task, @Nullable EvaluatedQualityGate gate,


### PR DESCRIPTION
as a developer, i validate sonarcloud webhook signature fail was caused by the JsonWriter build request payload.

org.sonar.server.webhook.WebhookPayloadFactoryImpl#create build the WebhookPayload with the JsonWriter which in sonar-plugin-api.jar, JsonWriter  based on Gson's JsonWriter  and set the htmlSafe is true, 
so it's escape some chars if the  payload contains the chars which in the array HTML_SAFE_REPLACEMENT_CHARS, and signature the payload with the secret, then post the body by the callback url, 

But the payload I received was un-escaped so that i validate SonarCloud webhook signature always fail, (the payload is changed).

for example: payload Object has a key-value is  {"key": "key=val"},  by the JsonWriter to json, sonar server sign the payload is {"key": "key\u003dval"}, i received the payload is  {"key": "key=val"}.

in the document https://docs.sonarsource.com/sonarcloud/advanced-setup/webhooks/#securing-your-webhooks,
i think at least the JsonWriter conver to json that escape some special chars maybe validate sonarcloud webhook signature fail need to describe clearly .
