### PR TITLE
Simplified creation of keystores

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -369,7 +369,7 @@ subprojects {
       dependency('com.googlecode.json-simple:json-simple:1.1.1') {
         exclude 'junit:junit'
       }
-      dependency 'io.github.hakky54:sslcontext-kickstart:9.0.0'
+      dependency 'io.github.hakky54:sslcontext-kickstart:9.1.0'
       dependency 'io.prometheus:simpleclient:0.16.0'
       dependency 'io.prometheus:simpleclient_common:0.16.0'
       dependency 'io.prometheus:simpleclient_servlet:0.16.0'


### PR DESCRIPTION
I noticed that the ssl configuration could be simplified, so I did an attempt. Not quite sure whether you guys will like it.  It eliminates the need of those additional methods such as `loadIdentityMaterialWithDefaultPassword`, `loadTrustStoreWithBouncyCastle` and `loadKeyStoreWithPassword`. Looking forward to the feedback