### PR TITLE
fix: better error message when languages do not have a builtin QP

### DIFF
--- a/server/sonar-webserver-webapi/src/main/java/org/sonar/server/qualityprofile/builtin/BuiltInQProfileRepositoryImpl.java
+++ b/server/sonar-webserver-webapi/src/main/java/org/sonar/server/qualityprofile/builtin/BuiltInQProfileRepositoryImpl.java
@@ -106,7 +106,7 @@ public class BuiltInQProfileRepositoryImpl implements BuiltInQProfileRepository 
       .collect(Collectors.toSet());
 
     checkState(languagesWithoutBuiltInQProfiles.isEmpty(), "The following languages have no built-in quality profiles: %s",
-      languagesWithoutBuiltInQProfiles.isEmpty() ? "" : String.join("", languagesWithoutBuiltInQProfiles));
+      languagesWithoutBuiltInQProfiles.isEmpty() ? "" : String.join(", ", languagesWithoutBuiltInQProfiles));
   }
 
   private Map<String, Map<String, BuiltInQualityProfile>> validateAndClean(BuiltInQualityProfilesDefinition.Context context) {

--- a/server/sonar-webserver-webapi/src/test/java/org/sonar/server/qualityprofile/builtin/BuiltInQProfileRepositoryImplTest.java
+++ b/server/sonar-webserver-webapi/src/test/java/org/sonar/server/qualityprofile/builtin/BuiltInQProfileRepositoryImplTest.java
@@ -1,0 +1,49 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.server.qualityprofile.builtin;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.api.resources.Language;
+import org.sonar.api.resources.Languages;
+import org.sonar.db.DbClient;
+import org.sonar.server.rule.ServerRuleFinder;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BuiltInQProfileRepositoryImplTest {
+  @Test
+  void initializationWithoutQualityProfiles() {
+    DbClient dbClient = mock(DbClient.class);
+    ServerRuleFinder ruleFinder = mock(ServerRuleFinder.class);
+    Languages languages = mock(Languages.class);
+    Language java = mock(Language.class);
+    Language kotlin = mock(Language.class);
+
+    when(languages.all()).thenReturn(new Language[]{ java, kotlin });
+    when(java.getKey()).thenReturn("java");
+    when(kotlin.getKey()).thenReturn("kotlin");
+    
+    BuiltInQProfileRepositoryImpl repository = new BuiltInQProfileRepositoryImpl(dbClient, ruleFinder, languages);
+
+    assertThatCode(repository::initialize).hasMessage("The following languages have no built-in quality profiles: java, kotlin");
+  }
+}


### PR DESCRIPTION
Hello,
As noticed [here](https://github.com/spotbugs/sonar-findbugs/issues/1271#issuecomment-2931463681) the error message for missing builtin quality profiles is a bit confusing:
```
The following languages have no built-in quality profiles: kubernetescssscalajsppyjsansibledockerplsqlrustdartjavawebflexxmljsonipynbtextvbnetcloudformationgrvyyamlswiftcppcgokotlinneutraltsqlsecretsrubycsshellphpterraformazureresourcemanagerabapobjcts
```