### PR TITLE
fix: fix logging for missing deprecated rules

### DIFF
--- a/server/sonar-webserver-core/src/main/java/org/sonar/server/rule/registration/RulesRegistrationContext.java
+++ b/server/sonar-webserver-core/src/main/java/org/sonar/server/rule/registration/RulesRegistrationContext.java
@@ -83,9 +83,11 @@ class RulesRegistrationContext {
       String ruleUuid = entry.getKey();
       RuleDto rule = dbRulesByRuleUuid.get(ruleUuid);
       if (rule == null) {
-        LOG.warn("Could not retrieve rule with uuid %s referenced by a deprecated rule key. " +
-          "The following deprecated rule keys seem to be referencing a non-existing rule",
-          ruleUuid, entry.getValue());
+        LOG.warn("Could not retrieve rule with uuid {} referenced by a deprecated rule key. " +
+          "The following deprecated rule keys seem to be referencing a non-existing rule: {}",
+          ruleUuid, entry.getValue().stream()
+            .map(SingleDeprecatedRuleKey::getOldRuleKeyAsRuleKey)
+            .collect(Collectors.toSet()));
       } else {
         entry.getValue().forEach(d -> rulesByKey.put(d.getOldRuleKeyAsRuleKey(), rule));
       }


### PR DESCRIPTION
Hello ! This PR is a small fix for the following incorrectly formatted string

I am not familiar with Sonarqube internals, so I don't know if `SingleDeprecatedRuleKey::getOldRuleKeyAsRuleKey()` was the string you originally wanted to output. Let me know if I should change it