### PR TITLE
Fix misleading Community Build upgrade error message

### DIFF
--- a/server/sonar-db-migration/src/main/java/org/sonar/server/platform/db/migration/version/DatabaseVersion.java
+++ b/server/sonar-db-migration/src/main/java/org/sonar/server/platform/db/migration/version/DatabaseVersion.java
@@ -35,7 +35,7 @@ public class DatabaseVersion {
 
   // In reality user is required to upgrade just to 10.8 but we want to 'market' 2025.1
   public static final String MIN_UPGRADE_VERSION_HUMAN_READABLE = "2026.1";
-  public static final String MIN_UPGRADE_VERSION_COMMUNITY_BUILD_READABLE = "25.12";
+  public static final String MIN_UPGRADE_VERSION_COMMUNITY_BUILD_READABLE = "26.1";
 
 
   private final MigrationSteps migrationSteps;

--- a/server/sonar-webserver-core/src/test/java/org/sonar/server/platform/DatabaseServerCompatibilityTest.java
+++ b/server/sonar-webserver-core/src/test/java/org/sonar/server/platform/DatabaseServerCompatibilityTest.java
@@ -69,14 +69,14 @@ public class DatabaseServerCompatibilityTest {
   }
 
   @Test
-  public void fail_if_requires_firstly_to_upgrade_to_25_12() {
+  public void fail_if_requires_firstly_to_upgrade_to_26_1() {
     when(version.getStatus()).thenReturn(DatabaseVersion.Status.REQUIRES_UPGRADE);
     when(version.getVersion()).thenReturn(Optional.of(12L));
     when(sonarRuntime.getEdition()).thenReturn(SonarEdition.COMMUNITY);
 
     assertThatThrownBy(compatibility::start)
       .isInstanceOf(MessageException.class)
-      .hasMessage("The version of SonarQube you are trying to upgrade from is too old. Please upgrade to the 25.12 version first.");
+      .hasMessage("The version of SonarQube you are trying to upgrade from is too old. Please upgrade to the 26.1 version first.");
     verifyNoInteractions(documentationLinkGenerator);
   }
 


### PR DESCRIPTION
## Summary

- `MIN_UPGRADE_VERSION` is set to `2026_01_000` (the first migration of version **26.1**)
- However, `MIN_UPGRADE_VERSION_COMMUNITY_BUILD_READABLE` was set to `"25.12"`
- This causes users upgrading from **25.12** to see: *"Please upgrade to the 25.12 version first"* — even though they are **already on 25.12**
- The fix changes the readable constant to `"26.1"` to match the actual numeric requirement

## Context

When upgrading SonarQube Community Build from 25.12 (last migration `2025_06_026` = `202506026`) to any version >= 26.3 (which requires `MIN_UPGRADE_VERSION = 2026_01_000` = `202601000`), the error message tells the user to upgrade to 25.12 first. This is confusing and incorrect — the user needs to upgrade to **26.1** first so that migration `2026_01_000` gets applied.

The Server Edition message (`MIN_UPGRADE_VERSION_HUMAN_READABLE = "2026.1"`) is already correct. Only the Community Build message was wrong.

## How to reproduce

1. Set up SonarQube Community Build 25.12 with a fully migrated database (max `schema_migrations` = `202506026`)
2. Attempt to start SonarQube 26.4 against the same database
3. Observe error: *"Please upgrade to the 25.12 version first"*
4. Expected: *"Please upgrade to the 26.1 version first"*

## Test plan

- [x] Updated `DatabaseServerCompatibilityTest.fail_if_requires_firstly_to_upgrade_to_26_1` to verify the corrected message