### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -377,7 +377,7 @@ subprojects {
       dependency('com.googlecode.json-simple:json-simple:1.1.1') {
         exclude 'junit:junit'
       }
-      dependency 'io.github.hakky54:sslcontext-kickstart:9.1.0'
+      dependency 'io.github.hakky54:ayza:10.0.0'
       dependency 'io.prometheus:simpleclient:0.16.0'
       dependency 'io.prometheus:simpleclient_common:0.16.0'
       dependency 'io.prometheus:simpleclient_servlet:0.16.0'

--- a/sonar-scanner-engine/build.gradle
+++ b/sonar-scanner-engine/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   api 'com.google.protobuf:protobuf-java'
   api 'com.squareup.okhttp3:okhttp'
   api 'com.fasterxml.staxmate:staxmate'
-  implementation 'io.github.hakky54:sslcontext-kickstart'
+  implementation 'io.github.hakky54:ayza'
   implementation 'org.bouncycastle:bcprov-jdk18on'
   api 'jakarta.annotation:jakarta.annotation-api'
   api 'org.eclipse.jgit:org.eclipse.jgit'


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience