### PR TITLE
Change Bitbucket server URL validation endpoint to support bitbucket 9+

### DIFF
--- a/server/sonar-alm-client/src/main/java/org/sonar/alm/client/bitbucketserver/BitbucketServerRestClient.java
+++ b/server/sonar-alm-client/src/main/java/org/sonar/alm/client/bitbucketserver/BitbucketServerRestClient.java
@@ -70,8 +70,8 @@ public class BitbucketServerRestClient {
   }
 
   public void validateUrl(String serverUrl) {
-    HttpUrl url = buildUrl(serverUrl, "/rest/api/1.0/repos");
-    doGet("", url, body -> buildGson().fromJson(body, RepositoryList.class));
+    HttpUrl url = buildUrl(serverUrl, "/status");
+    doGet("", url, body -> buildGson().fromJson(body, State.class));
   }
 
   public void validateToken(String serverUrl, String token) {

--- a/server/sonar-alm-client/src/main/java/org/sonar/alm/client/bitbucketserver/State.java
+++ b/server/sonar-alm-client/src/main/java/org/sonar/alm/client/bitbucketserver/State.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.alm.client.bitbucketserver;
+
+import com.google.gson.annotations.SerializedName;
+
+public class State {
+
+  @SerializedName("state")
+  private String state;
+
+  public State() {
+    // http://stackoverflow.com/a/18645370/229031
+  }
+
+}

--- a/server/sonar-alm-client/src/test/java/org/sonar/alm/client/bitbucketserver/BitbucketServerRestClientTest.java
+++ b/server/sonar-alm-client/src/test/java/org/sonar/alm/client/bitbucketserver/BitbucketServerRestClientTest.java
@@ -70,9 +70,7 @@ public class BitbucketServerRestClientTest {
     "    }\n" +
     "  ]\n" +
     "}";
-    private static final String STATUS_BODY = "{\n" +
-    "  \"state\": \"RUNNING\"\n" +
-    "}";
+    private static final String STATUS_BODY = "{\"state\": \"RUNNING\"}";
 
   @Rule
   public LogTester logTester = new LogTester();

--- a/server/sonar-alm-client/src/test/java/org/sonar/alm/client/bitbucketserver/BitbucketServerRestClientTest.java
+++ b/server/sonar-alm-client/src/test/java/org/sonar/alm/client/bitbucketserver/BitbucketServerRestClientTest.java
@@ -70,6 +70,9 @@ public class BitbucketServerRestClientTest {
     "    }\n" +
     "  ]\n" +
     "}";
+    private static final String STATUS_BODY = "{\n" +
+    "  \"state\": \"RUNNING\"\n" +
+    "}";
 
   @Rule
   public LogTester logTester = new LogTester();
@@ -474,7 +477,7 @@ public class BitbucketServerRestClientTest {
   @Test
   public void validate_url_success() {
     server.enqueue(new MockResponse().setResponseCode(200)
-      .setBody(REPOS_BODY));
+      .setBody(STATUS_BODY));
 
     underTest.validateUrl(server.url("/").toString());
   }


### PR DESCRIPTION
This PR contains changes that I believe will address the issues in these community posts: [SonarQube with Bitbucket 9.0](https://community.sonarsource.com/t/sonarqube-with-bitbucket-9-0/121126) and [Sonarqube is missing the Authorization token for Bitbucket DC](https://community.sonarsource.com/t/sonarqube-is-missing-the-authorization-token-for-bitbucket-dc/127914).

I changed the `validateUrl` function to use the `/status` endpoint. This endpoint returns a json object containing the current state of Bitbucket (e.g. `{"state":"RUNNING"}`), so I created the `State` class to read that into. Lastly, I updated the `validate_url_success` test to test against an expected response.

Since I started working on this, [SONAR-23470](https://sonarsource.atlassian.net/browse/SONAR-23470) has been created to address the issue internally within SonarSource.

I built the application twice: once directly from the master branch with no changes, and once with my changes. I then configured the Bitbucket integration using the same token on both.

Master:
![DevOps Platform Integrations](https://github.com/user-attachments/assets/8eaaf1e4-8780-4329-80c7-0ddeab649325)
```
==> /Users/lividsquid/sq/sonarqube/sonar-application/build/distributions/sonarqube-10.8-SNAPSHOT/logs/web.log <==
2024.10.24 17:18:00 INFO  web[b75b4eae-a2c6-4250-af7f-f970b4c54add][o.s.a.c.b.BitbucketServerRestClient] Unable to contact Bitbucket server: 401 com.atlassian.plugins.rest.api.security.exception.AuthenticationRequiredException You are not permitted to access this resource
```

This branch:
![DevOps Platform Integrations](https://github.com/user-attachments/assets/0f863d40-e5ac-4807-8e93-7bd2a14f8b6f)


[SONAR-23470]: https://sonarsource.atlassian.net/browse/SONAR-23470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ