### PR TITLE
Make sonar startup script insensitive to the terminal width

### DIFF
--- a/sonar-application/src/main/assembly/bin/linux-x86-64/sonar.sh
+++ b/sonar-application/src/main/assembly/bin/linux-x86-64/sonar.sh
@@ -117,7 +117,7 @@ getpid() {
                 #  common is during system startup after an unclean shutdown.
                 # The ps statement below looks for the specific wrapper command running as
                 #  the pid.  If it is not found then the pid file is considered to be stale.
-                pidtest=`$PSEXE -p $pid -o args | grep "sonar-application-@sqversion@.jar" | tail -1`
+                pidtest=`$PSEXE -p $pid -o args -ww | grep "sonar-application-@sqversion@.jar" | tail -1`
                 if [ "X$pidtest" = "X" ]
                 then
                     # This is a stale pid file.


### PR DESCRIPTION
Surprizingly, even when `ps` output is piped into another command, such as `grep` in this case, it is still truncated based on the terminal width. Depending on how wide your terminal you get different results from running the same command: 
- Wide-enough terminal:
```
./sonar.sh start
/usr/bin/java
Starting SonarQube...
Started SonarQube.
```
- Not-wide-enough terminal (width = 263 columns):
```
./sonar.sh start
/usr/bin/java
Starting SonarQube...
Removed stale pid file: ./SonarQube.pid
Failed to start SonarQube.
```

To fix that, I propose to run `ps` with `-ww` option, see the [man page](https://man7.org/linux/man-pages/man1/ps.1.html) Tested on `ps` version 4.0.3 and 3.3.17

