### PR TITLE
Reduce syscalls from DefaultIndexedFile::uri()

### DIFF
--- a/sonar-plugin-api-impl/src/main/java/org/sonar/api/batch/fs/internal/DefaultIndexedFile.java
+++ b/sonar-plugin-api-impl/src/main/java/org/sonar/api/batch/fs/internal/DefaultIndexedFile.java
@@ -52,6 +52,8 @@ public class DefaultIndexedFile extends DefaultInputComponent implements Indexed
   private final String oldRelativeFilePath;
   private final boolean hidden;
 
+  private URI uri;
+
   /**
    * Testing purposes only!
    */
@@ -193,6 +195,9 @@ public class DefaultIndexedFile extends DefaultInputComponent implements Indexed
 
   @Override
   public URI uri() {
-    return path().toUri();
+    if (uri == null) {
+      uri = path().toUri();
+    }
+    return uri;
   }
 }

--- a/sonar-plugin-api-impl/src/test/java/org/sonar/api/batch/fs/internal/DefaultIndexedFileTest.java
+++ b/sonar-plugin-api-impl/src/test/java/org/sonar/api/batch/fs/internal/DefaultIndexedFileTest.java
@@ -43,4 +43,14 @@ public class DefaultIndexedFileTest {
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessageContaining(invalidPath);
   }
+
+  @Test
+  public void uri_should_be_cached() {
+    String projectKey = "12345";
+    Path baseDir = Paths.get("");
+    String path = "foo/bar";
+
+    DefaultIndexedFile file = new DefaultIndexedFile(projectKey, baseDir, path, null);
+    Assertions.assertThat(file.uri()).isSameAs(file.uri());
+  }
 }


### PR DESCRIPTION
Hi,

as part of a performance investigation I noticed that there are a lot of repeated `statx` syscalls on the same file during a Sonar scan in our project. 
```
...
statx(AT_FDCWD, "/path/to/our/File.php", AT_STATX_SYNC_AS_STAT, STATX_TYPE|STATX_MODE, {stx_mask=STATX_BASIC_STATS|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=8905, ...}) = 0
statx(AT_FDCWD, "/path/to/our/File.php", AT_STATX_SYNC_AS_STAT, STATX_TYPE|STATX_MODE, {stx_mask=STATX_BASIC_STATS|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=8905, ...}) = 0
statx(AT_FDCWD, "/path/to/our/File.php", AT_STATX_SYNC_AS_STAT, STATX_TYPE|STATX_MODE, {stx_mask=STATX_BASIC_STATS|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=8905, ...}) = 0
statx(AT_FDCWD, "/path/to/our/File.php", AT_STATX_SYNC_AS_STAT, STATX_TYPE|STATX_MODE, {stx_mask=STATX_BASIC_STATS|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=8905, ...}) = 0
statx(AT_FDCWD, "/path/to/our/File.php", AT_STATX_SYNC_AS_STAT, STATX_TYPE|STATX_MODE, {stx_mask=STATX_BASIC_STATS|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=8905, ...}) = 0

... And many more for the same file - I guess you get the idea

```

I believe this is caused by repeated calls to `DefaultIndexedFile::uri()` which eventually ends up in `UnixUriUtils::toUri()` doing this:
```
        // trailing slash if directory
        if (sb.charAt(sb.length()-1) != '/') {
            try {
                up.checkRead();
                UnixFileAttributes attrs = UnixFileAttributes.getIfExists(up);
                if (attrs != null
                        && ((attrs.mode() & UnixConstants.S_IFMT) == UnixConstants.S_IFDIR))
                    sb.append('/');
            } catch (UnixException | SecurityException ignore) { }
        }
```
Reading the file attributes does eventually trigger the syscall. Especially the PHP UCFG stuff seems to often call this

<img width="1701" alt="image" src="https://github.com/user-attachments/assets/0506f3f0-e330-4fb2-9d6c-fd1c917355e9" />

Overall the complete Sonar scan looks roughly like this in terms of the TOP 5 syscalls
```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 39.00    2.434375           3    728736           statx
 15.69    0.979054          89     10990       995 futex
 14.85    0.927064           9    101550           openat
 12.13    0.757411           4    178987           write
  6.50    0.406029           4     97978     27696 stat
....
```
While the overall time of the syscall itself is low, there is an overhead involved in doing syscalls. I'd appreciate if this PR is considered. It's simply trying to cache the result and avoids repeated attempts to build up the URI that should never change as the underlying path also never changes.

Let me know what you think.

Cheers,
Christoph