### PR TITLE
Fix example-webhooks-list.json hasSecret Type

### DIFF
--- a/server/sonar-webserver-webapi/src/main/resources/org/sonar/server/webhook/ws/example-webhooks-list.json
+++ b/server/sonar-webserver-webapi/src/main/resources/org/sonar/server/webhook/ws/example-webhooks-list.json
@@ -4,13 +4,13 @@
       "key": "UUID-1",
       "name": "my first webhook",
       "url": "http://www.my-webhook-listener.com/sonarqube",
-      "hasSecret": "false"
+      "hasSecret": false
     },
     {
       "key": "UUID-2",
       "name": "my 2nd webhook",
       "url": "https://www.my-other-webhook-listener.com/fancy-listner",
-      "hasSecret": "true"
+      "hasSecret": true
     }
   ]
 }


### PR DESCRIPTION
The example in the interface documentation does not match the actual return value type.
![image](https://github.com/user-attachments/assets/bf9bcd9b-2ba3-4550-8a3b-75f6eb04cc23)

![image](https://github.com/user-attachments/assets/2fc97023-0ce9-4b5f-a780-eb5022ed45d8)

