### PR TITLE
Fix: Unexpected warning "remove this assertion from production code" on sources inside Eclipse test plugin projects

### DIFF
--- a/sonar-scanner-engine/src/it/java/org/sonar/scanner/mediumtest/fs/FileSystemMediumIT.java
+++ b/sonar-scanner-engine/src/it/java/org/sonar/scanner/mediumtest/fs/FileSystemMediumIT.java
@@ -1695,6 +1695,41 @@ class FileSystemMediumIT {
   }
 
   @Test
+  void eclipseTestPluginWithExplicitSonarTestsKeepsSourcesAsMainFiles() throws IOException {
+    File srcDir = new File(baseDir, "src");
+    assertThat(srcDir.mkdir()).isTrue();
+    writeFile(srcDir, "Sample.xoo", "Sample content");
+
+    File testDir = new File(baseDir, "test");
+    assertThat(testDir.mkdir()).isTrue();
+    writeFile(testDir, "SampleTest.xoo", "Sample test content");
+
+    File metaInf = new File(baseDir, "META-INF");
+    assertThat(metaInf.mkdir()).isTrue();
+    writeFile(metaInf, "MANIFEST.MF",
+      "Manifest-Version: 1.0\n" +
+        "Bundle-SymbolicName: com.example.myfeature.tests\n" +
+        "Bundle-Version: 1.0.0\n");
+
+    AnalysisResult result = tester.newAnalysis()
+      .properties(builder
+        .put("sonar.sources", "src")
+        .put("sonar.tests", "test")
+        .build())
+      .execute();
+
+    assertThat(result.inputFiles()).hasSize(2);
+
+    InputFile sourceFile = result.inputFile("src/Sample.xoo");
+    assertThat(sourceFile).isNotNull();
+    assertThat(sourceFile.type()).isEqualTo(InputFile.Type.MAIN);
+
+    InputFile testFile = result.inputFile("test/SampleTest.xoo");
+    assertThat(testFile).isNotNull();
+    assertThat(testFile.type()).isEqualTo(InputFile.Type.TEST);
+  }
+
+  @Test
   void eclipseTestPluginWithSingleTestSuffixSourcesAreIndexedAsTestFiles() throws IOException {
     File srcDir = new File(baseDir, "src");
     assertThat(srcDir.mkdir()).isTrue();

--- a/sonar-scanner-engine/src/it/java/org/sonar/scanner/mediumtest/fs/FileSystemMediumIT.java
+++ b/sonar-scanner-engine/src/it/java/org/sonar/scanner/mediumtest/fs/FileSystemMediumIT.java
@@ -1668,4 +1668,79 @@ class FileSystemMediumIT {
       assertThat(issues).isEmpty();
     }
   }
+
+  @Test
+  void eclipseTestPluginSourcesAreIndexedAsTestFiles() throws IOException {
+    File srcDir = new File(baseDir, "src");
+    assertThat(srcDir.mkdir()).isTrue();
+    writeFile(srcDir, "SampleTest.xoo", "Sample test content");
+
+    File metaInf = new File(baseDir, "META-INF");
+    assertThat(metaInf.mkdir()).isTrue();
+    writeFile(metaInf, "MANIFEST.MF",
+      "Manifest-Version: 1.0\n" +
+        "Bundle-SymbolicName: com.example.myfeature.tests\n" +
+        "Bundle-Version: 1.0.0\n");
+
+    AnalysisResult result = tester.newAnalysis()
+      .properties(builder
+        .put("sonar.sources", "src")
+        .build())
+      .execute();
+
+    assertThat(result.inputFiles()).hasSize(1);
+    InputFile inputFile = result.inputFile("src/SampleTest.xoo");
+    assertThat(inputFile).isNotNull();
+    assertThat(inputFile.type()).isEqualTo(InputFile.Type.TEST);
+  }
+
+  @Test
+  void eclipseTestPluginWithSingleTestSuffixSourcesAreIndexedAsTestFiles() throws IOException {
+    File srcDir = new File(baseDir, "src");
+    assertThat(srcDir.mkdir()).isTrue();
+    writeFile(srcDir, "SampleTest.xoo", "Sample test content");
+
+    File metaInf = new File(baseDir, "META-INF");
+    assertThat(metaInf.mkdir()).isTrue();
+    writeFile(metaInf, "MANIFEST.MF",
+      "Manifest-Version: 1.0\n" +
+        "Bundle-SymbolicName: com.example.myfeature.test;singleton:=true\n" +
+        "Bundle-Version: 1.0.0\n");
+
+    AnalysisResult result = tester.newAnalysis()
+      .properties(builder
+        .put("sonar.sources", "src")
+        .build())
+      .execute();
+
+    assertThat(result.inputFiles()).hasSize(1);
+    InputFile inputFile = result.inputFile("src/SampleTest.xoo");
+    assertThat(inputFile).isNotNull();
+    assertThat(inputFile.type()).isEqualTo(InputFile.Type.TEST);
+  }
+
+  @Test
+  void regularEclipsePluginSourcesAreIndexedAsMainFiles() throws IOException {
+    File srcDir = new File(baseDir, "src");
+    assertThat(srcDir.mkdir()).isTrue();
+    writeFile(srcDir, "Sample.xoo", "Sample content");
+
+    File metaInf = new File(baseDir, "META-INF");
+    assertThat(metaInf.mkdir()).isTrue();
+    writeFile(metaInf, "MANIFEST.MF",
+      "Manifest-Version: 1.0\n" +
+        "Bundle-SymbolicName: com.example.myfeature\n" +
+        "Bundle-Version: 1.0.0\n");
+
+    AnalysisResult result = tester.newAnalysis()
+      .properties(builder
+        .put("sonar.sources", "src")
+        .build())
+      .execute();
+
+    assertThat(result.inputFiles()).hasSize(1);
+    InputFile inputFile = result.inputFile("src/Sample.xoo");
+    assertThat(inputFile).isNotNull();
+    assertThat(inputFile.type()).isEqualTo(InputFile.Type.MAIN);
+  }
 }

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/ProjectFilePreprocessor.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/ProjectFilePreprocessor.java
@@ -180,7 +180,7 @@ public class ProjectFilePreprocessor {
         return !bundleSymbolicName.isEmpty() && (bundleSymbolicName.endsWith(".test") || bundleSymbolicName.endsWith(".tests"));
       }
     } catch (IOException e) {
-      LOG.debug("Failed to read MANIFEST.MF at {}: {}", manifestPath, e.getMessage());
+      LOG.debug("Failed to read MANIFEST.MF at {}", manifestPath, e);
     }
     return false;
   }

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/ProjectFilePreprocessor.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/ProjectFilePreprocessor.java
@@ -20,6 +20,7 @@
 package org.sonar.scanner.scan.filesystem;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.jar.Manifest;
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
@@ -140,15 +143,46 @@ public class ProjectFilePreprocessor {
     // Default to index basedir when no sources provided
     List<Path> mainSourceDirsOrFiles = module.getSourceDirsOrFiles()
       .orElseGet(() -> hasChildModules || hasTests ? emptyList() : singletonList(module.getBaseDir().toAbsolutePath()));
-    List<Path> processedSources = processModuleSources(module, moduleConfig, moduleExclusionFilters, mainSourceDirsOrFiles, InputFile.Type.MAIN,
-      exclusionCounter);
-    mainSourcesByModule.put(module, processedSources);
-    totalFilesPreprocessed += processedSources.size();
-    module.getTestDirsOrFiles().ifPresent(tests -> {
-      List<Path> processedTestSources = processModuleSources(module, moduleConfig, moduleExclusionFilters, tests, InputFile.Type.TEST, exclusionCounter);
+    if (!hasTests && isEclipseTestPlugin(module)) {
+      // Eclipse test plugin: treat sources as test sources
+      List<Path> processedTestSources = processModuleSources(module, moduleConfig, moduleExclusionFilters, mainSourceDirsOrFiles, InputFile.Type.TEST,
+        exclusionCounter);
       testSourcesByModule.put(module, processedTestSources);
       totalFilesPreprocessed += processedTestSources.size();
-    });
+      mainSourcesByModule.put(module, emptyList());
+    } else {
+      List<Path> processedSources = processModuleSources(module, moduleConfig, moduleExclusionFilters, mainSourceDirsOrFiles, InputFile.Type.MAIN,
+        exclusionCounter);
+      mainSourcesByModule.put(module, processedSources);
+      totalFilesPreprocessed += processedSources.size();
+      module.getTestDirsOrFiles().ifPresent(tests -> {
+        List<Path> processedTestSources = processModuleSources(module, moduleConfig, moduleExclusionFilters, tests, InputFile.Type.TEST, exclusionCounter);
+        testSourcesByModule.put(module, processedTestSources);
+        totalFilesPreprocessed += processedTestSources.size();
+      });
+    }
+  }
+
+  @VisibleForTesting
+  static boolean isEclipseTestPlugin(DefaultInputModule module) {
+    Path manifestPath = module.getBaseDir().resolve("META-INF/MANIFEST.MF");
+    if (!Files.isRegularFile(manifestPath)) {
+      return false;
+    }
+    try (InputStream is = Files.newInputStream(manifestPath)) {
+      Manifest manifest = new Manifest(is);
+      String bundleSymbolicName = manifest.getMainAttributes().getValue("Bundle-SymbolicName");
+      if (bundleSymbolicName != null) {
+        int semicolonIndex = bundleSymbolicName.indexOf(';');
+        if (semicolonIndex != -1) {
+          bundleSymbolicName = bundleSymbolicName.substring(0, semicolonIndex).trim();
+        }
+        return bundleSymbolicName.endsWith(".test") || bundleSymbolicName.endsWith(".tests");
+      }
+    } catch (IOException e) {
+      LOG.debug("Failed to read MANIFEST.MF at {}: {}", manifestPath, e.getMessage());
+    }
+    return false;
   }
 
   private List<Path> processModuleSources(DefaultInputModule module, ModuleConfiguration moduleConfiguration, ModuleExclusionFilters moduleExclusionFilters, List<Path> sources,

--- a/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/ProjectFilePreprocessor.java
+++ b/sonar-scanner-engine/src/main/java/org/sonar/scanner/scan/filesystem/ProjectFilePreprocessor.java
@@ -177,7 +177,7 @@ public class ProjectFilePreprocessor {
         if (semicolonIndex != -1) {
           bundleSymbolicName = bundleSymbolicName.substring(0, semicolonIndex).trim();
         }
-        return bundleSymbolicName.endsWith(".test") || bundleSymbolicName.endsWith(".tests");
+        return !bundleSymbolicName.isEmpty() && (bundleSymbolicName.endsWith(".test") || bundleSymbolicName.endsWith(".tests"));
       }
     } catch (IOException e) {
       LOG.debug("Failed to read MANIFEST.MF at {}: {}", manifestPath, e.getMessage());


### PR DESCRIPTION
This pull request adds support for correctly classifying Eclipse test plugin sources as test files during analysis, based on the contents of their `MANIFEST.MF`. It introduces logic to detect Eclipse test plugins and updates the file preprocessing to assign the proper file type. The changes are covered by new integration tests.

**Eclipse Test Plugin Support:**

* Added a new method `isEclipseTestPlugin` in `ProjectFilePreprocessor.java` to detect Eclipse test plugins by inspecting the `Bundle-SymbolicName` in `META-INF/MANIFEST.MF`, treating modules ending with `.test` or `.tests` as test plugins.
* Updated `processModule` in `ProjectFilePreprocessor.java` to index all source files as test files if the module is detected as an Eclipse test plugin and no explicit test directories are provided.

**Testing:**

* Added several integration tests in `FileSystemMediumIT.java` to verify correct classification of files as test or main for Eclipse test plugins, regular plugins, and combinations with explicit test directories.

**Codebase Maintenance:**

* Added necessary imports for manifest processing and testing annotations in `ProjectFilePreprocessor.java`. [[1]](diffhunk://#diff-f55da448dd8fef0c6fff0a18c2516884d100d8dbb50d7a8cc9b8cb75be45ed6bR23) [[2]](diffhunk://#diff-f55da448dd8fef0c6fff0a18c2516884d100d8dbb50d7a8cc9b8cb75be45ed6bR35-R36)SonarQube was raising "remove this assertion from production code" on sources inside Eclipse test plugin projects because the scanner unconditionally indexed all `sonar.sources` as `Type.MAIN`, with no awareness of OSGi test bundles.

## Changes

### `ProjectFilePreprocessor`
- Added `isEclipseTestPlugin(DefaultInputModule)`: reads `META-INF/MANIFEST.MF`, parses `Bundle-SymbolicName` (stripping OSGi directive attributes like `;singleton:=true`), and returns `true` if the name ends with `.test` or `.tests`.
- Modified `processModule()`: when the module is detected as an Eclipse test plugin **and** `sonar.tests` is not explicitly configured, sources are indexed as `Type.TEST` instead of `Type.MAIN`. Explicit user configuration still takes precedence.

```java
// com.example.myfeature.tests → sources treated as Type.TEST
// com.example.myfeature       → sources treated as Type.MAIN (unchanged)
```

### `FileSystemMediumIT`
Three new integration tests cover:
- `Bundle-SymbolicName: com.example.feature.tests` → `Type.TEST`
- `Bundle-SymbolicName: com.example.feature.test;singleton:=true` → `Type.TEST`
- Regular plugin (no `.test`/`.tests` suffix) → `Type.MAIN`
