### PR TITLE
Fix build cache issues and improve task configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -521,47 +521,69 @@ subprojects {
   }
 
   task generatePackageInfo {
-    doLast {
-      def allPathsContainingJavaFiles = [] as Set
+    String srcMainJava = 'src/main/java'
+    File outputDir = project.layout.buildDirectory.dir(name).get().asFile
+    inputs.files(fileTree(srcMainJava).matching() {
+      include "*/**/*.java"
+      exclude "*/**/package-info.java"
+    }).withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir outputDir
+    outputs.cacheIf { true }
 
-      fileTree('src/main/java/').matching() {
-        include "*/**/*.java"
-        exclude "*/**/package-info.java"
-      }.forEach {
-        allPathsContainingJavaFiles << it.toPath().toFile().getParent();
+    doLast {
+      Set<String> allPathsContainingJavaFiles = [] as Set<String>
+      inputs.files.files.forEach {
+        allPathsContainingJavaFiles << it.toPath().toFile().parent
       }
 
       allPathsContainingJavaFiles.each {
-        String packageInfoPath = it + "/package-info.java"
-        File packageInfoFile = new File (packageInfoPath)
-        if (!packageInfoFile.exists()) {
-            logger.info("Creating file: " + packageInfoPath)
-            def packageName = packageInfoFile.getParent().replaceAll("[\\\\ /]", ".").takeAfter("src.main.java.");
+        String dir = it as String
+        File packageInfoInputFile = project.file("${dir}/package-info.java")
+
+        File packageInfoOutputDir = project.file(dir.replace(project.file(srcMainJava).absolutePath, outputDir.absolutePath))
+        packageInfoOutputDir.mkdirs()
+        String packageInfoOutputPath = "${packageInfoOutputDir.absolutePath}/package-info.java"
+        File packageInfoOutputFile = project.file(packageInfoOutputPath)
+
+        if (!packageInfoInputFile.exists()) {
+            logger.info("Creating file: " + packageInfoOutputPath)
+            def packageName = packageInfoOutputFile.getParent().replaceAll("[\\\\ /]", ".").takeAfter("${name}.");
             String packageInfoContent = applyPackageInfoTemplate(packageName)
-            packageInfoFile << packageInfoContent
+            packageInfoOutputFile << packageInfoContent
         }
       }
 
       def allPackageInfoFiles = [] as Set
 
-      fileTree('src/main/java/').matching() {
+      fileTree(outputDir).matching() {
         include "*/**/package-info.java"
       }.forEach {
-        allPackageInfoFiles << it.toPath().toFile();
+        allPackageInfoFiles << it.toPath().toFile()
       }
 
       allPackageInfoFiles.forEach {
-        File packageInfoFile = it;
-        if (!allPathsContainingJavaFiles.contains(packageInfoFile.getParent())) {
+        File packageInfoFile = it as File
+        if (!allPathsContainingJavaFiles.contains(packageInfoFile.parent)) {
           logger.warn("Deleting package info file: " + packageInfoFile)
-          packageInfoFile.delete();
+          packageInfoFile.delete()
         }
       }
 
     }
   }
+
+  task copyPackageInfo(type: Copy) {
+    from generatePackageInfo
+    into 'src/main/java'
+  }
+
   build.dependsOn(generatePackageInfo)
+  tasks.named('licenseMain').configure { it.mustRunAfter(generatePackageInfo, copyPackageInfo) }
+  tasks.named('licenseFormatMain').configure { it.mustRunAfter(generatePackageInfo, copyPackageInfo) }
+  tasks.named('compileJava').configure { it.mustRunAfter(generatePackageInfo, copyPackageInfo) }
   generatePackageInfo.finalizedBy(licenseFormat)
+  generatePackageInfo.finalizedBy(copyPackageInfo)
+
 
   jacocoTestReport {
     reports {

--- a/server/sonar-db-dao/build.gradle
+++ b/server/sonar-db-dao/build.gradle
@@ -60,6 +60,9 @@ test {
 task dumpSchema(type:JavaExec) {
     mainClass = 'org.sonar.db.dump.DumpSQSchema'
     classpath = sourceSets.test.runtimeClasspath
+
+    outputs.file 'src/schema/schema-sq.ddl'
+    outputs.doNotCacheIf('Caching has not been enabled for the task.') { true }
 }
 
 tasks.check.dependsOn dumpSchema

--- a/server/sonar-web/build.gradle
+++ b/server/sonar-web/build.gradle
@@ -75,11 +75,17 @@ task licenseCheckWeb(type: com.hierynomus.gradle.license.tasks.LicenseCheck) {
   source = sources
   exclude 'main/js/helpers/standards.json'
   if (official) exclude 'main/js/app/components/GlobalFooterBranding.js'
+  subprojects { subproject ->
+    mustRunAfter(subproject.copyPackageInfo)
+  }
 }
 licenseMain.dependsOn licenseCheckWeb
 
 task licenseFormatWeb(type: com.hierynomus.gradle.license.tasks.LicenseFormat) {
   source = sources
   if (official) exclude 'main/js/app/components/GlobalFooterBranding.js'
+  subprojects { subproject ->
+    mustRunAfter(subproject.copyPackageInfo)
+  }
 }
 licenseFormat.dependsOn licenseFormatWeb

--- a/sonar-application/build.gradle
+++ b/sonar-application/build.gradle
@@ -109,6 +109,10 @@ downloadLicenses {
 }
 
 tasks.register('downloadJres') {
+  inputs.file(layout.projectDirectory.dir('src/main/resources/jres-metadata.json').asFile).withPathSensitivity(PathSensitivity.RELATIVE)
+  outputs.dir(layout.buildDirectory.file('jres'))
+  outputs.cacheIf { true }
+
   doLast {
     def jresMetadata = new JsonSlurper().parse(file(layout.projectDirectory.dir('src/main/resources/jres-metadata.json').asFile))
     jresMetadata.each { jre ->
@@ -363,6 +367,7 @@ task cleanLocalUnzippedDir(dependsOn: zip) {
   def unzippedDir = file("$buildDir/distributions/sonarqube-$version")
   inputs.files(file("$buildDir/distributions/sonar-application-${version}.zip"))
   outputs.upToDateWhen { true }
+  outputs.cacheIf('Caching has not been enabled for the task.') { false }
 
   doLast {
     println("delete directory ${unzippedDir}")


### PR DESCRIPTION
- Identified and corrected tasks missing input and output values, improving cache efficiency.
- Added missing path sensitivity configuration to prevent cache misses from differences in absolute file paths.
- Added explicit log messages for tasks that are uncacheable.
- Resolved overlapping task outputs issue: generatePackageInfo task now outputs to a build directory, with a finalizer task copying results to the source directory.