### PR TITLE
scanner/ssl: change default password to jvm's default

### DIFF
--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/http/ssl/CertificateStore.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/http/ssl/CertificateStore.java
@@ -22,7 +22,7 @@ package org.sonar.scanner.http.ssl;
 import java.nio.file.Path;
 
 public class CertificateStore {
-  public static final String DEFAULT_PASSWORD = "sonar";
+  public static final String DEFAULT_PASSWORD = "changeit";
   public static final String DEFAULT_STORE_TYPE = "PKCS12";
   private final Path path;
   private final String keyStorePassword;


### PR DESCRIPTION
This change updates the default CertificateStore password to match the JVM's default password instead. The default password `changeit` is equally insecure as `sonar`, but it's accepted, as opposed to `sonar`. For testing purposes, this change facilitates testing deployments using internal certificates and client certificates.

This default password is used in some places to load client certificates onto sonar scanner and it fails to load the truststores when using the `sonar` password if the `trustStorePassword` JVM argument is not specified.

Even though [this change](https://github.com/SonarSource/sonar-scanner-cli-docker/pull/264/files) was introduced in 6.2.0, we cannot properly load certificates without specifying the `-Djavax.net.ssl.trustStorePassword=<password>` everywhere we need, which will not scale. And for obvious reasons to me, users will not want to create trust stores which password is `sonar` password.

With this change, loading client certificates would be a lot easier where the password is not `sonar`. Additionally, it might make sense to evolve this into some sort of environment variable (or build var) that is injected in the code and/or in the [sonar-scanner docker CLI](https://github.com/SonarSource/sonar-scanner-cli-docker/)

---

This is my first time contributing to this project and I couldn't find better directions to propose this change - the ["Submit a feature" in here](https://github.com/SonarSource/sonarqube/blob/ef25df3cda00c12d463d18cefb7cb7bd7332e52e/docs/contributing.md) leads to a 404. I apologize in advance if this is not the best approach and would like to kindly ask you to point me in the right direction, even though I understand if this gets automatically closed due to not being compliant with your roadmap.