### PR TITLE
feat: allow dash in jdbc driver name

### DIFF
--- a/server/sonar-main/src/main/java/org/sonar/application/config/JdbcSettings.java
+++ b/server/sonar-main/src/main/java/org/sonar/application/config/JdbcSettings.java
@@ -113,7 +113,7 @@ public class JdbcSettings implements Consumer<Props> {
       return Provider.H2;
     }
 
-    Pattern pattern = Pattern.compile("jdbc:(\\w+):.+");
+    Pattern pattern = Pattern.compile("jdbc:([\\w\\-]+):.+");
     Matcher matcher = pattern.matcher(url);
     if (!matcher.find()) {
       throw new MessageException(format("Bad format of JDBC URL: %s", url));


### PR DESCRIPTION
Hello,

In order to be able to use AWS IAM authentication for RDS Postgresql, I want to be able to use the driver wrapper provided by AWS (https://github.com/aws/aws-advanced-jdbc-wrapper). The wrapper contains a dash in its name (`jdbc:aws-wrapper:postgresql`) which is making the validation fail because of this pattern `jdbc:(\\w+):.+` which allows only `[a-zA-Z0-9_]` as characters in the connection string. 

My PR adds `-` as supported characters so I can use the JDBC wrapper from AWS along with the PostgreSQL coming with SonarQube defaults.

fixes: https://community.sonarsource.com/t/sonarqube-aws-rds-authentication-through-iam-role/90887 + https://community.sonarsource.com/t/iam-database-authentication-with-aurora-postgresql-for-sonarqube/70520